### PR TITLE
feat(starlight): add code block syntax highlighting to starlight recipe

### DIFF
--- a/.changeset/starlight-code-highlighting.md
+++ b/.changeset/starlight-code-highlighting.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/create-litro": minor
+---
+
+Add syntax highlighting to the starlight recipe. Code blocks in Markdown docs are now automatically highlighted at SSG build time using `highlight.js` with the fire palette theme (dark background, orange keywords, sky-blue strings, amber numbers). The `DocPage` component includes `static override styles` with all `.hljs-*` token rules so highlighting works correctly inside the Lit shadow DOM.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ Verified working:
 - SSG plugin resolves `litro:content` via jiti alias so `generateRoutes()` can call content API
 - `LitroRouter` no longer intercepts plain `<a>` clicks — use `<litro-link>` for SPA navigation; plain `<a>` does full page reload
 - SSG navigation fix — `playground-11ty` pages use plain `<a>` tags so each navigation fetches fresh pre-rendered HTML with correct `__litro_data__`
-- `starlight` recipe — Astro Starlight-inspired docs+blog SSG site; `playground-starlight` workspace validates 11 prerendered routes
+- `starlight` recipe — Astro Starlight-inspired docs+blog SSG site; `playground-starlight` workspace validates 11 prerendered routes; syntax highlighting via `highlight.js` (fire theme, SSG build time, same as docs site)
 - Hash-only `popstate` events (TOC/fragment links) no longer re-render pages — `LitroRouter` guards on `_lastPathname`
 - Scroll-to-hash after mount — `LitroRouter` traverses shadow DOM via `_findDeep()` to reach heading `id` attributes inside shadow roots
 - `routeMeta.head` injected into HTML shell via `buildShell()` — required for stylesheet links and FOUC-prevention scripts to reach the browser

