### PR TITLE
fix: fullstack recipe vite base URL and LitroPage inheritance

### DIFF
--- a/.changeset/fix-fullstack-recipe-vite-base.md
+++ b/.changeset/fix-fullstack-recipe-vite-base.md
@@ -1,0 +1,9 @@
+---
+"@beatzball/create-litro": patch
+---
+
+Fix fullstack recipe: add `base: '/_litro/'` to `vite.config.ts` and extend `LitroPage` in `[slug].ts`
+
+Without `base: '/_litro/'`, Vite's compiled modulepreload URL resolver emits paths like `/assets/chunk.js` instead of `/_litro/assets/chunk.js`. These requests hit the Nitro catch-all page handler and return HTML, causing a MIME type error that leaves dynamic routes (e.g. `/blog/hello-world`) stuck on "Loading…".
+
+Also fixes `pages/blog/[slug].ts` to extend `LitroPage` (not `LitElement`) and implement `fetchData()`, so client-side SPA navigation to different slugs correctly updates `serverData`.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -249,6 +249,26 @@ Plain `<a>` links cause a full browser navigation, loading the pre-rendered HTML
 
 ---
 
+## `create-litro` fullstack recipe: `base: '/_litro/'` required in `vite.config.ts`
+
+**Decision**: Add `base: '/_litro/'` and `resolve.conditions` to the fullstack recipe's `vite.config.ts`, matching the playground and `11ty-blog` recipe.
+
+**Rationale**: Vite embeds the `base` URL into its compiled preload URL resolver at build time:
+
+```js
+const Ft = function(i) { return "/_litro/" + i }
+```
+
+Without `base: '/_litro/'`, Vite uses `"/"` and all `<link rel="modulepreload">` hints for dynamic import chunks resolve to `/assets/...` instead of `/_litro/assets/...`. The Nitro catch-all route handler matches those paths and returns HTML, causing the browser to reject the response with:
+
+> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".
+
+**Symptom**: Dynamic routes (e.g. `/blog/hello-world`) show "Loading…" indefinitely and the JS console shows the MIME type error. Two network requests are visible for the slug path — one HTML page response and one failed module preload.
+
+**Also fixed**: `pages/blog/[slug].ts` in the fullstack recipe was extending `LitElement` directly instead of `LitroPage`. Without `LitroPage`, client-side SPA navigation to a different slug does not call `fetchData()`, so `serverData` is never updated after the initial load.
+
+---
+
 ## Release pipeline: Changesets + GitHub Actions
 
 **Decision**: Use [Changesets](https://github.com/changesets/changesets) (`@changesets/cli`) for version management, changelog generation, and automated npm publishing via `changesets/action` in GitHub Actions.

--- a/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
@@ -1,6 +1,8 @@
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
+import type { LitroLocation } from '@beatzball/litro-router';
 
 export interface PostData {
   slug: string;
@@ -24,8 +26,18 @@ export async function generateRoutes(): Promise<string[]> {
 }
 
 @customElement('page-blog-slug')
-export class BlogPostPage extends LitElement {
+export class BlogPostPage extends LitroPage {
   @state() declare serverData: PostData | null;
+
+  // Called by LitroRouter on client-side navigation to fetch data for the new slug.
+  override async fetchData(location: LitroLocation): Promise<PostData> {
+    const slug = location.params['slug'] ?? '';
+    return {
+      slug,
+      title: `Post: ${slug}`,
+      content: `This is the content for the "${slug}" post.`,
+    };
+  }
 
   render() {
     return html`

--- a/packages/create-litro/recipes/fullstack/template/vite.config.ts
+++ b/packages/create-litro/recipes/fullstack/template/vite.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  // base must match publicAssets.baseURL in nitro.config.ts ('/_litro/').
+  // Vite embeds the base into the compiled preload URL resolver so that
+  // modulepreload hints resolve to /_litro/assets/... instead of /assets/...
+  // Without this, preload requests hit the catch-all page handler and return
+  // HTML, causing a MIME type error for module scripts.
+  base: '/_litro/',
+  resolve: {
+    conditions: ['source', 'browser', 'module', 'import', 'default'],
+  },
   build: {
     outDir: 'dist/client',
     rollupOptions: {


### PR DESCRIPTION
Add `base: '/_litro/'` to the fullstack recipe's vite.config.ts so Vite's compiled modulepreload resolver emits correct asset paths. Without it, preload hints target /assets/... which the Nitro catch-all returns as HTML, causing a MIME type error and "Loading…" on dynamic routes like /blog/hello-world.

Also fix pages/blog/[slug].ts to extend LitroPage and implement fetchData() so client-side SPA navigation updates serverData correctly.