### PR TITLE
fix(docs): restrict umami tracking to production domains

### DIFF
--- a/docs/src/route-meta.ts
+++ b/docs/src/route-meta.ts
@@ -12,7 +12,7 @@ export const starlightHead = [
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
   '<link rel="stylesheet" href="/styles/highlight.css" />',
-  '<script defer src="https://umami.litro.dev/script.js" data-website-id="b76614a6-2fb4-4f8c-b279-0075a2d54067"></script>',
+  '<script defer src="https://umami.litro.dev/script.js" data-website-id="b76614a6-2fb4-4f8c-b279-0075a2d54067" data-domains="litro.dev,beatzball.github.io"></script>',
   "<script>(function(){",
   'var s=localStorage.getItem("sl-theme");',
   'var t=s||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");',


### PR DESCRIPTION
## Summary
- Adds `data-domains="litro.dev,beatzball.github.io"` to the umami script tag so analytics only fire on production domains
- Localhost (dev and preview) is automatically ignored by umami's client-side hostname check

🤖 Generated with [Claude Code](https://claude.com/claude-code)