### PR TITLE
chore: dynamic port selection for litro dev/preview

### DIFF
--- a/.changeset/dynamic-port-selection.md
+++ b/.changeset/dynamic-port-selection.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": patch
+---
+
+`litro dev` and `litro preview` now default to port 3000 and auto-increment when that port is taken, rather than crashing with an opaque `EADDRINUSE` error. A connect-based TCP probe detects all listeners including Docker Desktop's port-forwarding on macOS. Passing `--port`/`-p` explicitly still errors out if that port is already in use.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,7 +100,7 @@ Vite produces content-hashed filenames so the client bundle can be served with a
 In development, **both Vite and Nitro share a single HTTP port**. There is no separate Vite port, no cross-process proxy, and no CORS issues.
 
 ```
-Browser ──HTTP──► :3030 (Nitro dev server)
+Browser ──HTTP──► :3000 (Nitro dev server, auto-increments if taken)
                      │
                      ├── /api/**          ─► Nitro API handlers
                      ├── /_litro/**       ─► Nitro static asset handler
@@ -249,8 +249,8 @@ Route-not-found requests during dev return a 404 HTML page listing all registere
 The `litro` CLI (`packages/framework/src/cli/index.ts`) is intentionally thin. It delegates all heavy work to the `nitro` and `vite` CLI binaries found in the project's `node_modules/.bin/`. This avoids re-implementing dev server, build orchestration, or preview logic. The CLI uses Node.js `child_process.spawn` (no `execa` dependency) and sets `LITRO_MODE` in the environment so downstream Nitro and Vite plugins can read the current mode.
 
 ```
-litro dev      → spawn('nitro', ['dev', '--port', '3030'], { LITRO_MODE: 'server' })
-               (default port 3030; override with --port <n> or -p <n>)
+litro dev      → resolvePort(3000) → spawn('nitro', ['dev', '--port', '<n>'], { LITRO_MODE: 'server' })
+               (default port 3000; auto-increments if taken; override with --port <n> or -p <n>)
 litro build    → scanAndWriteClientRoutes(cwd)            // Stage 0: write routes.generated.ts
                  then spawn('vite', ['build'])             // Stage 1: client bundle
                  then spawn('nitro', ['build'], { LITRO_MODE: 'server'|'static' })  // Stage 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Verified working:
 - `pageModules` registry enabling bundle-time page compilation
 - Dev server (`litro dev`) — Vite middleware intercepts JS/TS requests; Nitro handles HTML and API
   - Auto-builds `dist/client/app.js` via `vite build` if it doesn't exist (needed because `dist/` is gitignored)
-- Default dev port: 3030 (custom port via `litro dev --port <n>`)
+- Default dev port: 3000, auto-increments if taken (custom port via `litro dev --port <n>`)
 - Preview server (`litro preview`) — SSR builds served from `dist/server/server/index.mjs`; SSG builds served by built-in static file server from `dist/static/`
 - `litro build` — page scan runs before `vite build`; fresh routes always baked into client bundle
 - `create-litro` recipe system — `fullstack`, `11ty-blog`, `starlight` recipes, `{{placeholder}}` interpolation

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -170,11 +170,11 @@ The fix uses two changes together:
 
 ---
 
-## CLI: default dev port 3030
+## CLI: dynamic port selection
 
-**Decision**: `litro dev` defaults to port 3030 and accepts `--port` / `-p` for overrides.
+**Decision**: `litro dev` and `litro preview` default to port 3000 and auto-increment if that port is taken. Passing `--port` / `-p` explicitly errors out instead of silently moving to another port.
 
-**Rationale**: Avoids collision with the common defaults of React (3000), Vue (5173), and other tools. The port is passed through to `nitro dev --port <n>`; Nitro handles the actual binding.
+**Rationale**: Port collisions (multiple playgrounds, Docker containers, other dev tools) previously produced an opaque `EADDRINUSE` crash from Nitro. A connect-based TCP probe (`node:net` `createConnection`) is used rather than a bind-based probe — Docker Desktop on macOS publishes ports through a userspace proxy that may not hold a conventional bound socket, so only a connection attempt reliably detects occupancy. The resolved port is handed to Nitro/the static server; Nitro's own port fallback is never invoked.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "pnpm": {
     "overrides": {
-      "serialize-javascript": ">=7.0.3"
+      "serialize-javascript": ">=7.0.3",
+      "tar": ">=7.5.11"
     }
   }
 }

--- a/packages/framework/src/cli/index.ts
+++ b/packages/framework/src/cli/index.ts
@@ -24,6 +24,7 @@ import { createReadStream, existsSync, statSync } from 'node:fs';
 import { join, extname } from 'node:path';
 import process from 'node:process';
 import { scanAndWriteClientRoutes } from '../plugins/pages.js';