--- a/docs/content/docs/recipes/starlight.md
+++ b/docs/content/docs/recipes/starlight.md
@@ -62,6 +62,18 @@ export const siteConfig = {
 };
 ```
 
+## Syntax Highlighting
+
+Code blocks in Markdown are automatically syntax-highlighted at SSG build time using `highlight.js`. Fenced code blocks with a language tag are highlighted with the fire palette theme:
+
+````md
+```ts
+import { LitroPage } from '@beatzball/litro/runtime';
+```
+````
+
+The fire theme uses a dark background with orange keywords, sky-blue strings, and amber numbers — matching the overall Litro color palette. No client-side JavaScript is required; highlighting is baked into the prerendered HTML.
+
 ## Shoelace Integration
 
 The recipe includes Shoelace web components for enhanced UI elements (buttons, badges, copy buttons). Use Shoelace components directly in your Markdown via custom HTML, or in page components:

--- a/e2e/playground-starlight/pages.spec.ts
+++ b/e2e/playground-starlight/pages.spec.ts
@@ -60,6 +60,14 @@ test('blog post renders', async ({ page }) => {
   await expect(page.locator('page-blog-slug h1')).toContainText('Welcome');
 });
 
+test('docs page applies syntax highlighting to code blocks', async ({ page }) => {
+  await page.goto('/docs/getting-started');
+  await page.waitForSelector('page-docs-slug');
+  // applyHighlighting replaces language-* class with hljs class
+  const highlighted = page.locator('page-docs-slug code.hljs');
+  await expect(highlighted.first()).toBeVisible();
+});
+
 test('all prerendered routes return 200', async ({ request }) => {
   for (const route of PRERENDERED_ROUTES) {
     const response = await request.get(route);

--- a/packages/create-litro/recipes/starlight/template/package.json
+++ b/packages/create-litro/recipes/starlight/template/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@beatzball/litro": "latest",
     "@shoelace-style/shoelace": "^2.19.0",
+    "highlight.js": "^11.10.0",
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",

--- a/packages/create-litro/recipes/starlight/template/pages/docs/[slug].ts
+++ b/packages/create-litro/recipes/starlight/template/pages/docs/[slug].ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
@@ -8,6 +8,7 @@ import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
+import { applyHighlighting } from '../../src/highlight.js';
 import { starlightHead } from '../../src/route-meta.js';
 
 // Register components used in render()
@@ -55,7 +56,7 @@ export const pageData = definePageData(async (event) => {
   }
 
   const toc = extractHeadings(doc.rawBody);
-  const body = addHeadingIds(doc.body);
+  const body = applyHighlighting(addHeadingIds(doc.body));
   const { prevDoc, nextDoc } = computePrevNext(siteConfig.sidebar, slug);
   const editUrl = siteConfig.editUrlBase
     ? `${siteConfig.editUrlBase}/content/docs/${slug}.md`
@@ -89,6 +90,78 @@ export const routeMeta = {
 
 @customElement('page-docs-slug')
 export class DocPage extends LitroPage {
+  /**
+   * Styles injected into page-docs-slug's shadow root so they reach the
+   * <div slot="content"> subtree. Global stylesheets (starlight.css,
+   * highlight.css) cannot pierce shadow DOM boundaries.
+   */
+  static override styles = css`
+    /* ── Typography for slotted doc content ─────────────────────────── */
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.5em; margin-bottom: 0.5em;
+      font-weight: 600; line-height: 1.25;
+      color: var(--sl-color-text);
+    }
+    h1 { font-size: var(--sl-text-4xl, 2.25rem); }
+    h2 { font-size: var(--sl-text-2xl, 1.5rem); border-bottom: 1px solid var(--sl-color-border, #e8e8e8); padding-bottom: 0.25em; }
+    h3 { font-size: var(--sl-text-xl, 1.25rem); }
+    h4 { font-size: var(--sl-text-lg, 1.125rem); }
+    p  { margin-top: 0; margin-bottom: 1rem; line-height: 1.7; }
+    a  { color: var(--sl-color-text-accent, var(--sl-color-accent)); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      font-family: var(--sl-font-mono, ui-monospace, monospace);
+      font-size: 0.875em;
+      background-color: var(--sl-color-bg-inline-code, #e8e8e8);
+      border: 1px solid var(--sl-color-border, #e8e8e8);
+      border-radius: 0.25rem;
+      padding: 0.15em 0.4em;
+    }
+    pre {
+      background-color: #0d0e11;
+      color: #e2e4e9;
+      border-radius: 0.375rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      margin: 1.5rem 0;
+      font-size: var(--sl-text-sm, 0.875rem);
+      line-height: 1.6;
+    }
+    pre code { background: none; border: none; padding: 0; font-size: inherit; }
+    ul, ol { padding-left: 1.5rem; margin: 0 0 1rem; }
+    li { margin-bottom: 0.25rem; line-height: 1.7; }
+    blockquote {
+      margin: 1.5rem 0; padding: 0.75rem 1rem;
+      border-left: 4px solid var(--sl-color-accent, #ea580c);
+      background-color: var(--sl-color-accent-low, #fff7ed);
+      border-radius: 0 0.375rem 0.375rem 0;
+    }
+    hr { border: none; border-top: 1px solid var(--sl-color-border, #e8e8e8); margin: 2rem 0; }
+    img { max-width: 100%; height: auto; }
+    table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: var(--sl-text-sm, 0.875rem); }
+    th, td { border: 1px solid var(--sl-color-border, #e8e8e8); padding: 0.5rem 0.75rem; text-align: left; }
+    th { background-color: var(--sl-color-gray-1, #f6f6f6); font-weight: 600; }
+
+    /* ── highlight.js fire theme ─────────────────────────────────────── */
+    pre:has(.hljs) { background-color: #0d0d10; color: #cbd5e1; }
+    .hljs { color: #cbd5e1; background: transparent; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-tag { color: #f97316; }
+    .hljs-string, .hljs-attr, .hljs-attribute { color: #38bdf8; }
+    .hljs-number, .hljs-literal { color: #fbbf24; }
+    .hljs-title, .hljs-title.class_, .hljs-title.function_, .hljs-built_in { color: #fb923c; }
+    .hljs-comment { color: #6b7280; font-style: italic; }
+    .hljs-variable, .hljs-params { color: #cbd5e1; }
+    .hljs-operator, .hljs-punctuation { color: #94a3b8; }
+    .hljs-meta, .hljs-meta .hljs-keyword { color: #38bdf8; }
+    .hljs-type { color: #fb923c; }
+    .hljs-deletion { color: #f87171; background: rgba(248,113,113,.1); }
+    .hljs-addition { color: #4ade80; background: rgba(74,222,128,.1); }
+    .hljs-section, .hljs-selector-class, .hljs-selector-id { color: #fb923c; }
+    .hljs-symbol, .hljs-bullet, .hljs-link { color: #38bdf8; }
+    .hljs-emphasis { font-style: italic; }
+    .hljs-strong { font-weight: bold; }
+  `;
+
   override render() {
     const data = this.serverData as DocPageData | null;
     if (!data?.doc) return html`<p>Loading&hellip;</p>`;

--- a/packages/create-litro/recipes/starlight/template/public/styles/highlight.css
+++ b/packages/create-litro/recipes/starlight/template/public/styles/highlight.css
@@ -1,0 +1,108 @@
+/* highlight.js — fire theme (always dark background) */
+
+pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+.hljs {
+  color: #cbd5e1;
+  background: transparent;
+}
+
+/* Keywords: const, let, if, class, return … */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-tag {
+  color: #f97316;
+}
+
+/* Strings and attribute values */
+.hljs-string,
+.hljs-attr,
+.hljs-attribute {
+  color: #38bdf8;
+}
+
+/* Numbers and boolean literals */
+.hljs-number,
+.hljs-literal {
+  color: #fbbf24;
+}
+
+/* Function/class names, built-ins */
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.function_,
+.hljs-built_in {
+  color: #fb923c;
+}
+
+/* Comments */
+.hljs-comment {
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Variables and parameters */
+.hljs-variable,
+.hljs-params {
+  color: #cbd5e1;
+}
+
+/* Operators and punctuation */
+.hljs-operator,
+.hljs-punctuation {
+  color: #94a3b8;
+}
+
+/* Meta / imports / decorators */
+.hljs-meta,
+.hljs-meta .hljs-keyword {
+  color: #38bdf8;
+}
+
+/* Type annotations */
+.hljs-type {
+  color: #fb923c;
+}
+
+/* Diff deletions */
+.hljs-deletion {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.1);
+}
+
+/* Diff additions */
+.hljs-addition {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+}
+
+/* Section / selector */
+.hljs-section,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #fb923c;
+}
+
+/* Symbol / bullet */
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link {
+  color: #38bdf8;
+}
+
+/* Emphasis */
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/packages/create-litro/recipes/starlight/template/src/highlight.ts
+++ b/packages/create-litro/recipes/starlight/template/src/highlight.ts
@@ -1,0 +1,40 @@
+import hljs from 'highlight.js';
+
+const NAMED_ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+function decodeEntities(str: string): string {
+  return str.replace(/&#x[0-9a-fA-F]+;|&#[0-9]+;|&amp;|&lt;|&gt;|&quot;|&#39;/g, m => {
+    if (m.startsWith('&#x')) return String.fromCodePoint(parseInt(m.slice(3, -1), 16));
+    if (m.startsWith('&#'))  return String.fromCodePoint(parseInt(m.slice(2, -1), 10));
+    return NAMED_ENTITY_MAP[m]!;
+  });
+}
+
+/**
+ * Post-processes an HTML string, replacing every
+ * <pre><code class="language-*">…</code></pre>
+ * with a syntax-highlighted version produced by highlight.js.
+ *
+ * Must be called server-side only (SSG build time).
+ */
+export function applyHighlighting(html: string): string {
+  return html.replace(
+    /<pre><code class="language-([^"]+)">([\s\S]*?)<\/code><\/pre>/g,
+    (_match, lang: string, encoded: string) => {
+      const code = decodeEntities(encoded);
+      let highlighted: string;
+      try {
+        highlighted = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value;
+      } catch {
+        highlighted = hljs.highlightAuto(code).value;
+      }
+      return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+    },
+  );
+}

--- a/packages/create-litro/recipes/starlight/template/src/route-meta.ts
+++ b/packages/create-litro/recipes/starlight/template/src/route-meta.ts
@@ -10,6 +10,7 @@
 export const starlightHead = [
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
+  '<link rel="stylesheet" href="/styles/highlight.css" />',
   '<script>(function(){',
   'var s=localStorage.getItem("sl-theme");',
   'var t=s||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");',

--- a/playground-starlight/package.json
+++ b/playground-starlight/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@beatzball/litro": "workspace:*",
     "@shoelace-style/shoelace": "^2.19.0",
+    "highlight.js": "^11.10.0",
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",

--- a/playground-starlight/pages/docs/[slug].ts
+++ b/playground-starlight/pages/docs/[slug].ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
@@ -8,6 +8,7 @@ import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
+import { applyHighlighting } from '../../src/highlight.js';
 import { starlightHead } from '../../src/route-meta.js';
 
 // Register components used in render()
@@ -55,7 +56,7 @@ export const pageData = definePageData(async (event) => {
   }
 
   const toc = extractHeadings(doc.rawBody);
-  const body = addHeadingIds(doc.body);
+  const body = applyHighlighting(addHeadingIds(doc.body));
   const { prevDoc, nextDoc } = computePrevNext(siteConfig.sidebar, slug);
   const editUrl = siteConfig.editUrlBase
     ? `${siteConfig.editUrlBase}/content/docs/${slug}.md`
@@ -89,6 +90,78 @@ export const routeMeta = {
 
 @customElement('page-docs-slug')
 export class DocPage extends LitroPage {
+  /**
+   * Styles injected into page-docs-slug's shadow root so they reach the
+   * <div slot="content"> subtree. Global stylesheets (starlight.css,
+   * highlight.css) cannot pierce shadow DOM boundaries.
+   */
+  static override styles = css`
+    /* ── Typography for slotted doc content ─────────────────────────── */
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.5em; margin-bottom: 0.5em;
+      font-weight: 600; line-height: 1.25;
+      color: var(--sl-color-text);
+    }
+    h1 { font-size: var(--sl-text-4xl, 2.25rem); }
+    h2 { font-size: var(--sl-text-2xl, 1.5rem); border-bottom: 1px solid var(--sl-color-border, #e8e8e8); padding-bottom: 0.25em; }
+    h3 { font-size: var(--sl-text-xl, 1.25rem); }
+    h4 { font-size: var(--sl-text-lg, 1.125rem); }
+    p  { margin-top: 0; margin-bottom: 1rem; line-height: 1.7; }
+    a  { color: var(--sl-color-text-accent, var(--sl-color-accent)); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      font-family: var(--sl-font-mono, ui-monospace, monospace);
+      font-size: 0.875em;
+      background-color: var(--sl-color-bg-inline-code, #e8e8e8);
+      border: 1px solid var(--sl-color-border, #e8e8e8);
+      border-radius: 0.25rem;
+      padding: 0.15em 0.4em;
+    }
+    pre {
+      background-color: #0d0e11;
+      color: #e2e4e9;
+      border-radius: 0.375rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      margin: 1.5rem 0;
+      font-size: var(--sl-text-sm, 0.875rem);
+      line-height: 1.6;
+    }
+    pre code { background: none; border: none; padding: 0; font-size: inherit; }
+    ul, ol { padding-left: 1.5rem; margin: 0 0 1rem; }
+    li { margin-bottom: 0.25rem; line-height: 1.7; }
+    blockquote {
+      margin: 1.5rem 0; padding: 0.75rem 1rem;
+      border-left: 4px solid var(--sl-color-accent, #ea580c);
+      background-color: var(--sl-color-accent-low, #fff7ed);
+      border-radius: 0 0.375rem 0.375rem 0;
+    }
+    hr { border: none; border-top: 1px solid var(--sl-color-border, #e8e8e8); margin: 2rem 0; }
+    img { max-width: 100%; height: auto; }
+    table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: var(--sl-text-sm, 0.875rem); }
+    th, td { border: 1px solid var(--sl-color-border, #e8e8e8); padding: 0.5rem 0.75rem; text-align: left; }
+    th { background-color: var(--sl-color-gray-1, #f6f6f6); font-weight: 600; }
+
+    /* ── highlight.js fire theme ─────────────────────────────────────── */
+    pre:has(.hljs) { background-color: #0d0d10; color: #cbd5e1; }
+    .hljs { color: #cbd5e1; background: transparent; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-tag { color: #f97316; }
+    .hljs-string, .hljs-attr, .hljs-attribute { color: #38bdf8; }
+    .hljs-number, .hljs-literal { color: #fbbf24; }
+    .hljs-title, .hljs-title.class_, .hljs-title.function_, .hljs-built_in { color: #fb923c; }
+    .hljs-comment { color: #6b7280; font-style: italic; }
+    .hljs-variable, .hljs-params { color: #cbd5e1; }
+    .hljs-operator, .hljs-punctuation { color: #94a3b8; }
+    .hljs-meta, .hljs-meta .hljs-keyword { color: #38bdf8; }
+    .hljs-type { color: #fb923c; }
+    .hljs-deletion { color: #f87171; background: rgba(248,113,113,.1); }
+    .hljs-addition { color: #4ade80; background: rgba(74,222,128,.1); }
+    .hljs-section, .hljs-selector-class, .hljs-selector-id { color: #fb923c; }
+    .hljs-symbol, .hljs-bullet, .hljs-link { color: #38bdf8; }
+    .hljs-emphasis { font-style: italic; }
+    .hljs-strong { font-weight: bold; }
+  `;
+
   override render() {
     const data = this.serverData as DocPageData | null;
     if (!data?.doc) return html`<p>Loading&hellip;</p>`;

--- a/playground-starlight/public/styles/highlight.css
+++ b/playground-starlight/public/styles/highlight.css
@@ -1,0 +1,108 @@
+/* highlight.js — fire theme (always dark background) */
+
+pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+[data-theme="dark"] pre:has(.hljs) {
+  background-color: #0d0d10;
+  color: #cbd5e1;
+}
+
+.hljs {
+  color: #cbd5e1;
+  background: transparent;
+}
+
+/* Keywords: const, let, if, class, return … */
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-tag {
+  color: #f97316;
+}
+
+/* Strings and attribute values */
+.hljs-string,
+.hljs-attr,
+.hljs-attribute {
+  color: #38bdf8;
+}
+
+/* Numbers and boolean literals */
+.hljs-number,
+.hljs-literal {
+  color: #fbbf24;
+}
+
+/* Function/class names, built-ins */
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.function_,
+.hljs-built_in {
+  color: #fb923c;
+}
+
+/* Comments */
+.hljs-comment {
+  color: #6b7280;
+  font-style: italic;
+}
+
+/* Variables and parameters */
+.hljs-variable,
+.hljs-params {
+  color: #cbd5e1;
+}
+
+/* Operators and punctuation */
+.hljs-operator,
+.hljs-punctuation {
+  color: #94a3b8;
+}
+
+/* Meta / imports / decorators */
+.hljs-meta,
+.hljs-meta .hljs-keyword {
+  color: #38bdf8;
+}
+
+/* Type annotations */
+.hljs-type {
+  color: #fb923c;
+}
+
+/* Diff deletions */
+.hljs-deletion {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.1);
+}
+
+/* Diff additions */
+.hljs-addition {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+}
+
+/* Section / selector */
+.hljs-section,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #fb923c;
+}
+
+/* Symbol / bullet */
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link {
+  color: #38bdf8;
+}
+
+/* Emphasis */
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/playground-starlight/src/highlight.ts
+++ b/playground-starlight/src/highlight.ts
@@ -1,0 +1,40 @@
+import hljs from 'highlight.js';
+
+const NAMED_ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+
+function decodeEntities(str: string): string {
+  return str.replace(/&#x[0-9a-fA-F]+;|&#[0-9]+;|&amp;|&lt;|&gt;|&quot;|&#39;/g, m => {
+    if (m.startsWith('&#x')) return String.fromCodePoint(parseInt(m.slice(3, -1), 16));
+    if (m.startsWith('&#'))  return String.fromCodePoint(parseInt(m.slice(2, -1), 10));
+    return NAMED_ENTITY_MAP[m]!;
+  });
+}
+
+/**
+ * Post-processes an HTML string, replacing every
+ * <pre><code class="language-*">…</code></pre>
+ * with a syntax-highlighted version produced by highlight.js.
+ *
+ * Must be called server-side only (SSG build time).
+ */
+export function applyHighlighting(html: string): string {
+  return html.replace(
+    /<pre><code class="language-([^"]+)">([\s\S]*?)<\/code><\/pre>/g,
+    (_match, lang: string, encoded: string) => {
+      const code = decodeEntities(encoded);
+      let highlighted: string;
+      try {
+        highlighted = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value;
+      } catch {
+        highlighted = hljs.highlightAuto(code).value;
+      }
+      return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+    },
+  );
+}

--- a/playground-starlight/src/route-meta.ts
+++ b/playground-starlight/src/route-meta.ts
@@ -10,6 +10,7 @@
 export const starlightHead = [
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
+  '<link rel="stylesheet" href="/styles/highlight.css" />',
   '<script>(function(){',
   'var s=localStorage.getItem("sl-theme");',
   'var t=s||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       h3:
         specifier: ^1.13.0
         version: 1.15.5
+      highlight.js:
+        specifier: ^11.10.0
+        version: 11.11.1
       lit:
         specifier: ^3.2.1
         version: 3.3.2


### PR DESCRIPTION
## Summary

- Ports the `highlight.js` fire-palette theme from the docs site into the starlight recipe template and `playground-starlight`
- Fenced code blocks in Markdown docs are highlighted at SSG build time — no client-side JavaScript required
- `static override styles` on `DocPage` duplicates `.hljs-*` token rules so they work inside the Lit shadow DOM (global stylesheets cannot pierce it)

## Changes

- `src/highlight.ts` — `applyHighlighting()` function (identical to docs)
- `public/styles/highlight.css` — fire theme token rules
- `pages/docs/[slug].ts` — `applyHighlighting()` call + `static override styles` with typography and `.hljs-*` rules
- `src/route-meta.ts` — `highlight.css` linked in `starlightHead`
- `package.json` — `highlight.js ^11.10.0` added as dependency
- `e2e/playground-starlight/pages.spec.ts` — test asserting `code.hljs` is present on doc pages
- `docs/content/docs/recipes/starlight.md` — Syntax Highlighting section added

## Test plan

- [x] `pnpm test:e2e` passes (including new `pages.spec.ts` highlight test on port 3032)
- [x] `litro generate` in `playground-starlight` produces prerendered HTML with `class="hljs language-*"` on code blocks
- [x] Highlighted code renders with fire palette colors in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)