### PR TITLE
fix: use pnpm v10 in docs deploy workflow

### DIFF
--- a/.changeset/fix-docs-workflow-pnpm-version.md
+++ b/.changeset/fix-docs-workflow-pnpm-version.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix docs deploy workflow using pnpm v10 to match the rest of CI

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- `docs.yml` was written with `pnpm/action-setup@v3` and `version: 9`, while `ci.yml` and `release.yml` both use `@v4` / `version: 10`
- pnpm v9 does not correctly set up workspace package bin symlinks the same way as v10, causing `litro: not found` when the docs build step runs

## Fix

```diff
- uses: pnpm/action-setup@v3
  with:
-   version: 9
+ uses: pnpm/action-setup@v4
  with:
+   version: 10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)