### PR TITLE
fix: client-side SPA navigation broken on first load in fullstack apps

### DIFF
--- a/.changeset/fix-dynamic-links.md
+++ b/.changeset/fix-dynamic-links.md
@@ -1,38 +1,119 @@
 ---
 "@beatzball/litro": patch
+"@beatzball/litro-router": patch
 "@beatzball/create-litro": patch
 ---
 
 fix: client-side navigation links do not work on first load
 
-`<litro-link>` clicks were silently no-ops because the router was
-initialised with an empty route table.
+`<litro-link>` clicks were silently no-ops in scaffolded apps because of
+three compounding bugs.
 
-**Root cause**: When `app.ts` loads, importing `LitroOutlet.js` triggers
-`customElements.define()`, which immediately upgrades the SSR'd
-`<litro-outlet>` element. Lit schedules its first update as a microtask.
-The `DOMContentLoaded` listener in `app.ts` (a macrotask) fires only
-after that microtask, so `firstUpdated()` ran with `routes = []` and the
-router was initialised with no routes. Setting `outlet.routes` in the
-callback was ignored because there was no code path to call `setRoutes()`
-again.
+---
 
-**Fix — `LitroOutlet`**: Replace `@property({ type: Array }) routes` with
-a plain getter/setter. The setter calls `router.setRoutes()` directly
-when the router is already initialised. A Lit reactive property was
-rejected because Lit's `createProperty()` installs an accessor that calls
-`requestUpdate()`, scheduling a render cycle — which crashes with
-"ChildPart has no parentNode" because `firstUpdated()` already removed
-Lit's internal marker nodes to give the router full ownership of the
-outlet's subtree.
+**Bug 1 — Empty route table on init** (`LitroOutlet`, `app.ts`)
 
