### PR TITLE
fix(docs): move umami config to deploy-time env vars

### DIFF
--- a/docs/src/route-meta.ts
+++ b/docs/src/route-meta.ts
@@ -6,13 +6,22 @@
  *      the FOUC-prevention script so --sl-* tokens are available immediately.
  *   2. Inline script — synchronous, runs before first paint to set data-theme
  *      from localStorage, preventing a flash of the wrong theme on reload.
+ *
+ * Umami analytics: opt-in via env vars at deploy time.
+ *   UMAMI_WEBSITE_ID — required; if absent, no script is emitted
+ *   UMAMI_SRC        — script URL (default: https://cloud.umami.is/script.js)
+ *   UMAMI_DOMAINS    — data-domains allowlist (optional)
  */
+const umamiScript = process.env.UMAMI_WEBSITE_ID
+  ? `<script defer src="${process.env.UMAMI_SRC ?? 'https://cloud.umami.is/script.js'}" data-website-id="${process.env.UMAMI_WEBSITE_ID}"${process.env.UMAMI_DOMAINS ? ` data-domains="${process.env.UMAMI_DOMAINS}"` : ''}></script>`
+  : '';
+
 export const starlightHead = [
   '<link rel="icon" type="image/png" href="/logo.png" />',
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
   '<link rel="stylesheet" href="/styles/highlight.css" />',
-  '<script defer src="https://umami.litro.dev/script.js" data-website-id="b76614a6-2fb4-4f8c-b279-0075a2d54067" data-domains="litro.dev,beatzball.github.io"></script>',
+  umamiScript,
   "<script>(function(){",
   'var s=localStorage.getItem("sl-theme");',
   'var t=s||(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");',


### PR DESCRIPTION
## Summary
- Replace hardcoded umami tracking ID, script URL, and domain allowlist with `UMAMI_WEBSITE_ID`, `UMAMI_SRC`, and `UMAMI_DOMAINS` env vars
- No `<script>` tag is emitted when `UMAMI_WEBSITE_ID` is unset — dev, preview, and third-party forks get no tracking by default
- Configure the three vars in Coolify's build environment for the deployed site

## Env vars
| Variable | Purpose | Required |
|---|---|---|
| `UMAMI_WEBSITE_ID` | Tracking ID | Yes (absent = no script) |
| `UMAMI_SRC` | Script URL (default: `https://cloud.umami.is/script.js`) | No |
| `UMAMI_DOMAINS` | `data-domains` allowlist | No |

## Test plan
- [ ] Locally (no env vars set): `litro dev` or `litro preview` → view source, confirm no umami `<script>` tag
- [ ] In Coolify (with vars set): deployed HTML contains `<script defer src="..." data-website-id="...">` with correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)