### PR TITLE
fix: invoke litro CLI via node in docs deploy workflow

### DIFF
--- a/.changeset/feat-docs-workflow-dispatch.md
+++ b/.changeset/feat-docs-workflow-dispatch.md
@@ -1,0 +1,4 @@
+---
+---
+
+Allow docs deploy workflow to be triggered manually via workflow_dispatch

--- a/.changeset/fix-docs-workflow-litro-bin.md
+++ b/.changeset/fix-docs-workflow-litro-bin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix docs deploy workflow invoking litro CLI directly via node to avoid pnpm bin resolution failure (dist/cli/index.js doesn't exist at install time)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,8 @@ jobs:
         run: pnpm --filter @beatzball/litro build
 
       - name: Build docs site
-        run: pnpm --filter @beatzball/litro-docs build
+        working-directory: docs
+        run: node ../packages/framework/dist/cli/index.js build
         env:
           LITRO_BASE_PATH: /litro
           SITE_URL: https://beatzball.github.io/litro

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'docs/**'
       - 'packages/**'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `pnpm --filter @beatzball/litro-docs build` calls `litro build` which relies on pnpm's bin wrapper at `docs/node_modules/.bin/litro`
- That wrapper is created during `pnpm install`, **before** `dist/cli/index.js` exists (it's built in a later step)
- Bypass pnpm bin resolution entirely by calling `node ../packages/framework/dist/cli/index.js build` from the `docs/` working directory
- The CLI uses `process.cwd()` for the app root, so running from `docs/` is correct — it resolves `docs/node_modules/.bin/vite` and `docs/node_modules/.bin/nitro` via its own PATH prepend logic

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and verify the "Build docs site" step succeeds
- [ ] Confirm `docs/dist/static/` is non-empty and deployed to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)