-**Fix — `app.ts`** (fullstack recipe template + playground): Set
+`app.ts` set `outlet.routes` inside a `DOMContentLoaded` callback (a
+macrotask). By that point Lit's first-update microtask had already fired,
+so `firstUpdated()` ran with `routes = []` and the router was initialised
+with no routes.
+
+*Fix — `LitroOutlet`*: Replace `@property({ type: Array }) routes` with a
+plain getter/setter. The setter calls `router.setRoutes()` directly when
+the router is already initialised, without going through Lit's render cycle
+(which would crash with "ChildPart has no parentNode" because
+`firstUpdated()` removes Lit's internal marker nodes to give the router
+ownership of the outlet's subtree).
+
+*Fix — `app.ts`* (fullstack recipe template + playground): Set
 `outlet.routes` synchronously after imports rather than inside a
 `DOMContentLoaded` callback. Module scripts are deferred by the browser;
 by the time they execute the DOM is fully parsed and `<litro-outlet>` is
-present. Synchronous assignment ensures `firstUpdated()` sees the real
-route table before the first Lit update microtask fires.
+present.
 
-Adds a new `LitroOutlet.test.ts` test file (6 tests) covering both the
+---
+
+**Bug 2 — Click handler never attached on SSR'd pages** (`LitroLink`)
+
+`@lit-labs/ssr` adds `defer-hydration` to custom elements inside shadow
+DOM. `@lit-labs/ssr-client` patches `LitElement.prototype.connectedCallback`
+to block Lit's update cycle when this attribute is present. A `@click`
+binding on the shadow `<a>` is a Lit binding — it is never attached until
+`defer-hydration` is removed, which only happens when the parent component
+hydrates. For page components that are never hydrated client-side (because
+the router replaces the SSR content before they load), `<litro-link>`
+elements inside them never receive a click handler.
+
+This is why the playground appeared to work: its home page has no
+`<litro-link>` elements. The fullstack generator template does, so clicks
+on the SSR'd page were silently ignored.
+
+*Fix*: Move the click handler from a `@click` binding on the shadow `<a>`
+to the HOST element via `addEventListener('click', ...)` registered in
+`connectedCallback()` (before `super.connectedCallback()`). The host
+listener runs in `LitroLink`'s own `connectedCallback` override, which
+executes before the `@lit-labs/ssr-client` patch checks for
+`defer-hydration`. This ensures the handler is active immediately after the
+element connects to the DOM, even for SSR'd elements on first load.
+
+The shadow `<a>` is kept without a `@click` binding — it exists for
+progressive enhancement (no-JS navigation) and accessibility (cursor,
+focus, keyboard navigation).
+
+---
+
+**Bug 3 — `_resolve()` race condition** (`LitroRouter`)
+
+`setRoutes()` calls `_resolve()` immediately for the current URL. If the
+user clicks a link before that initial `_resolve()` completes (e.g. while
+the page action's dynamic import is in flight), a second `_resolve()` call
+starts concurrently. If the first call (for `/`) completes after the second
+(for `/blog`), it overwrites the blog page with the home page.
+
+*Fix*: Add a `_resolveToken` monotonic counter. Each `_resolve()` call
+captures its own token at the start and checks it after every `await`. If
+the token has advanced, a newer navigation superseded this one and the call
+returns without touching the DOM.
+
+---
+
+**Bug 4 — `@property()` decorators silently dropped by esbuild TC39 transform** (`LitroLink`)
+
+esbuild 0.21+ uses the TC39 Stage 3 decorator transform. In that mode,
+Lit's `@property()` decorator only handles `accessor` fields; applied to a
+plain field (`href = ''`) it is silently not applied. As a result `href`,
+`target`, and `rel` were absent from `observedAttributes`, so
+`attributeChangedCallback` was never called during element upgrade, leaving
+`this.href = ''` forever regardless of what the HTML attribute said.
+
+*Fix*: Replace the three `@property()` field decorators with a
+`static override properties = { href, target, rel }` declaration. Lit reads
+this static field at class-finalization time via `finalize()`, which runs
+before the element is defined in `customElements`, ensuring the properties
+are correctly registered in `observedAttributes`.
+
+---
+
+Adds a new `LitroOutlet.test.ts` test file (6 tests) covering the
 synchronous and late-assignment code paths, the setter guard, SSR child
 clearing, and the `LitroRouter` constructor call.
+
+Updates `LitroLink.test.ts` (12 tests) to dispatch real `MouseEvent`s on
+the host element (exercising the `addEventListener` path) rather than
+calling the private handler directly by name.
+
+---
+
+**Template fix — `@state() declare serverData` incompatible with jiti/SSG**
+
+The fullstack recipe template used `@state() declare serverData: T | null` to
+narrow the `serverData: unknown` type inherited from `LitroPage`. The `declare`
+modifier emits no runtime code, but jiti's oxc-transform (used in SSG mode to
+load page files) throws "Fields with the 'declare' modifier cannot be
+initialized here" under TC39 Stage 3 decorator mode.
+
+*Fix*: Remove `@state() declare serverData` from both page templates. Use a
+local type cast in `render()` instead: `const data = this.serverData as T | null`.
+The property is already reactive (declared as `@state() serverData = null` in
+`LitroPage`). Updated `LitroPage.ts` JSDoc and `DECISIONS.md` to document this
+pattern and warn against `declare` fields in subclasses.

--- a/.changeset/fix-dynamic-links.md
+++ b/.changeset/fix-dynamic-links.md
@@ -1,0 +1,38 @@
+---
+"@beatzball/litro": patch
+"@beatzball/create-litro": patch
+---
+
+fix: client-side navigation links do not work on first load
+
+`<litro-link>` clicks were silently no-ops because the router was
+initialised with an empty route table.
+
+**Root cause**: When `app.ts` loads, importing `LitroOutlet.js` triggers
+`customElements.define()`, which immediately upgrades the SSR'd
+`<litro-outlet>` element. Lit schedules its first update as a microtask.
+The `DOMContentLoaded` listener in `app.ts` (a macrotask) fires only
+after that microtask, so `firstUpdated()` ran with `routes = []` and the
+router was initialised with no routes. Setting `outlet.routes` in the
+callback was ignored because there was no code path to call `setRoutes()`
+again.
+
+**Fix — `LitroOutlet`**: Replace `@property({ type: Array }) routes` with
+a plain getter/setter. The setter calls `router.setRoutes()` directly
+when the router is already initialised. A Lit reactive property was
+rejected because Lit's `createProperty()` installs an accessor that calls
+`requestUpdate()`, scheduling a render cycle — which crashes with
+"ChildPart has no parentNode" because `firstUpdated()` already removed
+Lit's internal marker nodes to give the router full ownership of the
+outlet's subtree.
+
+**Fix — `app.ts`** (fullstack recipe template + playground): Set
+`outlet.routes` synchronously after imports rather than inside a
+`DOMContentLoaded` callback. Module scripts are deferred by the browser;
+by the time they execute the DOM is fully parsed and `<litro-outlet>` is
+present. Synchronous assignment ensures `firstUpdated()` sees the real
+route table before the first Lit update microtask fires.
+
+Adds a new `LitroOutlet.test.ts` test file (6 tests) covering both the
+synchronous and late-assignment code paths, the setter guard, SSR child
+clearing, and the `LitroRouter` constructor call.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -383,7 +383,7 @@ interface LitroLocation {
 
 ### Server-side safety
 
-`litro-router.ts` does not access `window`, `history`, or `document` at module evaluation time. The dynamic import in `LitroOutlet.firstUpdated()` and `LitroLink.handleClick()` ensures the module is never evaluated in Node.js. No Rollup stub plugin is needed (unlike the former `@vaadin/router` approach).
+`litro-router.ts` does not access `window`, `history`, or `document` at module evaluation time. The dynamic import in `LitroOutlet.firstUpdated()` and `LitroLink._clickHandler()` ensures the module is never evaluated in Node.js. No Rollup stub plugin is needed (unlike the former `@vaadin/router` approach).
 
 ### TypeScript types
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -94,6 +94,20 @@ Running log of architectural and implementation decisions. All agents append her
 
 ---
 
+## LitroLink: `static override properties` instead of `@property()` field decorators
+
+**Decision**: `LitroLink` declares `href`, `target`, and `rel` via `static override properties = { ... }` plus plain field initializers (`href = ''`), NOT `@property()` on plain fields.
+
+**Rationale**: Vite 5 uses esbuild 0.21+ which applies the TC39 Stage 3 decorator transform to client bundles. In that transform, `@property()` only handles `accessor` fields (`accessor href = ''`); applied to a plain field (`href = ''`) it is silently dropped and the field is never added to `observedAttributes`. As a result, `this.href` stays `''` forever regardless of the HTML attribute, breaking all link navigation silently.
+
+`accessor` fields are also problematic: Lit's TC39 `init` function fires during instance construction before `elementProperties` is populated, causing a runtime crash ("Cannot read properties of undefined (reading 'has')").
+
+`static override properties` is read by Lit in `finalize()`, called from the `observedAttributes` getter when `customElements.define()` runs — before any instances are created. This works correctly under both legacy experimental decorators (Nitro/SSR esbuild) and TC39 Stage 3 (Vite client build).
+
+**Corollary — template pages**: Page components should NOT use `@state() declare serverData: T | null` to narrow the inherited `serverData: unknown` type. The `declare` modifier emits no runtime code but causes jiti's oxc-transform to throw "Fields with the 'declare' modifier cannot be initialized here" in SSG mode. Instead, use a local type cast in `render()`: `const data = this.serverData as T | null`.
+
+---
+
 ## Replaced `@vaadin/router` with `LitroRouter` (URLPattern API)
 
 **Decision**: Remove `@vaadin/router` (deprecated) as a dependency. Replace with a thin built-in router class (`packages/framework/src/runtime/litro-router.ts`) built on the native `URLPattern` web API.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -269,6 +269,27 @@ Without `base: '/_litro/'`, Vite uses `"/"` and all `<link rel="modulepreload">`
 
 ---
 
+## LitroOutlet: plain getter/setter for `routes`, not a Lit reactive property
+
+**Decision**: Replace `@property({ type: Array }) routes: Route[] = []` with a plain getter/setter on `LitroOutlet` that calls `router.setRoutes()` directly when the router is already initialised. The property is NOT declared as a Lit reactive property.
+
+**Rationale**:
+
+The timing sequence when `app.ts` loads:
+1. Importing `LitroOutlet.js` calls `customElements.define()`, which immediately upgrades the SSR'd `<litro-outlet>` element already in the DOM
+2. Lit schedules the first update as a **microtask**
+3. `app.ts` registers a `DOMContentLoaded` listener (a macrotask)
+4. The microtask fires → `firstUpdated()` runs with `routes = []` → router initialised with no routes
+5. `DOMContentLoaded` fires → `outlet.routes = routes` — but the router never receives them
+
+The `updated()` lifecycle hook was considered but rejected: Lit's `createProperty()` installs an accessor that calls `requestUpdate()`, scheduling a render cycle. `firstUpdated()` removes all children (including Lit's internal ChildPart marker nodes) so the router owns the subtree. Any subsequent Lit render cycle crashes with "ChildPart has no parentNode".
+
+A plain getter/setter fixes both problems without touching Lit's render pipeline: the setter forwards route changes directly to the router if it exists, with no `requestUpdate()` call. Since `LitroOutlet` has no render output and routes are never set via HTML attribute, Lit's reactive property system is not needed.
+
+**Also fixed**: `app.ts` (in the fullstack recipe template and in `playground/`) updated to set `outlet.routes` synchronously after imports, before any async task boundary. Module scripts are deferred by the browser, so by the time they execute the DOM is fully parsed and `<litro-outlet>` is present. Setting routes synchronously ensures `firstUpdated()` sees the real route table before the first Lit update microtask fires.
+
+---
+
 ## Release pipeline: Changesets + GitHub Actions
 
 **Decision**: Use [Changesets](https://github.com/changesets/changesets) (`@changesets/cli`) for version management, changelog generation, and automated npm publishing via `changesets/action` in GitHub Actions.

--- a/packages/create-litro/recipes/fullstack/template/app.ts
+++ b/packages/create-litro/recipes/fullstack/template/app.ts
@@ -10,11 +10,14 @@ import '@beatzball/litro/runtime/LitroLink.js';
 // emptyOutDir does not delete it between builds.
 import { routes } from './routes.generated.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  const outlet = document.querySelector('litro-outlet') as (Element & { routes: unknown }) | null;
-  if (outlet) {
-    outlet.routes = routes;
-  } else {
-    console.warn('[litro] <litro-outlet> not found — router will not start.');
-  }
-});
+// Set routes synchronously. By the time this module-script executes (all
+// module scripts are deferred), the HTML is fully parsed and <litro-outlet>
+// is already in the DOM. Setting outlet.routes here — before Lit's first
+// update microtask fires — ensures firstUpdated() sees the real route table
+// rather than the empty default, so the router starts correctly.
+const outlet = document.querySelector('litro-outlet') as (Element & { routes: unknown }) | null;
+if (outlet) {
+  outlet.routes = routes;
+} else {
+  console.warn('[litro] <litro-outlet> not found — router will not start.');
+}

