### PR TITLE
docs: update README for create-litro completion and fix @state() declare example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ litro/
 
 ## Quick start — scaffold a new app (local)
 
-> **Note:** `create-litro` is not published to npm yet. Use the local path instructions below.
-
 **Step 1 — build the framework and scaffolder from source:**
 
 ```bash
@@ -185,8 +183,6 @@ export const pageData = definePageData(async (event) => {
 
 @customElement("page-home")
 export class HomePage extends LitroPage {
-  @state() declare serverData: { message: string; timestamp: string } | null;
-
   override async fetchData() {
     // Called on client-side navigation (not on the initial SSR load)
     const res = await fetch("/api/hello");
@@ -194,7 +190,9 @@ export class HomePage extends LitroPage {
   }
 
   render() {
-    return html` <h1>${this.serverData?.message ?? "Loading..."}</h1> `;
+    // Cast serverData locally — do NOT use `@state() declare` (breaks jiti/SSG)
+    const data = this.serverData as { message: string; timestamp: string } | null;
+    return html` <h1>${data?.message ?? "Loading..."}</h1> `;
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Remove stale "not published to npm yet" caveat from the `create-litro` scaffolding section — the package is complete and working
- Fix the `serverData` code example to use a local cast in `render()` instead of `@state() declare`, which breaks jiti/SSG (jiti's oxc-transform throws on `declare` fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)