### PR TITLE
chore: add changesets for starlight release

### DIFF
--- a/.changeset/feat-starlight-recipe.md
+++ b/.changeset/feat-starlight-recipe.md
@@ -1,0 +1,14 @@
+---
+"@beatzball/create-litro": minor
+---
+
+Add `starlight` recipe — Astro Starlight-inspired docs + blog site scaffolded as Lit web components with full SSG support.
+
+`npm create @beatzball/litro my-docs -- --recipe starlight` scaffolds a static docs + blog site with:
+
+- **Layout components**: `<starlight-page>`, `<starlight-header>`, `<starlight-sidebar>`, `<starlight-toc>`
+- **UI components**: `<sl-card>`, `<sl-card-grid>`, `<sl-badge>`, `<sl-aside>`, `<sl-tabs>`, `<sl-tab-item>`
+- **Pages**: `/` (splash), `/docs/:slug`, `/blog`, `/blog/:slug`, `/blog/tags/:tag` — all SSG-prerendered
+- **`--sl-*` CSS token layer** with dark/light mode toggle and no flash of unstyled content
+- **`server/starlight.config.js`** — site title, nav links, sidebar groups
+- SSG-only (no `--mode` flag needed)

--- a/.changeset/fix-router-hash-nav-and-head-injection.md
+++ b/.changeset/fix-router-hash-nav-and-head-injection.md
@@ -1,0 +1,15 @@
+---
+"@beatzball/litro-router": patch
+"@beatzball/litro": patch
+---
+
+Fix hash-only navigation re-renders, shadow DOM scroll-to-hash, SSG preview, and routeMeta.head injection.
+
+**`@beatzball/litro-router`**
+- Hash-only `popstate` events (fragment/TOC links) no longer re-render the current page. `LitroRouter` now tracks `_lastPathname` and skips `_resolve()` when only the hash changes.
+- After mounting a component, if `location.hash` is set, the router waits for `updateComplete` then scrolls to the target element via `_scrollToHash()`. Heading elements inside shadow roots are located using `_findDeep()` recursive shadow DOM traversal — native `document.getElementById()` cannot cross shadow boundaries.
+
+**`@beatzball/litro`**
+- `createPageHandler` now forwards `routeMeta.head` to `buildShell()`. Previously, stylesheet links and inline scripts declared in `routeMeta.head` were silently dropped from the HTML `<head>`.
+- `litro preview` now serves SSG builds from `dist/static/` with a built-in Node.js static file server (clean-URL resolution, correct MIME types). Previously only SSR builds were handled and `litro preview` after an SSG build exited with "No production build found".
+- Fixed Node.js v22 DEP0190 deprecation: `spawn`/`spawnSync` calls with an args array and `shell: true` now join into a single command string.


### PR DESCRIPTION
Adds changesets for the changes merged in #14.

## Version bumps

| Package | Bump | New version |
|---|---|---|
| `@beatzball/litro-router` | patch | 0.1.3 |
| `@beatzball/litro` | patch | 0.1.3 |
| `@beatzball/create-litro` | minor | 0.2.0 |

(`@beatzball/litro` also picks up an internal patch bump from the `litro-router` dep cascade.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)