--- a/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 import type { LitroLocation } from '@beatzball/litro-router';
@@ -27,8 +27,6 @@ export async function generateRoutes(): Promise<string[]> {
 
 @customElement('page-blog-slug')
 export class BlogPostPage extends LitroPage {
-  @state() declare serverData: PostData | null;
-
   // Called by LitroRouter on client-side navigation to fetch data for the new slug.
   override async fetchData(location: LitroLocation): Promise<PostData> {
     const slug = location.params['slug'] ?? '';
@@ -40,10 +38,11 @@ export class BlogPostPage extends LitroPage {
   }
 
   render() {
+    const data = this.serverData as PostData | null;
     return html`
       <article>
-        <h1>${this.serverData?.title ?? 'Loading…'}</h1>
-        <p>${this.serverData?.content ?? ''}</p>
+        <h1>${data?.title ?? 'Loading…'}</h1>
+        <p>${data?.content ?? ''}</p>
         <litro-link href="/blog">← Back to Blog</litro-link>
         &nbsp;|&nbsp;
         <litro-link href="/">← Home</litro-link>

--- a/packages/create-litro/recipes/fullstack/template/pages/index.ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/index.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 
@@ -18,8 +18,6 @@ export const pageData = definePageData(async (_event) => {
 
 @customElement('page-home')
 export class HomePage extends LitroPage {
-  @state() declare serverData: HomeData | null;
-
   // Called on client-side navigation (not on the initial SSR load).
   override async fetchData() {
     const res = await fetch('/api/hello');
@@ -27,11 +25,12 @@ export class HomePage extends LitroPage {
   }
 
   render() {
+    const data = this.serverData as HomeData | null;
     if (this.loading) return html`<p>Loading…</p>`;
     return html`
       <main>
-        <h1>${this.serverData?.message ?? 'Welcome to {{projectName}}'}</h1>
-        <p><small>Rendered at: ${this.serverData?.timestamp ?? '—'}</small></p>
+        <h1>${data?.message ?? 'Welcome to {{projectName}}'}</h1>
+        <p><small>Rendered at: ${data?.timestamp ?? '—'}</small></p>
         <nav>
           <litro-link href="/blog">Go to Blog →</litro-link>
         </nav>

--- a/packages/framework/src/runtime/LitroLink.ts
+++ b/packages/framework/src/runtime/LitroLink.ts
@@ -23,11 +23,25 @@
  *    to the default browser handling. Only internal paths (starting with '/')
  *    are intercepted; external URLs are left to the browser.
  *
- * 4. event.composedPath() FOR SHADOW DOM TRAVERSAL
- *    When a click originates inside a shadow root, event.target is the shadow
- *    host rather than the actual clicked element. composedPath() returns the
- *    full path from the event target through all shadow boundaries, so we can
- *    still identify the inner <a> and extract its href.
+ * 4. CLICK HANDLER ON THE HOST ELEMENT (not on the inner <a>)
+ *    The click handler is attached to <litro-link> itself in connectedCallback,
+ *    not via @click on the shadow <a>. This is critical for two reasons:
+ *
+ *    a) defer-hydration: @lit-labs/ssr adds defer-hydration to custom elements
+ *       inside shadow DOM. This blocks Lit's update cycle, so a @click binding
+ *       on the shadow <a> is never attached until the parent hydrates and removes
+ *       defer-hydration. By registering on the host in connectedCallback (which
+ *       runs before super.connectedCallback()'s defer-hydration check), the
+ *       handler is active immediately — even for SSR'd elements on first load.
+ *
+ *    b) cross-shadow-DOM reliability: click events on slotted content propagate
+ *       to the host element in all browsers. Relying on the shadow <a>'s @click
+ *       requires correct composed-path event propagation through nested shadow
+ *       roots, which can be inconsistent. The host listener is simpler and
+ *       more reliable.
+ *
+ *    The shadow <a> is kept WITHOUT a @click binding — it exists purely for
+ *    progressive enhancement (no-JS navigation) and semantics (cursor, a11y).
  *
  * 5. litro-router IS CLIENT-ONLY
  *    This module must NEVER be imported in server-side code paths. LitroRouter
@@ -35,28 +49,44 @@
  */
 
 import { LitElement, html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-// litro-router is dynamically imported inside handleClick() so it is never
+import { customElement } from 'lit/decorators.js';
+// litro-router is dynamically imported inside _clickHandler() so it is never
 // evaluated in Node.js (window does not exist server-side).
 
 @customElement('litro-link')
 export class LitroLink extends LitElement {
-  /** The destination path. Should be an absolute path starting with '/'. */
-  @property() href = '';
+  /**
+   * Declare reactive properties via static class field rather than @property()
+   * decorators. esbuild 0.21+ (Vite 5) uses the TC39 Stage 3 decorator
+   * transform. In that mode @property() on a plain field is silently dropped
+   * (only `accessor` fields are supported), and @property() accessor crashes
+   * at instantiation with "Cannot read properties of undefined (reading 'has')"
+   * because Lit's init function fires before elementProperties is populated.
+   *
+   * static override properties is read by Lit in finalize(), which is called
+   * from the observedAttributes getter when customElements.define() runs in
+   * the browser — before any instances are created — so attributeChangedCallback
+   * correctly fires for href/target/rel during element upgrade.
+   */
+  static override properties = {
+    href: { type: String },
+    target: { type: String },
+    rel: { type: String },
+  };
+
+  href = '';
+  target = '';
+  rel = '';
 
   /**
-   * The anchor target attribute (_blank, _self, etc.).
-   * If set, the click is NOT intercepted — the browser handles it natively.
+   * Bound click handler stored as a field so the same function reference can
+   * be used in both addEventListener and removeEventListener.
+   *
+   * Arrow function captures `this` (the LitroLink instance) so property
+   * access (this.href, this.target, etc.) works correctly regardless of how
+   * the browser invokes the listener.
    */
-  @property() target = '';
-
-  /**
-   * The anchor rel attribute. Passed through to the inner <a> element.
-   * Useful for 'noopener noreferrer' when target='_blank'.
-   */
-  @property() rel = '';
-
-  private handleClick(e: MouseEvent): void {
+  private _clickHandler = (e: MouseEvent): void => {
     // Do not intercept if:
     //   - target is set (user wants a specific frame/tab)
     //   - modifier keys are held (user wants a new tab / OS-level action)
@@ -67,17 +97,50 @@ export class LitroLink extends LitElement {
 
     // preventDefault() must be called synchronously before the async import.
     e.preventDefault();
-    // litro-router is loaded lazily — safe because handleClick() only fires
+    // litro-router is loaded lazily — safe because _clickHandler only fires
     // in the browser where window exists.
     void import('@beatzball/litro-router').then(({ LitroRouter }) => LitroRouter.go(this.href));
+  };
+
+  /**
+   * Attach the click listener to the host element using CAPTURE phase.
+   *
+   * WHY CAPTURE (not bubble):
+   *   For slotted content, the composed event path in bubble phase is:
+   *     text-node → <slot> → <a> → shadow-root → <litro-link>
+   *   Browsers commit the <a> default navigation when the event reaches <a>
+   *   in the bubble phase — before it ever reaches <litro-link>. A bubble
+   *   listener on the host is therefore always too late to call preventDefault.
+   *
+   *   In capture phase, the traversal goes DOWN from the root:
+   *     window → … → <litro-link> → shadow-root → <a> → <slot> → text-node
+   *   Our listener fires at <litro-link> BEFORE the event enters the shadow
+   *   DOM, so preventDefault() is guaranteed to block the <a> navigation.
+   *
+   * WHY connectedCallback (before super):
+   *   @lit-labs/ssr-client patches LitElement.prototype.connectedCallback to
+   *   skip Lit's update cycle when defer-hydration is present. Registering the
+   *   listener here (in LitroLink's own override, before super) ensures it is
+   *   active immediately — even for SSR'd elements on first load.
+   */
+  override connectedCallback(): void {
+    this.addEventListener('click', this._clickHandler, true);
+    super.connectedCallback();
+  }
+
+  override disconnectedCallback(): void {
+    this.removeEventListener('click', this._clickHandler, true);
+    super.disconnectedCallback();
   }
 
   override render() {
+    // No @click here — interception is handled by the host listener above.
+    // The <a> element exists for progressive enhancement (no-JS navigation)
+    // and correct semantics/accessibility (pointer cursor, keyboard focus).
     return html`<a
       href=${this.href}
       target=${this.target}
       rel=${this.rel}
-      @click=${this.handleClick}
     ><slot></slot></a>`;
   }
 }

--- a/packages/framework/src/runtime/LitroOutlet.ts
+++ b/packages/framework/src/runtime/LitroOutlet.ts
@@ -32,7 +32,7 @@
  */
 
 import { LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 // LitroRouter accesses `window` at runtime. We only import the TYPE here
 // (erased at runtime); the value is loaded lazily via a dynamic import inside
 // firstUpdated() so the module is never evaluated in Node.js.
@@ -52,15 +52,41 @@ export class LitroOutlet extends LitElement {
    * The array of Route objects. Set by the client entry after
    * routes.generated.ts is imported.
    *
+   * Plain getter/setter — NOT a Lit reactive property (@property / static
+   * properties). Routes are always assigned programmatically, never via an
+   * HTML attribute, so Lit's reactive property system is not needed here.
+   *
+   * Why not a Lit reactive property: Lit's createProperty() installs its own
+   * accessor that calls requestUpdate(), scheduling a render cycle. But
+   * firstUpdated() clears all children (including Lit's internal ChildPart
+   * marker nodes) so the router can own the element's subtree. Any subsequent
+   * render cycle crashes with "ChildPart has no parentNode". The plain setter
+   * forwards route changes directly to the router without touching Lit's
+   * render pipeline.
+   *
    * Example:
    *   [
    *     { path: '/', component: 'page-home', action: async () => { await import('./pages/index.js'); } },
    *     { path: '/about', component: 'page-about', action: async () => { await import('./pages/about.js'); } },
    *   ]
    */
-  @property({ type: Array }) routes: Route[] = [];
-
+  private _routes: Route[] = [];
   private router?: LitroRouter;
+
+  get routes(): Route[] {
+    return this._routes;
+  }
+
+  set routes(value: Route[]) {
+    this._routes = value;
+    // If the router is already initialised (i.e. routes arrived after
+    // firstUpdated()), forward them immediately. This handles the timing race
+    // where app.ts sets outlet.routes inside a DOMContentLoaded callback that
+    // fires after Lit's first-update microtask.
+    if (this.router) {
+      this.router.setRoutes(value);
+    }
+  }
 
   /**
    * Mount the router after the first render.
@@ -85,7 +111,7 @@ export class LitroOutlet extends LitElement {
       this.removeChild(this.lastChild);
     }
     this.router = new LitroRouter(this);
-    this.router.setRoutes(this.routes);
+    this.router.setRoutes(this._routes);
   }
 }
 

--- a/packages/framework/src/runtime/LitroPage.ts
+++ b/packages/framework/src/runtime/LitroPage.ts
@@ -77,10 +77,10 @@ export const LitroPageMixin = <T extends Constructor>(Base: T): (new (...args: a
      * The page data, populated either from the server-injected script tag
      * (on SSR load) or from `fetchData()` (on client navigation).
      *
-     * Type is `unknown` at the mixin level; subclasses should narrow it:
-     * ```ts
-     * @state() declare serverData: MyDataShape | null;
-     * ```
+     * Type is `unknown` at the mixin level; subclasses narrow it with a local
+     * cast in render(): `const data = this.serverData as MyDataShape | null`.
+     * Do NOT use `@state() declare serverData` — the `declare` modifier causes
+     * jiti/oxc-transform to throw in SSG mode.
      */
     @state() serverData: unknown = null;
 
@@ -156,16 +156,15 @@ export const LitroPageMixin = <T extends Constructor>(Base: T): (new (...args: a
  * ```ts
  * @customElement('page-home')
  * export class HomePage extends LitroPage {
- *   @state() declare serverData: { message: string } | null;
- *
  *   override async fetchData() {
  *     const res = await fetch('/api/hello');
  *     return res.json();
  *   }
  *
  *   render() {
+ *     const data = this.serverData as { message: string } | null;
  *     if (this.loading) return html`<p>Loading...</p>`;
- *     return html`<h1>${this.serverData?.message}</h1>`;
+ *     return html`<h1>${data?.message}</h1>`;
  *   }
  * }
  * ```

--- a/packages/framework/src/runtime/__tests__/LitroLink.test.ts
+++ b/packages/framework/src/runtime/__tests__/LitroLink.test.ts
@@ -2,26 +2,29 @@
  * Unit tests for LitroLink (<litro-link>) in LitroLink.ts.
  *
  * LitroLink wraps a standard <a> element and intercepts clicks for client-side
- * navigation via LitroRouter.go(). The click handler (handleClick) is the
- * critical logic under test.
+ * navigation via LitroRouter.go(). The click handler is registered on the HOST
+ * element via addEventListener in connectedCallback(), NOT as a Lit @click
+ * binding on the shadow <a>. This ensures it fires even when Lit's update cycle
+ * is blocked by defer-hydration on SSR'd elements.
  *
  * Testing approach:
  *   - Mock `@beatzball/litro-router` so LitroRouter.go() is a spy function.
  *   - Register LitroLink with customElements.define() so jsdom can instantiate it.
- *   - Call the private handleClick() method directly via type cast — this avoids
- *     the complexity of simulating full Lit rendering and shadow DOM events.
+ *   - Append to document.body so connectedCallback() fires and registers the listener.
+ *   - Dispatch real MouseEvents on the element — this exercises the actual
+ *     addEventListener path rather than calling the private handler directly.
  *
  * @vitest-environment jsdom
  *
  * Run with: pnpm --filter litro test
  */
 
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mock litro-router before importing LitroLink.
 //
-// LitroLink.handleClick() does:
+// LitroLink._clickHandler() does:
 //   void import('@beatzball/litro-router').then(({ LitroRouter }) => LitroRouter.go(this.href));
 //
 // We intercept this dynamic import so LitroRouter.go() becomes a vi.fn() spy.
@@ -65,68 +68,96 @@ function makeClick(opts: {
 
 /**
  * Flush the microtask queue so that `void import(...).then(...)` chains resolve.
- * We need this because handleClick fires the dynamic import asynchronously.
+ * We need this because _clickHandler fires the dynamic import asynchronously.
  */
 function flushMicrotasks(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 /**
- * Creates a LitroLink instance with the given href/target/rel properties,
- * registered under a unique tag name.
+ * Creates a LitroLink instance, sets href/target/rel, appends it to the
+ * document so connectedCallback() fires and registers the host click listener,
+ * then returns the element.
  */
-let linkCounter = 0;
 function makeLitroLink(
   href: string,
   target = '',
   rel = '',
 ): InstanceType<typeof LitroLink> {
-  // LitroLink is registered by @customElement('litro-link') at import time.
-  // We can retrieve and reuse it here. The element is already defined.
   const el = document.createElement('litro-link') as InstanceType<typeof LitroLink>;
   el.href = href;
   el.target = target;
   el.rel = rel;
+  // Append to body so connectedCallback() runs and addEventListener is called.
+  document.body.appendChild(el);
   return el;
 }
 
 // ---------------------------------------------------------------------------
-// LitroLink — SPA navigation (handleClick intercept path)
+// Cleanup between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  goSpy.mockClear();
+  document.querySelectorAll('litro-link').forEach(el => el.remove());
+});
+
+// ---------------------------------------------------------------------------
+// LitroLink — SPA navigation (_clickHandler intercept path)
 // ---------------------------------------------------------------------------
 
 describe('LitroLink — SPA navigation via LitroRouter.go()', () => {
   it('calls LitroRouter.go(href) for a same-origin path', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about');
 
-    const event = makeClick();
-    // Access private method via cast — avoids needing a full Lit render cycle.
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(makeClick());
     await flushMicrotasks();
 
     expect(goSpy).toHaveBeenCalledWith('/about');
   });
 
   it('calls e.preventDefault() to block the native navigation', () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/contact');
 
     const event = makeClick();
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
 
     // preventDefault must be called synchronously (before the async import resolves)
     expect(event.defaultPrevented).toBe(true);
   });
 
   it('passes the correct href to LitroRouter.go() for nested paths', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/blog/hello-world');
 
-    const event = makeClick();
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(makeClick());
     await flushMicrotasks();
 
     expect(goSpy).toHaveBeenCalledWith('/blog/hello-world');
+  });
+
+  it('registers the listener in connectedCallback so it fires without Lit hydration', () => {
+    // Element appended to DOM — connectedCallback() fired.
+    // Dispatching a click should reach _clickHandler even though the Lit
+    // render cycle has not run (simulates defer-hydration scenario).
+    const link = makeLitroLink('/about');
+
+    const event = makeClick();
+    link.dispatchEvent(event);
+
+    // preventDefault is the synchronous signal that the handler ran.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('removes the listener after disconnectedCallback', () => {
+    const link = makeLitroLink('/about');
+
+    // Remove from DOM — disconnectedCallback() should remove the listener.
+    link.remove();
+
+    const event = makeClick();
+    link.dispatchEvent(event);
+    // Handler was removed; default should not be prevented.
+    expect(event.defaultPrevented).toBe(false);
   });
 });
 
@@ -136,11 +167,10 @@ describe('LitroLink — SPA navigation via LitroRouter.go()', () => {
 
 describe('LitroLink — conditions where click is NOT intercepted', () => {
   it('does NOT intercept when target is set (_blank)', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about', '_blank');
 
     const event = makeClick();
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
@@ -148,11 +178,10 @@ describe('LitroLink — conditions where click is NOT intercepted', () => {
   });
 
   it('does NOT intercept when metaKey is held (new tab intent)', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about');
 
     const event = makeClick({ metaKey: true });
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
@@ -160,44 +189,40 @@ describe('LitroLink — conditions where click is NOT intercepted', () => {
   });
 
   it('does NOT intercept when ctrlKey is held', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about');
 
     const event = makeClick({ ctrlKey: true });
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
   });
 
   it('does NOT intercept when shiftKey is held (new window intent)', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about');
 
     const event = makeClick({ shiftKey: true });
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
   });
 
   it('does NOT intercept when altKey is held', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('/about');
 
     const event = makeClick({ altKey: true });
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
   });
 
   it('does NOT intercept external URLs (http://)', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('http://example.com/page');
 
     const event = makeClick();
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();
@@ -205,11 +230,10 @@ describe('LitroLink — conditions where click is NOT intercepted', () => {
   });
 
   it('does NOT intercept external URLs (https://)', async () => {
-    goSpy.mockClear();
     const link = makeLitroLink('https://example.com');
 
     const event = makeClick();
-    (link as unknown as { handleClick(e: MouseEvent): void }).handleClick(event);
+    link.dispatchEvent(event);
     await flushMicrotasks();
 
     expect(goSpy).not.toHaveBeenCalled();

--- a/packages/framework/src/runtime/__tests__/LitroOutlet.test.ts
+++ b/packages/framework/src/runtime/__tests__/LitroOutlet.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for LitroOutlet (<litro-outlet>) in LitroOutlet.ts.
+ *
+ * The critical invariant under test: the router always receives the real route
+ * table via setRoutes(), regardless of whether routes are assigned before or
+ * after Lit's first update microtask fires.
+ *
+ * Background on the timing bug this tests against:
+ *   - When <litro-outlet> is upgraded (customElements.define()), Lit schedules
+ *     the first update as a microtask — not synchronously.
+ *   - If `outlet.routes` is set inside a DOMContentLoaded callback, it fires
+ *     AFTER that microtask, so firstUpdated() runs with routes=[] and the
+ *     router is never given the real routes.
+ *   - The fix: LitroOutlet.routes uses a property setter that calls
+ *     setRoutes() directly when the router is already initialised. This avoids
+ *     triggering Lit's update/render cycle (which would crash because
+ *     firstUpdated() removes Lit's internal ChildPart marker nodes).
+ *
+ * Testing approach:
+ *   - Mock `@beatzball/litro-router` so LitroRouter is a class whose
+ *     setRoutes() is a spy, and its constructor records the outlet element.
+ *   - Register LitroOutlet with customElements.define().
+ *   - Append to jsdom document so Lit's lifecycle hooks fire.
+ *   - Use `await afterUpdate(el)` to wait for firstUpdated()'s async body
+ *     (the dynamic import + router setup) before asserting. Lit's
+ *     `updateComplete` resolves when the synchronous render cycle ends but
+ *     does NOT await the async firstUpdated() body; a zero-delay setTimeout
+ *     flushes those remaining microtasks.
+ *
+ * @vitest-environment jsdom
+ *
+ * Run with: pnpm --filter litro test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @beatzball/litro-router before importing LitroOutlet.
+//
+// LitroOutlet.firstUpdated() does:
+//   const { LitroRouter } = await import('@beatzball/litro-router');
+//   this.router = new LitroRouter(this);
+//   this.router.setRoutes(this.routes);
+//
+// We replace LitroRouter with a class whose constructor and setRoutes() are
+// vi.fn() spies so we can assert on call counts and arguments.
+// ---------------------------------------------------------------------------
+
+const setRoutesSpy = vi.fn();
+const RouterConstructorSpy = vi.fn();
+
+vi.mock('@beatzball/litro-router', () => ({
+  LitroRouter: class MockLitroRouter {
+    constructor(outlet: Element) {
+      RouterConstructorSpy(outlet);
+    }
+    setRoutes = setRoutesSpy;
+  },
+}));
+
+// Import LitroOutlet AFTER vi.mock() so the mock is in place.
+const { LitroOutlet } = await import('../LitroOutlet.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal route fixture matching the Route type shape expected by the router. */
+const ROUTES = [
+  { path: '/', component: 'page-home', action: async () => {} },
+  { path: '/blog', component: 'page-blog', action: async () => {} },
+];
+
+/**
+ * Wait for Lit's update cycle AND the async body of firstUpdated() to finish.
+ *
+ * Lit calls firstUpdated() but does not await it (async lifecycle methods are
+ * fire-and-forget in Lit). updateComplete therefore resolves before the
+ * `await import('@beatzball/litro-router')` inside firstUpdated() settles.
+ * A zero-delay setTimeout flushes those remaining microtasks.
+ */
+async function afterUpdate(el: InstanceType<typeof LitroOutlet>): Promise<void> {
+  await el.updateComplete;
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/**
+ * Creates a LitroOutlet element, appends it to document.body so Lit's
+ * lifecycle fires, then waits for firstUpdated()'s async body to complete.
+ */
+async function makeOutlet(): Promise<InstanceType<typeof LitroOutlet>> {
+  const el = document.createElement('litro-outlet') as InstanceType<typeof LitroOutlet>;
+  document.body.appendChild(el);
+  await afterUpdate(el);
+  return el;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  setRoutesSpy.mockClear();
+  RouterConstructorSpy.mockClear();
+  document.querySelectorAll('litro-outlet').forEach(el => el.remove());
+});
+
+// ---------------------------------------------------------------------------
+// firstUpdated() — routes set before the first update microtask fires
+// ---------------------------------------------------------------------------
+
+describe('LitroOutlet — routes set synchronously before first update', () => {
+  it('passes routes to setRoutes() during firstUpdated()', async () => {
+    const el = document.createElement('litro-outlet') as InstanceType<typeof LitroOutlet>;
+    // Set routes synchronously — before appending to DOM triggers firstUpdated().
+    el.routes = ROUTES as never;
+    document.body.appendChild(el);
+    await afterUpdate(el);
+
+    expect(setRoutesSpy).toHaveBeenCalledOnce();
+    expect(setRoutesSpy).toHaveBeenCalledWith(ROUTES);
+  });
+
+  it('constructs LitroRouter with the outlet element as its argument', async () => {
+    const el = document.createElement('litro-outlet') as InstanceType<typeof LitroOutlet>;
+    el.routes = ROUTES as never;
+    document.body.appendChild(el);
+    await afterUpdate(el);
+
+    expect(RouterConstructorSpy).toHaveBeenCalledOnce();
+    expect(RouterConstructorSpy).toHaveBeenCalledWith(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property setter — routes set after firstUpdated() fires (timing-race fix)
+//
+// The setter calls setRoutes() directly on the router instance without going
+// through Lit's update/render cycle (which would crash because firstUpdated()
+// removes Lit's internal ChildPart marker nodes).
+// ---------------------------------------------------------------------------
+
+describe('LitroOutlet — routes set after first update (timing-race fix)', () => {
+  it('calls setRoutes() when routes are assigned after the router is initialised', async () => {
+    // Append without routes — simulates the DOMContentLoaded timing race where
+    // firstUpdated() fires before the routes are assigned.
+    const el = await makeOutlet();
+    setRoutesSpy.mockClear(); // discard the call from firstUpdated()
+
+    // Now set routes — as if a DOMContentLoaded callback fires late.
+    // The property setter calls setRoutes() synchronously (no update cycle).
+    el.routes = ROUTES as never;
+
+    expect(setRoutesSpy).toHaveBeenCalledOnce();
+    expect(setRoutesSpy).toHaveBeenCalledWith(ROUTES);
+  });
+
+  it('does NOT call setRoutes() before the router is initialised (setter guard)', () => {
+    // Element created but NOT appended → firstUpdated() never fires → router = undefined.
+    const el = document.createElement('litro-outlet') as InstanceType<typeof LitroOutlet>;
+    el.routes = ROUTES as never; // setter runs but router is undefined
+
+    // setRoutes() must NOT be called — the router doesn't exist yet.
+    expect(setRoutesSpy).not.toHaveBeenCalled();
+    // The routes value is still stored and will be forwarded by firstUpdated().
+    expect(el.routes).toBe(ROUTES);
+  });
+
+  it('calls setRoutes() each time routes is replaced after init', async () => {
+    const el = await makeOutlet();
+    setRoutesSpy.mockClear();
+
+    const firstRoutes = [{ path: '/', component: 'page-home', action: async () => {} }];
+    const secondRoutes = [...firstRoutes, { path: '/about', component: 'page-about', action: async () => {} }];
+
+    el.routes = firstRoutes as never;
+    el.routes = secondRoutes as never;
+
+    expect(setRoutesSpy).toHaveBeenCalledTimes(2);
+    expect(setRoutesSpy).toHaveBeenNthCalledWith(1, firstRoutes);
+    expect(setRoutesSpy).toHaveBeenNthCalledWith(2, secondRoutes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSR child-clearing behaviour
+// ---------------------------------------------------------------------------
+
+describe('LitroOutlet — clears SSR children on firstUpdated()', () => {
+  it('removes any children present before the router initialises', async () => {
+    const el = document.createElement('litro-outlet') as InstanceType<typeof LitroOutlet>;
+    // Simulate SSR-streamed content inside the outlet.
+    const ssrNode = document.createElement('div');
+    ssrNode.textContent = 'SSR content';
+    el.appendChild(ssrNode);
+
+    document.body.appendChild(el);
+    await afterUpdate(el);
+
+    expect(el.childElementCount).toBe(0);
+  });
+});

--- a/packages/litro-router/src/index.ts
+++ b/packages/litro-router/src/index.ts
@@ -83,6 +83,13 @@ interface InternalRoute {
 export class LitroRouter {
   private routes: InternalRoute[] = [];
   private outlet: HTMLElement;
+  /**
+   * Monotonically increasing counter. Incremented at the start of every
+   * `_resolve()` call. Each invocation captures its own token and checks it
+   * after every `await`; if the counter has moved on, a newer navigation
+   * superseded this one and we bail out without touching the DOM.
+   */
+  private _resolveToken = 0;
 
   constructor(outlet: HTMLElement) {
     this.outlet = outlet;
@@ -111,6 +118,7 @@ export class LitroRouter {
   }
 
   private async _resolve(): Promise<void> {
+    const token = ++this._resolveToken;
     const pathname = location.pathname;
 
     for (const route of this.routes) {
@@ -122,6 +130,9 @@ export class LitroRouter {
       // Run the action first (typically: dynamically import the page module so
       // customElements.define() runs before createElement is called).
       await route.action();
+
+      // A newer navigation superseded this one — bail out without touching DOM.
+      if (token !== this._resolveToken) return;
 
       const loc: LitroLocation = {
         pathname,
@@ -138,6 +149,9 @@ export class LitroRouter {
       if (typeof el.onBeforeEnter === 'function') {
         await el.onBeforeEnter(loc);
       }
+
+      // Check again after the onBeforeEnter async hook.
+      if (token !== this._resolveToken) return;
 
       // Swap outlet content.
       while (this.outlet.lastChild) {

--- a/playground/app.ts
+++ b/playground/app.ts
@@ -28,18 +28,17 @@ import '@beatzball/litro/runtime/LitroLink.js';
 // emptyOutDir does not delete it, and it can be re-generated before vite build.
 import { routes } from './routes.generated.js';
 
-// Step 4 — initialize the router when the DOM is ready
-// We set .routes on the <litro-outlet> element rather than calling initRouter()
-// here so the element's own firstUpdated() lifecycle creates the Router instance
-// after the element is in the DOM.
-document.addEventListener('DOMContentLoaded', () => {
-  const outlet = document.querySelector('litro-outlet') as (Element & { routes: unknown }) | null;
-  if (outlet) {
-    outlet.routes = routes;
-  } else {
-    console.warn(
-      '[litro] DOMContentLoaded: no <litro-outlet> found in the document. ' +
-        'Make sure the HTML shell includes <litro-outlet></litro-outlet>.'
-    );
-  }
-});
+// Step 4 — initialize the router
+// Set .routes synchronously. Module scripts are deferred, so by the time this
+// executes the HTML is fully parsed and <litro-outlet> is in the DOM. Setting
+// routes here — before Lit's first update microtask fires — ensures
+// firstUpdated() sees the real route table, not the empty default.
+const outlet = document.querySelector('litro-outlet') as (Element & { routes: unknown }) | null;
+if (outlet) {
+  outlet.routes = routes;
+} else {
+  console.warn(
+    '[litro] no <litro-outlet> found in the document. ' +
+      'Make sure the HTML shell includes <litro-outlet></litro-outlet>.'
+  );
+}


### PR DESCRIPTION
  Summary

  Fixes four compounding bugs that caused <litro-link> clicks to be silently ignored (full page reloads instead of SPA navigation) in freshly scaffolded fullstack apps.

  - Bug 1 — Empty route table on init (LitroOutlet, app.ts): outlet.routes was set inside a DOMContentLoaded callback, so Lit's first-update microtask fired before routes were assigned. Fix: replace @property({ type: Array }) routes with a plain getter/setter that calls router.setRoutes() directly; set routes synchronously in app.ts.
  - Bug 2 — Click handler never attached on SSR'd pages (LitroLink): @lit-labs/ssr adds defer-hydration to custom elements inside shadow DOM, blocking Lit's update cycle. A @click binding on the shadow <a> was never attached on SSR'd pages. Fix: move the handler to the host element via addEventListener('click', ..., true) registered in
  connectedCallback() before super.
  - Bug 3 — _resolve() race condition (LitroRouter): Concurrent navigations could let a stale _resolve() overwrite a newer result. Fix: add a _resolveToken monotonic counter; each call bails out if superseded.
  - Bug 4 — @property() decorators silently dropped by esbuild TC39 transform (LitroLink): Vite 5 / esbuild 0.21+ uses the TC39 Stage 3 decorator transform, which silently drops @property() on plain fields. this.href stayed '' forever. Fix: replace with static override properties = { href, target, rel } plus plain field initializers.
  - Template fix — @state() declare serverData breaks SSG: jiti's oxc-transform throws on declare fields in TC39 mode. Fix: remove @state() declare serverData from recipe templates; use local type casts in render() instead.

  Test plan

  - pnpm --filter @beatzball/litro-router test — 16 tests pass
  - pnpm --filter @beatzball/litro test — 182 tests pass
  - pnpm --filter @beatzball/create-litro test — 11 tests pass
  - Scaffold a new app with npm create @beatzball/litro, run litro dev, click <litro-link> elements — SPA navigation works, no full page reloads, no JS console errors
  - Verify litro build && litro preview serves correctly (SSR + hydration)
