### PR TITLE
feat(docs): fire theme, homepage hero redesign, and syntax highlighting

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@beatzball/litro": "workspace:*",
     "@beatzball/litro-router": "workspace:*",
     "@shoelace-style/shoelace": "^2.19.0",
+    "highlight.js": "^11.10.0",
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",

--- a/docs/pages/blog/[slug].ts
+++ b/docs/pages/blog/[slug].ts
@@ -59,6 +59,7 @@ export const routeMeta = {
 
 @customElement('page-blog-slug')
 export class BlogPostPage extends LitroPage {
+
   override render() {
     const data = this.serverData as BlogPostData | null;
     if (!data?.post) return html`<p>Loading&hellip;</p>`;

--- a/docs/pages/blog/index.ts
+++ b/docs/pages/blog/index.ts
@@ -35,6 +35,7 @@ export const routeMeta = {
 
 @customElement('page-blog')
 export class BlogIndexPage extends LitroPage {
+
   override render() {
     const data = this.serverData as BlogIndexData | null;
     const { posts = [], siteTitle = 'Litro', nav = [] } = data ?? {};

--- a/docs/pages/blog/tags/[tag].ts
+++ b/docs/pages/blog/tags/[tag].ts
@@ -45,6 +45,7 @@ export const routeMeta = {
 
 @customElement('page-blog-tags-tag')
 export class TagPage extends LitroPage {
+
   override render() {
     const data = this.serverData as TagPageData | null;
     const { tag = '', posts = [], siteTitle = 'Litro', nav = [] } = data ?? {};

--- a/docs/pages/docs/[...slug].ts
+++ b/docs/pages/docs/[...slug].ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
@@ -8,6 +8,7 @@ import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
+import { applyHighlighting } from '../../src/highlight.js';
 import { starlightHead } from '../../src/route-meta.js';
 import { buildSeoHead } from '../../src/seo.js';
 
@@ -58,7 +59,9 @@ export const pageData = definePageData(async (event) => {
   // Strip the first <h1> from the HTML body — starlight-page renders the
   // page title from the frontmatter `title` field as its own styled <h1>.
   // Keeping the Markdown's leading # heading would produce duplicate <h1>s.
-  const body = addHeadingIds(doc.body).replace(/^<h1[^>]*>.*?<\/h1>\s*/is, '');
+  const body = applyHighlighting(
+    addHeadingIds(doc.body).replace(/^<h1[^>]*>.*?<\/h1>\s*/is, ''),
+  );
   const { prevDoc, nextDoc } = computePrevNext(siteConfig.sidebar, slug);
   const editUrl = siteConfig.editUrlBase
     ? `${siteConfig.editUrlBase}/content/docs/${slug}.md`
@@ -100,6 +103,78 @@ export const routeMeta = {
 
 @customElement('page-docs-slug')
 export class DocPage extends LitroPage {
+  /**
+   * Styles injected into page-docs-slug's shadow root so they reach the
+   * <div slot="content"> subtree. Global stylesheets (starlight.css,
+   * highlight.css) cannot pierce shadow DOM boundaries.
+   */
+  static override styles = css`
+    /* ── Typography for slotted doc content ─────────────────────────── */
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.5em; margin-bottom: 0.5em;
+      font-weight: 600; line-height: 1.25;
+      color: var(--sl-color-text);
+    }
+    h1 { font-size: var(--sl-text-4xl, 2.25rem); }
+    h2 { font-size: var(--sl-text-2xl, 1.5rem); border-bottom: 1px solid var(--sl-color-border, #e8e8e8); padding-bottom: 0.25em; }
+    h3 { font-size: var(--sl-text-xl, 1.25rem); }
+    h4 { font-size: var(--sl-text-lg, 1.125rem); }
+    p  { margin-top: 0; margin-bottom: 1rem; line-height: 1.7; }
+    a  { color: var(--sl-color-text-accent, var(--sl-color-accent)); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      font-family: var(--sl-font-mono, ui-monospace, monospace);
+      font-size: 0.875em;
+      background-color: var(--sl-color-bg-inline-code, #e8e8e8);
+      border: 1px solid var(--sl-color-border, #e8e8e8);
+      border-radius: 0.25rem;
+      padding: 0.15em 0.4em;
+    }
+    pre {
+      background-color: #0d0e11;
+      color: #e2e4e9;
+      border-radius: 0.375rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      margin: 1.5rem 0;
+      font-size: var(--sl-text-sm, 0.875rem);
+      line-height: 1.6;
+    }
+    pre code { background: none; border: none; padding: 0; font-size: inherit; }
+    ul, ol { padding-left: 1.5rem; margin: 0 0 1rem; }
+    li { margin-bottom: 0.25rem; line-height: 1.7; }
+    blockquote {
+      margin: 1.5rem 0; padding: 0.75rem 1rem;
+      border-left: 4px solid var(--sl-color-accent, #ea580c);
+      background-color: var(--sl-color-accent-low, #fff7ed);
+      border-radius: 0 0.375rem 0.375rem 0;
+    }
+    hr { border: none; border-top: 1px solid var(--sl-color-border, #e8e8e8); margin: 2rem 0; }
+    img { max-width: 100%; height: auto; }
+    table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: var(--sl-text-sm, 0.875rem); }
+    th, td { border: 1px solid var(--sl-color-border, #e8e8e8); padding: 0.5rem 0.75rem; text-align: left; }
+    th { background-color: var(--sl-color-gray-1, #f6f6f6); font-weight: 600; }
+
+    /* ── highlight.js fire theme ─────────────────────────────────────── */
+    pre:has(.hljs) { background-color: #0d0d10; color: #cbd5e1; }
+    .hljs { color: #cbd5e1; background: transparent; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-tag { color: #f97316; }
+    .hljs-string, .hljs-attr, .hljs-attribute { color: #38bdf8; }
+    .hljs-number, .hljs-literal { color: #fbbf24; }
+    .hljs-title, .hljs-title.class_, .hljs-title.function_, .hljs-built_in { color: #fb923c; }
+    .hljs-comment { color: #6b7280; font-style: italic; }
+    .hljs-variable, .hljs-params { color: #cbd5e1; }
+    .hljs-operator, .hljs-punctuation { color: #94a3b8; }
+    .hljs-meta, .hljs-meta .hljs-keyword { color: #38bdf8; }
+    .hljs-type { color: #fb923c; }
+    .hljs-deletion { color: #f87171; background: rgba(248,113,113,.1); }
+    .hljs-addition { color: #4ade80; background: rgba(74,222,128,.1); }
+    .hljs-section, .hljs-selector-class, .hljs-selector-id { color: #fb923c; }
+    .hljs-symbol, .hljs-bullet, .hljs-link { color: #38bdf8; }
+    .hljs-emphasis { font-style: italic; }
+    .hljs-strong { font-weight: bold; }
+  `;
+
   override render() {
     const data = this.serverData as DocPageData | null;
     if (!data?.doc) return html`<p>Loading&hellip;</p>`;

--- a/docs/pages/index.ts
+++ b/docs/pages/index.ts
@@ -90,30 +90,64 @@ export class SplashPage extends LitroPage {
           .nav="${nav}"
           currentPath="/"
         ></starlight-header>
-        <main style="
-          flex:1;
-          max-width:56rem;
-          margin:0 auto;
-          padding:4rem 1.5rem 3rem;
-          width:100%;
+
+        <section style="
+          position:relative;
+          text-align:center;
+          padding:5rem 1.5rem 5rem;
+          overflow:hidden;
+          background:
+            radial-gradient(ellipse 80% 50% at 50% -10%, color-mix(in srgb, var(--sl-color-accent) 18%, transparent), transparent),
+            var(--sl-color-bg);
         ">
-          <section style="text-align:center;margin-bottom:4rem;">
+          <!-- dot texture overlay -->
+          <div style="
+            position:absolute;
+            inset:0;
+            background-image:radial-gradient(circle, color-mix(in srgb, var(--sl-color-accent) 25%, transparent) 1px, transparent 1px);
+            background-size:20px 20px;
+            opacity:0.5;
+            pointer-events:none;
+          "></div>
+
+          <!-- pill badge -->
+          <div style="
+            position:relative;
+            display:inline-block;
+            margin-bottom:1.5rem;
+            padding:0.3rem 0.9rem;
+            border:1px solid color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+            border-radius:9999px;
+            font-size:var(--sl-text-sm);
+            font-weight:500;
+            color:var(--sl-color-accent);
+            background:color-mix(in srgb, var(--sl-color-accent) 8%, transparent);
+          ">Fullstack Web Framework</div>
+
+          <div style="position:relative;">
             <img
               src="/logo.png"
               alt="Litro logo"
-              style="width:7rem;height:7rem;object-fit:contain;margin-bottom:1rem;"
+              style="
+                width:7rem;height:7rem;object-fit:contain;
+                display:block;margin:0 auto 1.25rem;
+                filter:drop-shadow(0 0 24px color-mix(in srgb, var(--sl-color-accent) 60%, transparent));
+              "
             />
             <h1 style="
-              font-size:clamp(2rem,5vw,3.5rem);
+              font-size:clamp(2.5rem,6vw,4rem);
               font-weight:800;
-              color:var(--sl-color-text);
-              margin:0 0 1rem;
-              line-height:1.1;
+              margin:0 0 1.25rem;
+              line-height:1.05;
+              background:linear-gradient(135deg, var(--sl-color-accent) 0%, color-mix(in srgb, var(--sl-color-accent) 60%, #38bdf8) 100%);
+              -webkit-background-clip:text;
+              -webkit-text-fill-color:transparent;
+              background-clip:text;
             ">${siteTitle}</h1>
             ${description ? html`
               <p style="
                 font-size:var(--sl-text-xl);
-                color:var(--sl-color-gray-4);
+                color:var(--sl-color-gray-5);
                 max-width:36rem;
                 margin:0 auto 2.5rem;
                 line-height:1.6;
@@ -123,20 +157,26 @@ export class SplashPage extends LitroPage {
               <sl-button variant="primary" size="medium" href="/docs/introduction">Get Started</sl-button>
               <sl-button variant="default" size="medium" href="/blog">Blog</sl-button>
             </div>
-          </section>
+          </div>
+        </section>
 
-          <section>
-            <litro-card-grid>
-              ${features.map(f => html`
-                <litro-card
-                  icon="${f.icon ?? ''}"
-                  iconSrc="${f.iconSrc ?? ''}"
-                  title="${f.title}"
-                  description="${f.description}"
-                ></litro-card>
-              `)}
-            </litro-card-grid>
-          </section>
+        <main style="
+          flex:1;
+          max-width:56rem;
+          margin:0 auto;
+          padding:3rem 1.5rem 4rem;
+          width:100%;
+        ">
+          <litro-card-grid>
+            ${features.map(f => html`
+              <litro-card
+                icon="${f.icon ?? ''}"
+                iconSrc="${f.iconSrc ?? ''}"
+                title="${f.title}"
+                description="${f.description}"
+              ></litro-card>
+            `)}
+          </litro-card-grid>
         </main>
       </div>
     `;

--- a/docs/public/styles/highlight.css
+++ b/docs/public/styles/highlight.css
@@ -1,0 +1,108 @@
+/* highlight.js — fire theme (always dark background) */
+
+pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+.hljs {
+  color: #cbd5e1;
+  background: transparent;
+}
+
+/* Keywords: const, let, if, class, return … */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-tag {
+  color: #f97316;
+}
+
+/* Strings and attribute values */
+.hljs-string,
+.hljs-attr,
+.hljs-attribute {
+  color: #38bdf8;
+}
+
+/* Numbers and boolean literals */
+.hljs-number,
+.hljs-literal {
+  color: #fbbf24;
+}
+
+/* Function/class names, built-ins */
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.function_,
+.hljs-built_in {
+  color: #fb923c;
+}
+
+/* Comments */
+.hljs-comment {
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Variables and parameters */
+.hljs-variable,
+.hljs-params {
+  color: #cbd5e1;
+}
+
+/* Operators and punctuation */
+.hljs-operator,
+.hljs-punctuation {
+  color: #94a3b8;
+}
+
+/* Meta / imports / decorators */
+.hljs-meta,
+.hljs-meta .hljs-keyword {
+  color: #38bdf8;
+}
+
+/* Type annotations */
+.hljs-type {
+  color: #fb923c;
+}
+
+/* Diff deletions */
+.hljs-deletion {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.1);
+}
+
+/* Diff additions */
+.hljs-addition {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+}
+
+/* Section / selector */
+.hljs-section,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #fb923c;
+}
+
+/* Symbol / bullet */
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link {
+  color: #38bdf8;
+}
+
+/* Emphasis */
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/docs/public/styles/starlight.css
+++ b/docs/public/styles/starlight.css
@@ -5,17 +5,17 @@
 
 /* Shoelace color bridge — maps Shoelace's primary palette to Litro accent */
 :root {
-  --sl-color-primary-50: #f5f3ff;
-  --sl-color-primary-100: #ede9fe;
-  --sl-color-primary-200: #ddd6fe;
-  --sl-color-primary-300: #c4b5fd;
-  --sl-color-primary-400: #a78bfa;
-  --sl-color-primary-500: #8b5cf6;
-  --sl-color-primary-600: #7c3aed;
-  --sl-color-primary-700: #6d28d9;
-  --sl-color-primary-800: #5b21b6;
-  --sl-color-primary-900: #4c1d95;
-  --sl-color-primary-950: #2e1065;
+  --sl-color-primary-50: #fff7ed;
+  --sl-color-primary-100: #ffedd5;
+  --sl-color-primary-200: #fed7aa;
+  --sl-color-primary-300: #fdba74;
+  --sl-color-primary-400: #fb923c;
+  --sl-color-primary-500: #f97316;
+  --sl-color-primary-600: #ea580c;
+  --sl-color-primary-700: #c2410c;
+  --sl-color-primary-800: #9a3412;
+  --sl-color-primary-900: #7c2d12;
+  --sl-color-primary-950: #431407;
 }
 
 /* Starlight design tokens — light mode defaults */
@@ -29,13 +29,13 @@
   --sl-color-gray-5: #4b4b4b;
   --sl-color-gray-6: #2a2a2a;
 
-  --sl-color-accent: #7c3aed;
-  --sl-color-accent-high: #5b21b6;
-  --sl-color-accent-low: #ede9fe;
+  --sl-color-accent: #ea580c;
+  --sl-color-accent-high: #9a3412;
+  --sl-color-accent-low: #fff7ed;
 
-  --sl-color-note: #1d4ed8;
+  --sl-color-note: #0284c7;
   --sl-color-tip: #15803d;
-  --sl-color-caution: #b45309;
+  --sl-color-caution: #d97706;
   --sl-color-danger: #b91c1c;
 
   --sl-color-text: var(--sl-color-black);
@@ -89,11 +89,11 @@
   --sl-color-gray-5: #c0c1cb;
   --sl-color-gray-6: #e8e9f0;
 
-  --sl-color-accent: #a78bfa;
-  --sl-color-accent-high: #c4b5fd;
-  --sl-color-accent-low: #2e1b54;
+  --sl-color-accent: #fb923c;
+  --sl-color-accent-high: #fed7aa;
+  --sl-color-accent-low: #3a1e0a;
 
-  --sl-color-note: #60a5fa;
+  --sl-color-note: #38bdf8;
   --sl-color-tip: #4ade80;
   --sl-color-caution: #fbbf24;
   --sl-color-danger: #f87171;
@@ -114,8 +114,8 @@
   --sl-color-neutral-1000: hsl(0, 0%, 100%);
 
   /* Shoelace primary palette — dark mode (brighter accent for dark backgrounds) */
-  --sl-color-primary-600: #a78bfa;
-  --sl-color-primary-700: #8b5cf6;
+  --sl-color-primary-600: #fb923c;
+  --sl-color-primary-700: #f97316;
 }
 
 /* Base reset */

--- a/docs/src/highlight.ts
+++ b/docs/src/highlight.ts
@@ -1,0 +1,40 @@
+import hljs from 'highlight.js';
+
+const NAMED_ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+function decodeEntities(str: string): string {
+  return str.replace(/&#x[0-9a-fA-F]+;|&#[0-9]+;|&amp;|&lt;|&gt;|&quot;|&#39;/g, m => {
+    if (m.startsWith('&#x')) return String.fromCodePoint(parseInt(m.slice(3, -1), 16));
+    if (m.startsWith('&#'))  return String.fromCodePoint(parseInt(m.slice(2, -1), 10));
+    return NAMED_ENTITY_MAP[m]!;
+  });
+}
+
+/**
+ * Post-processes an HTML string, replacing every
+ * <pre><code class="language-*">…</code></pre>
+ * with a syntax-highlighted version produced by highlight.js.
+ *
+ * Must be called server-side only (SSG build time).
+ */
+export function applyHighlighting(html: string): string {
+  return html.replace(
+    /<pre><code class="language-([^"]+)">([\s\S]*?)<\/code><\/pre>/g,
+    (_match, lang: string, encoded: string) => {
+      const code = decodeEntities(encoded);
+      let highlighted: string;
+      try {
+        highlighted = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value;
+      } catch {
+        highlighted = hljs.highlightAuto(code).value;
+      }
+      return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+    },
+  );
+}

--- a/docs/src/route-meta.ts
+++ b/docs/src/route-meta.ts
@@ -11,6 +11,7 @@ export const starlightHead = [
   '<link rel="icon" type="image/png" href="/logo.png" />',
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
+  '<link rel="stylesheet" href="/styles/highlight.css" />',
   '<script>(function(){',
   'var s=localStorage.getItem("sl-theme");',
   'var t=s||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       h3:
         specifier: ^1.13.0
         version: 1.15.5
+      highlight.js:
+        specifier: ^11.10.0
+        version: 11.11.1
       lit:
         specifier: ^3.2.1
         version: 3.3.2
@@ -1813,6 +1816,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -4654,6 +4661,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
## Summary

- **Fire color theme** — replaces purple palette with orange/red accent (`#ea580c` light, `#fb923c` dark) and sky-blue note tokens throughout `starlight.css`
- **Homepage hero redesign** — radial-gradient glow, dot-pattern texture overlay, pill badge, gradient title, logo drop-shadow glow
- **Syntax highlighting** — server-side via `highlight.js` at SSG build time; custom fire-palette theme in `highlight.css`; shadow DOM fix ensures styles reach inside `page-docs-slug`'s shadow root via `DocPage.static styles`

## Key fixes discovered during implementation

- **Shadow DOM boundary** — `@lit-labs/ssr` always renders `LitElement` components with DSD, so global stylesheets can't pierce `page-docs-slug`'s shadow root. Fixed by moving highlight + typography CSS into `DocPage.static styles` (injected as `<style>` inside the shadow root by the SSR renderer).
- **Hex entity decoding** — `rehype-stringify` encodes `<` as `&#x3C;` in HTML code blocks. Extended `decodeEntities` to handle `&#x…;` and `&#…;` numeric entities.
- **Dark mode pre inversion** — `var(--sl-color-gray-6)` flips to a light color in dark mode. Fixed by using fixed `#0d0e11` for all untagged code blocks.

## Test plan

- [x] `pnpm --filter @beatzball/litro-docs build` — should complete with no errors
- [x] Homepage: gradient hero visible, orange accent throughout, pill badge present
- [x] `/docs/getting-started` or `/docs/configuration`: code blocks have colored tokens
- [x] Toggle dark mode: accent shifts to `#fb923c`, code blocks stay dark
- [x] HTML code blocks (if any): `<` renders correctly, not as `&#x3C;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)