### PR TITLE
chore: add workflow_dispatch trigger to docs deploy workflow

### DIFF
--- a/.changeset/feat-docs-workflow-dispatch.md
+++ b/.changeset/feat-docs-workflow-dispatch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Allow docs deploy workflow to be triggered manually via workflow_dispatch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'docs/**'
       - 'packages/**'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to `docs.yml` so the deploy can be triggered manually from the GitHub Actions UI without needing a push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)