+import { parsePortArg, resolvePort } from './port.js';
 
 const [,, command, ...args] = process.argv;
 const cwd = process.cwd();
@@ -73,14 +74,9 @@ switch (command) {
       });
     }
 
-    // Resolve port: --port <n> or -p <n> from args, falling back to 3030.
-    const portFlagIdx = args.findIndex((a) => a === '--port' || a === '-p');
-    const portInline = args.find((a) => a.startsWith('--port=') || a.startsWith('-p='));
-    const port =
-      portInline?.split('=')[1] ??
-      (portFlagIdx !== -1 ? args[portFlagIdx + 1] : undefined) ??
-      '3030';
-    run('nitro', ['dev', '--port', port], { LITRO_MODE: 'server' });
+    const { port: rawPort, explicit } = parsePortArg(args);
+    const port = await resolvePort(rawPort, explicit);
+    run('nitro', ['dev', '--port', String(port)], { LITRO_MODE: 'server' });
     break;
   }
 
@@ -142,13 +138,8 @@ switch (command) {
     break;
 
   case 'preview': {
-    const portFlagIdx = args.findIndex((a) => a === '--port' || a === '-p');
-    const portInline = args.find((a) => a.startsWith('--port=') || a.startsWith('-p='));
-    const port = Number(
-      portInline?.split('=')[1] ??
-      (portFlagIdx !== -1 ? args[portFlagIdx + 1] : undefined) ??
-      '3030',
-    );
+    const { port: rawPort, explicit } = parsePortArg(args);
+    const port = await resolvePort(rawPort, explicit);
 
     // SSG build: serve dist/static/ with a built-in static file server.
     const staticDir = join(cwd, 'dist', 'static');
@@ -219,7 +210,7 @@ switch (command) {
 litro — Lit-first fullstack framework
 
 Commands:
-  litro dev              Start development server (default port: 3030)
+  litro dev              Start development server (default port: 3000)
   litro dev --port 8080  Start on a custom port
   litro build            Build for production (--mode static|server, default: server)
   litro generate         Build static site (alias for litro build --mode static)

--- a/packages/framework/src/cli/port.test.ts
+++ b/packages/framework/src/cli/port.test.ts
@@ -1,0 +1,99 @@
+import { createServer } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parsePortArg, probePort, resolvePort } from './port.js';
+
+// Helper: bind a real TCP server on a port and return a cleanup function.
+function bindPort(port: number): Promise<() => Promise<void>> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(port, () => {
+      resolve(() => new Promise<void>((res) => server.close(() => res())));
+    });
+  });
+}
+
+describe('probePort', () => {
+  it('returns true for a free port', async () => {
+    // Port 0 → OS assigns an ephemeral port; we need a known-free port.
+    // Use a high port unlikely to be in use.
+    const free = await probePort(19847);
+    expect(free).toBe(true);
+  });
+
+  it('returns false when a port is already occupied', async () => {
+    const close = await bindPort(19848);
+    try {
+      expect(await probePort(19848)).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('parsePortArg', () => {
+  it('parses --port <n>', () => {
+    expect(parsePortArg(['--port', '8080'])).toEqual({ port: 8080, explicit: true });
+  });
+
+  it('parses --port=<n>', () => {
+    expect(parsePortArg(['--port=9000'])).toEqual({ port: 9000, explicit: true });
+  });
+
+  it('parses -p <n>', () => {
+    expect(parsePortArg(['-p', '4000'])).toEqual({ port: 4000, explicit: true });
+  });
+
+  it('parses -p=<n>', () => {
+    expect(parsePortArg(['-p=9000'])).toEqual({ port: 9000, explicit: true });
+  });
+
+  it('returns default when no flag present', () => {
+    expect(parsePortArg([])).toEqual({ port: 3000, explicit: false });
+  });
+
+  it('respects a custom defaultPort', () => {
+    expect(parsePortArg([], 4321)).toEqual({ port: 4321, explicit: false });
+  });
+});
+
+describe('resolvePort', () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (close) {
+      await close();
+      close = undefined;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns the port as-is when free (implicit)', async () => {
+    const result = await resolvePort(19849, false);
+    expect(result).toBe(19849);
+  });
+
+  it('returns the port as-is when free (explicit)', async () => {
+    const result = await resolvePort(19850, true);
+    expect(result).toBe(19850);
+  });
+
+  it('auto-increments to next free port when default port is taken', async () => {
+    close = await bindPort(19851);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await resolvePort(19851, false);
+    expect(result).toBe(19852);
+    expect(consoleSpy).toHaveBeenCalledWith('[litro] Port 19851 in use, using 19852');
+  });
+
+  it('calls process.exit(1) when explicit port is taken', async () => {
+    close = await bindPort(19853);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await resolvePort(19853, true);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Port 19853 is already in use'),
+    );
+  });
+});

--- a/packages/framework/src/cli/port.ts
+++ b/packages/framework/src/cli/port.ts
@@ -1,0 +1,77 @@
+import { createConnection } from 'node:net';
+import process from 'node:process';
+
+/**
+ * Probe whether a TCP port is available on localhost.
+ * Returns true if the port is free, false if it is already in use.
+ *
+ * Uses a connect probe rather than a bind probe so it detects all listeners
+ * on 127.0.0.1 — including Docker Desktop's port-forwarding on macOS, which
+ * occupies ports through a userspace proxy that may not hold a conventional
+ * bound socket visible to a bind attempt.
+ */
+export function probePort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host: '127.0.0.1' });
+    socket.setTimeout(300);
+    socket.once('connect', () => {
+      socket.destroy();
+      resolve(false); // something accepted the connection → port in use
+    });
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      socket.destroy();
+      resolve(err.code === 'ECONNREFUSED'); // ECONNREFUSED = nothing listening → free
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      resolve(false); // conservative: treat a hanging connection as in use
+    });
+  });
+}
+
+/**
+ * Parse --port / -p from an argv array.
+ * Returns { port, explicit: true } when the flag is present,
+ * { port: defaultPort, explicit: false } otherwise.
+ */
+export function parsePortArg(
+  args: string[],
+  defaultPort = 3000,
+): { port: number; explicit: boolean } {
+  const inline = args.find((a) => a.startsWith('--port=') || a.startsWith('-p='));
+  if (inline) {
+    return { port: Number(inline.split('=')[1]), explicit: true };
+  }
+  const flagIdx = args.findIndex((a) => a === '--port' || a === '-p');
+  if (flagIdx !== -1 && args[flagIdx + 1] !== undefined) {
+    return { port: Number(args[flagIdx + 1]), explicit: true };
+  }
+  return { port: defaultPort, explicit: false };
+}
+
+/**
+ * Resolve a port for use by the dev/preview server.
+ *
+ * - explicit + taken  → print error, process.exit(1)
+ * - default + taken   → increment until free, print notice once
+ * - free              → return as-is
+ */
+export async function resolvePort(port: number, explicit: boolean): Promise<number> {
+  if (await probePort(port)) {
+    return port;
+  }
+
+  if (explicit) {
+    console.error(`[litro] Port ${port} is already in use. Choose a different port with --port.`);
+    process.exit(1);
+  }
+
+  // Auto-increment until we find a free port.
+  const original = port;
+  let candidate = port + 1;
+  while (!(await probePort(candidate))) {
+    candidate++;
+  }
+  console.log(`[litro] Port ${original} in use, using ${candidate}`);
+  return candidate;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   serialize-javascript: '>=7.0.3'
+  tar: '>=7.5.11'
 
 importers:
 
@@ -2687,8 +2688,8 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@7.5.10:
-    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -3508,7 +3509,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.7.4
-      tar: 7.5.10
+      tar: 7.5.11
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5753,7 +5754,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.10:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Summary

- Default port changes from 3030 → 3000
- `litro dev` and `litro preview` auto-increment when the default port is taken, printing `[litro] Port 3000 in use, using 3002` (skipping any occupied ports)
- Passing `--port`/`-p` explicitly errors out cleanly if that port is in use, rather than crashing with an opaque `EADDRINUSE` from Nitro
- Port probe uses `node:net` `createConnection` (connect-based) rather than `createServer().listen()` (bind-based) — Docker Desktop on macOS publishes ports through a userspace proxy that may not hold a conventional bound socket, so only a connection attempt reliably detects occupancy

## New files

- `packages/framework/src/cli/port.ts` — `parsePortArg` + `resolvePort` + `probePort`
- `packages/framework/src/cli/port.test.ts` — 12 tests covering all probe/parse/resolve scenarios

## Test plan

- [ ] `pnpm --filter @beatzball/litro test` — 194 tests pass
- [ ] Start a server on 3000: `node -e "require('net').createServer().listen(3000)"`, run `litro dev` → prints `[litro] Port 3000 in use, using 3001` and starts on 3001
- [ ] Run `litro dev --port 3000` with 3000 occupied → prints error and exits non-zero
- [ ] With Docker containers on 3000 and 3001, run `litro dev` → skips both, starts on 3002

🤖 Generated with [Claude Code](https://claude.com/claude-code)