### PR TITLE
feat(seo): SEO phase 1 — structured data, sitemap, RSS, blog posts, npm discovery

### DIFF
--- a/.changeset/seo-phase-1.md
+++ b/.changeset/seo-phase-1.md
@@ -1,0 +1,11 @@
+---
+"@beatzball/litro": minor
+"@beatzball/litro-router": patch
+"@beatzball/create-litro": patch
+---
+
+feat(seo): inject seoHead and seoTitle from pageData into HTML shell
+
+Pages can now return `seoHead` (a string of meta/JSON-LD tags) and `seoTitle` from `definePageData()`. The framework extracts these at request time and injects them into the actual `<head>` element of the HTML response — not buried in the `__litro_data__` JSON blob.
+
+Also improves npm discoverability: updated descriptions and keywords for all three packages, and rewrote the framework README with a Hello World example, comparison table, and SEO section.

--- a/.changeset/seo-phase-1.md
+++ b/.changeset/seo-phase-1.md
@@ -8,4 +8,6 @@ feat(seo): inject seoHead and seoTitle from pageData into HTML shell
 
 Pages can now return `seoHead` (a string of meta/JSON-LD tags) and `seoTitle` from `definePageData()`. The framework extracts these at request time and injects them into the actual `<head>` element of the HTML response — not buried in the `__litro_data__` JSON blob.
 
+Also bumps the `h3` dependency to `>=1.15.6` to patch CVE GHSA-22cc-p3c6-wpvm.
+
 Also improves npm discoverability: updated descriptions and keywords for all three packages, and rewrote the framework README with a Hello World example, comparison table, and SEO section.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -451,3 +451,23 @@ This rule is present in `starlight/template/public/styles/starlight.css`, `playg
 **`@customElement` name must match `fileToComponentTag` output**: The tag name is derived from the file's full path relative to `pages/`. For `pages/docs/packages/[pkg].ts` the segments are `['docs', 'packages', 'pkg']` → `page-docs-packages-pkg`. Using a shorter name (e.g. `page-docs-pkg`) silently produces a no-op — the router mounts the element by the derived tag and finds it unregistered.
 
 **Test coverage**: Unit tests for `extractHeadings`, `addHeadingIds`, and `renderMarkdown` live in `docs/src/__tests__/`. The docs site is added as a 4th Playwright project (`e2e/docs/packages.spec.ts`, port 3033) covering route 200-checks, element rendering, version badge, icon links, install block, and sidebar active state.
+
+---
+
+## SEO Phase 1: seoHead / seoTitle injection via pageData
+
+**Decision**: Pages return `seoHead` (HTML string of meta tags and JSON-LD) and optionally `seoTitle` from `definePageData()`. `create-page-handler.ts` extracts these at request time and passes them to `buildShell()` — injecting them into the actual `<head>` element of the HTML response.
+
+**Rationale**: Per-page SEO meta tags (description, OG, JSON-LD structured data) must be in the real `<head>` to be visible to crawlers. The previous pattern of returning them via `pageData` buried them inside the `<script type="application/json" id="__litro_data__">` blob, which search engines don't parse as metadata.
+
+**Implementation**: `create-page-handler.ts` checks `typeof d.seoHead === 'string'` and `typeof d.seoTitle === 'string'` after the data fetch. `dynamicHead` is concatenated with `routeMeta.head` (static head from the page component's `routeMeta` export) — static head comes first. `dynamicTitle` takes precedence over `routeMeta.title` via `dynamicTitle ?? routeMeta?.title`. An empty final string (`'' + '' === ''`, falsy) resolves to `undefined` so `buildShell` receives no head option rather than an empty string.
+
+---
+
+## SEO Phase 1: Dedicated Nitro server routes for sitemap.xml and RSS
+
+**Decision**: `docs/server/routes/sitemap.xml.ts` and `docs/server/routes/blog/rss.xml.ts` are implemented as dedicated Nitro server routes rather than Lit page components under `pages/`.
+
+**Rationale**: The catch-all `server/routes/[...].ts` handler wraps every route in an HTML shell via `createPageHandler`. A `pages/sitemap.xml.ts` would produce an HTML document (not valid XML) because it goes through the same handler. Nitro's specific route files (`server/routes/sitemap.xml.ts`) take priority over the catch-all, allowing the handlers to set `content-type: application/xml` and return raw XML strings directly. The same principle applies to the RSS feed.
+
+**Prerendering**: `/blog/rss.xml` is explicitly added to `prerender.routes` in `docs/nitro.config.ts` because `crawlLinks` does not follow `<link rel="alternate">` tags reliably. `/sitemap.xml` is discovered via `<link rel="sitemap">` in `starlightHead`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ A fullstack web framework for [Lit](https://lit.dev) components, powered by [Nit
 
 ---
 
+## How It Compares
+
+|                     | Litro       | Next.js     | Nuxt.js     |
+|---------------------|-------------|-------------|-------------|
+| Component model     | Lit         | React       | Vue         |
+| File-based routing  | ✓           | ✓           | ✓           |
+| SSR / SSG           | ✓           | ✓           | ✓           |
+| Server engine       | Nitro       | custom      | Nitro       |
+| Hello World JS      | ~8 kB       | ~90 kB      | ~60 kB      |
+| Virtual DOM         | —           | ✓           | ✓           |
+| W3C standard comps  | ✓           | —           | —           |
+
+[Full comparison →](https://litro.dev/compare/nextjs)
+
+---
+
 ## Monorepo structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A fullstack web framework for [Lit](https://lit.dev) components, powered by [Nit
 | Virtual DOM         | —           | ✓           | ✓           |
 | W3C standard comps  | ✓           | —           | —           |
 
+> **Note on Hello World JS figures**: these are approximate figures based on widely-cited community benchmarks and published framework documentation — they were not independently measured by this project. Lit's ~5 kB runtime size is documented on [lit.dev](https://lit.dev). The Next.js and Nuxt.js figures reflect commonly reported baseline JS payloads for a minimal page and vary by framework version and configuration.
+
 ---
 
 ## Monorepo structure

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ A fullstack web framework for [Lit](https://lit.dev) components, powered by [Nit
 | Virtual DOM         | —           | ✓           | ✓           |
 | W3C standard comps  | ✓           | —           | —           |
 
-[Full comparison →](https://litro.dev/compare/nextjs)
-
 ---
 
 ## Monorepo structure

--- a/docs/content/blog/shadow-dom-seo.md
+++ b/docs/content/blog/shadow-dom-seo.md
@@ -1,0 +1,102 @@
+---
+title: Shadow DOM and SEO — The Problem and Litro's Solution
+description: Web components have an SEO problem — content inside Shadow DOM is invisible to crawlers. Here's why that happens, why it matters less than you think, and how Litro eliminates the issue entirely with server-side Declarative Shadow DOM.
+date: 2026-02-01
+tags:
+  - blog
+  - seo
+  - web-components
+  - ssr
+---
+
+# Shadow DOM and SEO — The Problem and Litro's Solution
+
+Web components have a reputation for being bad for SEO. It comes up every time someone evaluates Lit, every time a team considers moving away from React. The concern is real — but it applies specifically to *client-side-only* web components. Litro's SSR model eliminates the problem entirely.
+
+Here's how.
+
+## Why Shadow DOM Creates an SEO Problem
+
+When you build a web component with Shadow DOM, the component's internal HTML is hidden from the document's main DOM until JavaScript runs and attaches it. Before that point, the element exists as an empty custom element tag — `<my-component></my-component>` — with no visible content.
+
+Search engine crawlers request your page, parse the HTML, and if they execute JavaScript at all, they do so asynchronously and with time limits. Googlebot is better at this than most crawlers, but it still has known delays of days to weeks before crawled JavaScript content is indexed. For Bing and most other crawlers, client-side rendering is a meaningful ranking disadvantage.
+
+The result for a client-rendered web component app:
+
+1. Crawler fetches `GET /`
+2. Gets back `<body><my-app></my-app></body>` — essentially empty
+3. Either skips indexing the content or queues JS execution for later
+4. Your text, headings, and links are invisible to the crawler
+
+For marketing pages, documentation, and blogs, this matters a lot.
+
+## The Standard Solution: Declarative Shadow DOM
+
+The WHATWG HTML specification addressed this with [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) (DSD) — a way to express shadow DOM structure directly in HTML, without JavaScript.
+
+Instead of:
+
+```html
+<my-component></my-component>
+```
+
+A server can render:
+
+```html
+<my-component>
+  <template shadowrootmode="open">
+    <h1>Hello from the server!</h1>
+    <p>This content is fully visible to crawlers.</p>
+  </template>
+</my-component>
+```
+
+The browser parses this natively — no JavaScript needed. The shadow DOM is attached before the first paint. Crawlers get real content. The approach is now Baseline (Chrome since 2021, Safari since March 2023, Firefox since October 2023), and the older attribute name `shadowroot` has been updated to `shadowrootmode`.
+
+## How `@lit-labs/ssr` Implements This
+
+Lit's SSR library renders Lit components to Declarative Shadow DOM on the server. Given:
+
+```typescript
+@customElement('my-component')
+class MyComponent extends LitElement {
+  override render() {
+    return html`<h1>Hello from the server!</h1>`;
+  }
+}
+```
+
+`@lit-labs/ssr` produces the DSD template string above. The client then *hydrates* — `@lit-labs/ssr-client` takes over the existing DOM rather than re-rendering it, eliminating the flicker and double-render you'd get with naive SSR.
+
+This is streaming, too. Nitro pipes the DSD output through Node.js streams directly to the response — the browser starts rendering before the full page has been generated.
+
+## What Litro Does
+
+Litro wires all of this together automatically:
+
+- Your page components extend `LitroPage` (a thin subclass of `LitElement`) and call `definePageData()` for server-side data fetching
+- The framework renders them server-side on every request via `@lit-labs/ssr`
+- The resulting DSD HTML is streamed to the browser
+- On the client, `@lit-labs/ssr-client` hydrates without re-rendering, and `LitroRouter` takes over for subsequent navigation
+
+What crawlers see when they request a Litro page is identical to what a user sees in a slow browser. Every heading, paragraph, link, and list item is in the HTML response.
+
+## The Static Site Generation Option
+
+For sites that don't need dynamic data — documentation, marketing pages, blogs — Litro also supports SSG (static site generation). During build, every route is prerendered to static HTML. The output is a directory of `.html` files you can deploy to a CDN, GitHub Pages, or any static host.
+
+The litro.dev documentation site you're reading right now is built this way. Every page is a static HTML file with fully-rendered content in the response body.
+
+## What About `<slot>` and Distributed Content?
+
+One subtlety: content passed into a component via `<slot>` sits in the *light* DOM (outside the shadow root) and is always visible to crawlers regardless of SSR. Only content generated *inside* the shadow root needs DSD to be crawler-visible. If your components receive their text content via slots, client-side-only rendering is less of a crawlability problem — though SSR still helps with above-the-fold render performance.
+
+## Summary
+
+The SEO concern with web components is real but specific: client-side-only rendering hides content from crawlers until JavaScript executes. Litro eliminates this by rendering to Declarative Shadow DOM on the server before the response is sent. Crawlers receive complete HTML. Users get a fast first paint. And after hydration, the app behaves as a full SPA with client-side navigation.
+
+You get the component model of the web platform, the deployment flexibility of Nitro, and no SEO compromises.
+
+```bash
+npm create @beatzball/litro@latest my-app
+```

--- a/docs/content/blog/shadow-dom-seo.md
+++ b/docs/content/blog/shadow-dom-seo.md
@@ -1,7 +1,7 @@
 ---
 title: Shadow DOM and SEO — The Problem and Litro's Solution
 description: Web components have an SEO problem — content inside Shadow DOM is invisible to crawlers. Here's why that happens, why it matters less than you think, and how Litro eliminates the issue entirely with server-side Declarative Shadow DOM.
-date: 2026-02-01
+date: 2026-03-10
 tags:
   - blog
   - seo

--- a/docs/content/blog/why-we-built-litro.md
+++ b/docs/content/blog/why-we-built-litro.md
@@ -1,0 +1,101 @@
+---
+title: Why We Built Litro — The Case for Standards-Based Development
+description: React and Vue solved real problems in 2013. But the web platform has caught up. Here's why we think web components, URLPattern, and Declarative Shadow DOM are the right foundation for a modern fullstack framework.
+date: 2026-02-15
+tags:
+  - blog
+  - announcement
+  - web-components
+---
+
+# Why We Built Litro — The Case for Standards-Based Development
+
+In 2013, React introduced a component model that reshaped how developers think about UI. Virtual DOM, JSX, one-way data flow — these were genuinely good ideas for the moment. The browser didn't offer much, and frameworks filled the gap.
+
+Twelve years later, browsers are different. The web platform has shipped component primitives, native routing APIs, and server-rendering specs that don't require a framework to use. We built Litro because we think it's time for the server framework to catch up.
+
+## What the Web Platform Actually Offers Now
+
+Three APIs define what's changed:
+
+**Custom Elements** — define reusable, encapsulated HTML elements with lifecycle hooks. Supported in all modern browsers since 2020 (Chrome since 2016, Safari since 2017, Firefox since 2018, Chromium Edge since 2020). Your components are standard HTML elements: they work in any framework, in vanilla HTML, in any environment that renders HTML and runs JavaScript.
+
+**Shadow DOM and Declarative Shadow DOM** — true style encapsulation without CSS Modules hacks. And with [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) (Baseline since 2023), the server can render shadow DOM directly into HTML — crawlers and browsers get the content before JavaScript runs.
+
+**URLPattern** — a native browser API for matching URL patterns, including named groups and wildcards. It's what `@beatzball/litro-router` is built on. No regex string parsing, no custom path-to-regexp, no external dependency.
+
+None of these existed in a usable, cross-browser form when React, Vue, and Angular were being designed. Frameworks built their own component systems, their own scoping, their own routing because they had to.
+
+## Why We Like Lit
+
+[Lit](https://lit.dev) is the Polymer team's distillation of a decade of web component experience into something minimal and practical. It adds two things to the native custom elements API that are genuinely worth having:
+
+1. **Reactive properties** — declarative re-rendering when data changes, powered by an efficient update lifecycle, without a virtual DOM
+2. **Tagged template literals** — `html\`<div>${value}</div>\`` syntax that's valid JavaScript, has good TypeScript support, and can be statically analyzed by the SSR renderer
+
+Everything else in a Lit component is standard DOM. `connectedCallback`, `disconnectedCallback`, `attributeChangedCallback` — these are the platform lifecycle methods. A Lit component's `render()` method produces real DOM, not a virtual representation.
+
+The SSR story for Lit is mature. `@lit-labs/ssr` renders Lit components to Declarative Shadow DOM. `@lit-labs/ssr-client` hydrates without re-rendering. The hydration model is the one the web standards bodies designed.
+
+## The Nitro Decision
+
+We could have written a custom server. Nuxt's team did — then they extracted it as [Nitro](https://nitro.unjs.io) and open-sourced it, because writing a production-ready server that deploys to Node.js, Cloudflare Workers, Vercel Edge, Netlify, Deno, and Bun is a significant amount of work.
+
+Nitro handles all of this:
+
+- File-based API routes via H3 event handlers
+- Deployment adapters for every major target
+- Server middleware, caching, static assets, SSG crawling
+- A plugin system with well-defined build lifecycle hooks
+
+Litro's server is Nitro. When you configure `NITRO_PRESET=cloudflare-workers` and run `litro build`, you get a Worker bundle. When you configure `LITRO_MODE=static`, you get a directory of prerendered HTML files. We don't maintain any of that deployment infrastructure — we benefit from the Nuxt ecosystem doing it.
+
+This also means Nitro improvements come to Litro automatically. New adapter? It works. Better build performance? We get it.
+
+## What Litro Actually Adds
+
+Given Lit (component model) and Nitro (server), what does the framework add?
+
+**File-based routing** — pages in `pages/index.ts` map to `/`, `pages/blog/[slug].ts` maps to `/blog/:slug`. A build-time scanner generates a virtual module with all routes; a single Nitro catch-all handler serves them.
+
+**SSR pipeline** — `@lit-labs/ssr` renders page components to streaming DSD HTML. `@lit-labs/ssr-client` + `LitroRouter` handle client hydration and subsequent navigation.
+
+**`definePageData()`** — a typed hook for server-side data fetching. The fetcher runs on the server, the result is serialized into the HTML shell, and on the first load `serverData` is populated from that JSON. On subsequent client-side navigations, `fetchData()` is called instead. No fetch waterfall, no loading state on the initial render.
+
+**`LitroRouter`** — a client-side router built on `URLPattern`. Zero dependencies, standalone (also published as `@beatzball/litro-router`), and aware of how `@lit-labs/ssr-client` handles hydration.
+
+**Content layer** — the `litro:content` virtual module provides a file-system Markdown API compatible with the 11ty data cascade format. Frontmatter, tags, sorted post lists, per-directory data inheritance.
+
+**Scaffolding** — `npm create @beatzball/litro` with three recipes: `fullstack` (SSR), `11ty-blog` (Markdown blog, SSG), and `starlight` (docs + blog site, SSG).
+
+## On Bundle Size
+
+A Litro hello-world page sends roughly 8 kB of JavaScript to the browser. Widely-cited figures for Next.js put the baseline JS payload at roughly 90 kB; for Nuxt, roughly 60 kB. These are approximations that vary with version and configuration, but the order-of-magnitude difference reflects a structural one.
+
+The difference comes from what each framework carries. React's runtime is inherently in the bundle. The virtual DOM reconciler, the fiber scheduler, the event delegation system, the concurrent mode infrastructure — all of it ships to every user. Lit's runtime is about 5 kB. The client router adds a little more. That's the ceiling.
+
+For most applications, runtime performance differences between React and Lit are not meaningful. But bundle size is felt by users on every page load, on every network. Smaller bundles mean faster time-to-interactive on real-world connections, lower data costs for users on metered plans, and better Core Web Vitals scores.
+
+## Standards Will Outlast Frameworks
+
+The web platform evolves slowly by design. When a capability is standardized and ships in all browsers, it tends to stay. Custom Elements are part of the HTML specification. Declarative Shadow DOM is in the HTML parser. URLPattern is a WHATWG standard.
+
+Framework component models, on the other hand, have a history of change. Angular 1 to Angular 2 was a rewrite. React's class components gave way to hooks. Ember, Backbone, Knockout — frameworks from the same era as React have been superseded or abandoned. The components you write for them don't transfer.
+
+A Lit web component written today is HTML. It will work in a browser ten years from now without an upgrade. It can be used from vanilla JavaScript, from Vue, from any system that can render a custom element tag.
+
+We're not claiming Litro will be permanent — every framework has a lifespan. But the components you write with it are durable in a way that framework-specific components are not.
+
+## Where We Are
+
+Litro is in early development. The core pipeline — SSR, client hydration, data fetching, file-based routing, content layer, SSG — is working and tested. The scaffolding creates real, runnable applications. The docs site you're reading is built with the starlight recipe and deployed as static HTML.
+
+What's not there yet: an ecosystem of third-party integrations, a large community, production case studies, and the accumulated polish that comes from years of user feedback. We're working on it.
+
+If you're building something where bundle size matters, where you want your components to be portable, or where you've been waiting for a server framework that treats web components as a first-class target — we'd like you to try it.
+
+```bash
+npm create @beatzball/litro@latest my-app
+```
+
+Documentation at [litro.dev](https://litro.dev). Source at [github.com/beatzball/litro](https://github.com/beatzball/litro).

--- a/docs/content/blog/why-we-built-litro.md
+++ b/docs/content/blog/why-we-built-litro.md
@@ -1,7 +1,7 @@
 ---
 title: Why We Built Litro — The Case for Standards-Based Development
 description: React and Vue solved real problems in 2013. But the web platform has caught up. Here's why we think web components, URLPattern, and Declarative Shadow DOM are the right foundation for a modern fullstack framework.
-date: 2026-02-15
+date: 2026-03-17
 tags:
   - blog
   - announcement

--- a/docs/content/blog/why-we-built-litro.md
+++ b/docs/content/blog/why-we-built-litro.md
@@ -70,7 +70,7 @@ Given Lit (component model) and Nitro (server), what does the framework add?
 
 ## On Bundle Size
 
-A Litro hello-world page sends roughly 8 kB of JavaScript to the browser. Widely-cited figures for Next.js put the baseline JS payload at roughly 90 kB; for Nuxt, roughly 60 kB. These are approximations that vary with version and configuration, but the order-of-magnitude difference reflects a structural one.
+A Litro hello-world page sends roughly 8 kB of JavaScript to the browser. Community benchmarks and published framework documentation commonly cite the baseline JS payload for Next.js at roughly 90 kB and for Nuxt at roughly 60 kB — we have not independently measured these figures, and they vary by framework version and configuration. Lit's ~5 kB runtime size is documented on [lit.dev](https://lit.dev). The order-of-magnitude difference nonetheless reflects something structural.
 
 The difference comes from what each framework carries. React's runtime is inherently in the bundle. The virtual DOM reconciler, the fiber scheduler, the event delegation system, the concurrent mode infrastructure — all of it ships to every user. Lit's runtime is about 5 kB. The client router adds a little more. That's the ceiling.
 

--- a/docs/nitro.config.ts
+++ b/docs/nitro.config.ts
@@ -7,9 +7,18 @@ import ssgPlugin from '@beatzball/litro/plugins/ssg';
 import contentPlugin from '@beatzball/litro/content/plugin';
 
 const basePath = process.env.LITRO_BASE_PATH ?? '';
+const ssg = ssgPreset();
 
 export default defineNitroConfig({
-  ...ssgPreset(),
+  ...ssg,
+  // Extend ssgPreset's prerender config to explicitly include XML routes.
+  // /sitemap.xml is also discovered via crawlLinks (<link rel="sitemap">),
+  // but /blog/rss.xml needs explicit registration since crawlLinks may not
+  // follow <link rel="alternate"> tags in all Nitro versions.
+  prerender: {
+    ...ssg.prerender,
+    routes: [...(ssg.prerender?.routes ?? []), '/blog/rss.xml'],
+  },
 
   srcDir: 'server',
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
-    "h3": "^1.13.0"
+    "h3": "^1.15.6"
   },
   "devDependencies": {
     "nitropack": "^2.13.1",

--- a/docs/pages/blog/[slug].ts
+++ b/docs/pages/blog/[slug].ts
@@ -9,6 +9,7 @@ import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
 import { starlightHead } from '../../src/route-meta.js';
+import { buildSeoHead, buildJsonLd } from '../../src/seo.js';
 import { formatDate, isoDate } from '../../src/date-utils.js';
 
 // Register components used in render()
@@ -20,6 +21,8 @@ export interface BlogPostData {
   toc: Array<{ depth: number; text: string; slug: string }>;
   siteTitle: string;
   nav: typeof siteConfig.nav;
+  seoHead: string;
+  seoTitle: string;
 }
 
 export const pageData = definePageData(async (event) => {
@@ -35,6 +38,24 @@ export const pageData = definePageData(async (event) => {
 
   const toc = extractHeadings(post.rawBody);
   const body = addHeadingIds(post.body);
+  const blogSlug = post.url.slice('/content/blog/'.length);
+  const postDescription = (post as Post & { description?: string }).description ?? '';
+  const seoTitle = `${post.title} — Litro Blog`;
+  const seoHead = buildSeoHead({
+    title: seoTitle,
+    description: postDescription,
+    path: `/blog/${blogSlug}`,
+    type: 'article',
+  }) + buildJsonLd({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": post.title,
+    "description": postDescription,
+    "datePublished": isoDate(post.date),
+    "url": `https://litro.dev/blog/${blogSlug}`,
+    "author": { "@type": "Organization", "name": "beatzball" },
+    "keywords": post.tags.join(', '),
+  });
 
   return {
     post,
@@ -42,6 +63,8 @@ export const pageData = definePageData(async (event) => {
     toc,
     siteTitle: siteConfig.title,
     nav: siteConfig.nav,
+    seoHead,
+    seoTitle,
   } satisfies BlogPostData;
 });
 

--- a/docs/pages/blog/index.ts
+++ b/docs/pages/blog/index.ts
@@ -6,6 +6,7 @@ import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { starlightHead } from '../../src/route-meta.js';
+import { buildSeoHead } from '../../src/seo.js';
 import { formatDate, isoDate } from '../../src/date-utils.js';
 
 // Register components used in render()
@@ -15,16 +16,24 @@ export interface BlogIndexData {
   posts: Post[];
   siteTitle: string;
   nav: typeof siteConfig.nav;
+  seoHead: string;
 }
 
 export const pageData = definePageData(async (_event) => {
   const all = await getPosts();
   // Filter to only blog posts (URL prefix from contentDir='content')
   const posts = all.filter(p => p.url.startsWith('/content/blog/'));
+  const seoHead = buildSeoHead({
+    title: 'Blog — Litro',
+    description: 'Technical articles on web components, SSR, standards-based development, and the Litro framework.',
+    path: '/blog',
+    type: 'website',
+  });
   return {
     posts,
     siteTitle: siteConfig.title,
     nav: siteConfig.nav,
+    seoHead,
   } satisfies BlogIndexData;
 });
 

--- a/docs/pages/blog/tags/[tag].ts
+++ b/docs/pages/blog/tags/[tag].ts
@@ -39,7 +39,7 @@ export async function generateRoutes(): Promise<string[]> {
 }
 
 export const routeMeta = {
-  head: starlightHead,
+  head: starlightHead + '<meta name="robots" content="noindex, follow" />',
   title: 'Tags — Litro',
 };
 

--- a/docs/pages/docs/[...slug].ts
+++ b/docs/pages/docs/[...slug].ts
@@ -10,7 +10,7 @@ import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
 import { applyHighlighting } from '../../src/highlight.js';
 import { starlightHead } from '../../src/route-meta.js';
-import { buildSeoHead } from '../../src/seo.js';
+import { buildSeoHead, buildJsonLd } from '../../src/seo.js';
 
 // Register components used in render()
 import '../../src/components/starlight-page.js';
@@ -27,6 +27,7 @@ export interface DocPageData {
   nav: typeof siteConfig.nav;
   editUrl: string | null;
   seoHead: string;
+  seoTitle: string;
 }
 
 function computePrevNext(
@@ -67,11 +68,21 @@ export const pageData = definePageData(async (event) => {
     ? `${siteConfig.editUrlBase}/content/docs/${slug}.md`
     : null;
 
+  const docDescription = (doc as Post & { description?: string }).description ?? siteConfig.description;
+  const seoTitle = `${doc.title} — Litro`;
   const seoHead = buildSeoHead({
-    title: `${doc.title} — Litro`,
-    description: (doc as Post & { description?: string }).description ?? siteConfig.description,
+    title: seoTitle,
+    description: docDescription,
     path: `/docs/${slug}`,
     type: 'article',
+  }) + buildJsonLd({
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": seoTitle,
+    "description": docDescription,
+    "url": `https://litro.dev/docs/${slug}`,
+    "author": { "@type": "Organization", "name": "beatzball" },
+    "isPartOf": { "@type": "WebSite", "name": "Litro Documentation", "url": "https://litro.dev" },
   });
 
   return {
@@ -86,6 +97,7 @@ export const pageData = definePageData(async (event) => {
     nav: siteConfig.nav,
     editUrl,
     seoHead,
+    seoTitle,
   } satisfies DocPageData;
 });
 

--- a/docs/pages/index.ts
+++ b/docs/pages/index.ts
@@ -5,7 +5,7 @@ import { definePageData } from "@beatzball/litro";
 import { getGlobalData } from "litro:content";
 import { siteConfig } from "../server/starlight.config.js";
 import { starlightHead } from "../src/route-meta.js";
-import { buildSeoHead } from "../src/seo.js";
+import { buildSeoHead, buildJsonLd } from "../src/seo.js";
 
 // Register components used in render()
 import "../src/components/starlight-header.js";
@@ -35,6 +35,19 @@ export const pageData = definePageData(async (_event) => {
     description,
     path: "/",
     type: "website",
+  }) + buildJsonLd({
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Litro",
+    "description": "A fullstack web framework combining Lit web components, Nitro server, and Vite. File-based routing, streaming SSR, SSG, and Declarative Shadow DOM.",
+    "url": "https://litro.dev",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Node.js",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "author": { "@type": "Organization", "name": "beatzball", "url": "https://github.com/beatzball" },
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "codeRepository": "https://github.com/beatzball/litro",
+    "programmingLanguage": ["TypeScript", "JavaScript"],
   });
 
   return {

--- a/docs/server/routes/blog/rss.xml.ts
+++ b/docs/server/routes/blog/rss.xml.ts
@@ -1,0 +1,53 @@
+import { defineEventHandler, setResponseHeader } from 'h3';
+import { getPosts } from 'litro:content';
+
+const SITE_URL = (process.env.SITE_URL ?? 'https://litro.dev').replace(/\/$/, '');
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'content-type', 'application/rss+xml; charset=utf-8');
+
+  const allPosts = await getPosts();
+  const blogPosts = allPosts
+    .filter(p => p.url.startsWith('/content/blog/'))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const items = blogPosts.map(post => {
+    const slug = post.url.slice('/content/blog/'.length);
+    const link = `${SITE_URL}/blog/${slug}`;
+    const pubDate = new Date(post.date).toUTCString();
+    const description = (post as typeof post & { description?: string }).description ?? '';
+    return `
+    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${pubDate}</pubDate>
+    </item>`;
+  });
+
+  const lastBuildDate = blogPosts.length > 0
+    ? new Date(blogPosts[0].date).toUTCString()
+    : new Date().toUTCString();
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Litro Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Technical articles on web components, SSR, and standards-based development from the Litro team.</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${SITE_URL}/blog/rss.xml" rel="self" type="application/rss+xml" />${items.join('')}
+  </channel>
+</rss>`;
+});

--- a/docs/server/routes/sitemap.xml.ts
+++ b/docs/server/routes/sitemap.xml.ts
@@ -1,0 +1,59 @@
+import { defineEventHandler, setResponseHeader } from 'h3';
+import { getPosts } from 'litro:content';
+
+const SITE_URL = (process.env.SITE_URL ?? 'https://litro.dev').replace(/\/$/, '');
+
+// Static routes that are always present. Blog posts are added dynamically.
+const STATIC_ROUTES: Array<{ path: string; priority: string }> = [
+  { path: '/', priority: '1.0' },
+  { path: '/blog', priority: '0.8' },
+  { path: '/docs/introduction', priority: '0.8' },
+  { path: '/docs/getting-started', priority: '0.8' },
+  { path: '/docs/configuration', priority: '0.8' },
+  { path: '/docs/core-concepts/routing', priority: '0.8' },
+  { path: '/docs/core-concepts/ssr', priority: '0.8' },
+  { path: '/docs/core-concepts/data-fetching', priority: '0.8' },
+  { path: '/docs/core-concepts/client-router', priority: '0.8' },
+  { path: '/docs/api-routes', priority: '0.8' },
+  { path: '/docs/content-layer', priority: '0.8' },
+  { path: '/docs/ssg', priority: '0.8' },
+  { path: '/docs/litro-router', priority: '0.8' },
+  { path: '/docs/recipes/fullstack', priority: '0.8' },
+  { path: '/docs/recipes/11ty-blog', priority: '0.8' },
+  { path: '/docs/recipes/starlight', priority: '0.8' },
+  { path: '/docs/deployment/github-pages', priority: '0.8' },
+  { path: '/docs/deployment/coolify', priority: '0.8' },
+  { path: '/docs/contributing', priority: '0.6' },
+  { path: '/docs/packages/litro', priority: '0.6' },
+  { path: '/docs/packages/litro-router', priority: '0.6' },
+  { path: '/docs/packages/create-litro', priority: '0.6' },
+];
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'content-type', 'application/xml; charset=utf-8');
+
+  const allPosts = await getPosts();
+  const blogPosts = allPosts.filter(p => p.url.startsWith('/content/blog/'));
+
+  const staticEntries = STATIC_ROUTES.map(({ path, priority }) => `
+  <url>
+    <loc>${SITE_URL}${path}</loc>
+    <changefreq>${path === '/' ? 'weekly' : 'monthly'}</changefreq>
+    <priority>${priority}</priority>
+  </url>`);
+
+  const blogEntries = blogPosts.map(post => {
+    const slug = post.url.slice('/content/blog/'.length);
+    const lastmod = post.date ? new Date(post.date).toISOString().slice(0, 10) : '';
+    return `
+  <url>
+    <loc>${SITE_URL}/blog/${slug}</loc>${lastmod ? `\n    <lastmod>${lastmod}</lastmod>` : ''}
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>`;
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${staticEntries.join('')}${blogEntries.join('')}
+</urlset>`;
+});

--- a/docs/src/__tests__/rss.test.ts
+++ b/docs/src/__tests__/rss.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for docs/server/routes/blog/rss.xml.ts
+ *
+ * The handler is a plain async function (defineEventHandler is mocked as a
+ * passthrough). litro:content is mocked so no real file system is needed.
+ *
+ * Run with: pnpm test:docs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Post } from '@beatzball/litro/content';
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before imports
+// ---------------------------------------------------------------------------
+
+vi.mock('litro:content', () => ({
+  getPosts: vi.fn(),
+}));
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: Function) => fn,
+  setResponseHeader: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import { getPosts } from 'litro:content';
+import { setResponseHeader } from 'h3';
+import handler from '../../server/routes/blog/rss.xml.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockEvent = {};
+
+function makePost(overrides: Partial<Post> & { url: string; title: string }): Post {
+  return {
+    slug: overrides.url.split('/').pop() ?? 'slug',
+    title: overrides.title,
+    date: new Date('2026-01-01'),
+    description: 'Default description.',
+    tags: [],
+    draft: false,
+    body: '',
+    rawBody: '',
+    frontmatter: {},
+    ...overrides,
+  };
+}
+
+async function getXml(): Promise<string> {
+  return (handler as (event: unknown) => Promise<string>)(mockEvent);
+}
+
+// Sample posts for ordering / multi-post tests (dates intentionally out of order).
+const samplePosts: Post[] = [
+  makePost({ url: '/content/blog/post-a', title: 'Post A', date: new Date('2026-03-01'), description: 'Desc A' }),
+  makePost({ url: '/content/blog/post-b', title: 'Post B', date: new Date('2026-01-15'), description: 'Desc B' }),
+  makePost({ url: '/content/blog/post-c', title: 'Post C', date: new Date('2026-02-10'), description: 'Desc C' }),
+];
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.mocked(getPosts).mockResolvedValue([]);
+  vi.mocked(setResponseHeader).mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Response headers
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — response headers', () => {
+  it('sets content-type to application/rss+xml; charset=utf-8', async () => {
+    await getXml();
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      mockEvent,
+      'content-type',
+      'application/rss+xml; charset=utf-8',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RSS structure
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — RSS structure', () => {
+  it('starts with an XML declaration', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+  });
+
+  it('contains <rss version="2.0">', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<rss version="2.0"');
+  });
+
+  it('closes with </rss>', async () => {
+    const xml = await getXml();
+    expect(xml.trimEnd().endsWith('</rss>')).toBe(true);
+  });
+
+  it('includes atom namespace declaration', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('xmlns:atom=');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel metadata
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — channel metadata', () => {
+  it('sets channel <title> to "Litro Blog"', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<title>Litro Blog</title>');
+  });
+
+  it('sets channel <link> to the blog URL', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<link>https://litro.dev/blog</link>');
+  });
+
+  it('includes a channel <description>', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<description>');
+  });
+
+  it('sets <language> to "en"', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<language>en</language>');
+  });
+
+  it('includes <lastBuildDate>', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<lastBuildDate>');
+  });
+
+  it('includes <atom:link> self-reference pointing to the RSS URL', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('href="https://litro.dev/blog/rss.xml"');
+    expect(xml).toContain('rel="self"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post items
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — post items', () => {
+  it('generates one <item> per blog post', async () => {
+    vi.mocked(getPosts).mockResolvedValue(samplePosts);
+    const xml = await getXml();
+    expect(xml.match(/<item>/g)).toHaveLength(3);
+  });
+
+  it('each item has a <title>', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain('<title>Post A</title>');
+  });
+
+  it('each item has a <link> to the blog post URL', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain('<link>https://litro.dev/blog/post-a</link>');
+  });
+
+  it('each item has a <guid isPermaLink="true"> matching the link', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://litro.dev/blog/post-a</guid>',
+    );
+  });
+
+  it('each item has a <pubDate>', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain('<pubDate>');
+  });
+
+  it('each item has a <description>', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain('<description>Desc A</description>');
+  });
+
+  it('strips /content/blog/ prefix for the post URL slug', async () => {
+    vi.mocked(getPosts).mockResolvedValue([samplePosts[0]]);
+    const xml = await getXml();
+    expect(xml).toContain('blog/post-a');
+    expect(xml).not.toContain('/content/blog/post-a');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sort order
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — sort order', () => {
+  it('posts are sorted newest-first', async () => {
+    vi.mocked(getPosts).mockResolvedValue(samplePosts);
+    const xml = await getXml();
+    // post-a (Mar 1) > post-c (Feb 10) > post-b (Jan 15)
+    const posA = xml.indexOf('blog/post-a');
+    const posC = xml.indexOf('blog/post-c');
+    const posB = xml.indexOf('blog/post-b');
+    expect(posA).toBeLessThan(posC);
+    expect(posC).toBeLessThan(posB);
+  });
+
+  it('lastBuildDate matches the most recent post date', async () => {
+    vi.mocked(getPosts).mockResolvedValue(samplePosts);
+    const xml = await getXml();
+    const match = xml.match(/<lastBuildDate>(.+?)<\/lastBuildDate>/);
+    expect(match).not.toBeNull();
+    // Most recent post is post-a: 2026-03-01
+    expect(new Date(match![1]).getTime()).toBe(new Date('2026-03-01').getTime());
+  });
+
+  it('lastBuildDate is still a valid date when there are no posts', async () => {
+    vi.mocked(getPosts).mockResolvedValue([]);
+    const xml = await getXml();
+    const match = xml.match(/<lastBuildDate>(.+?)<\/lastBuildDate>/);
+    expect(match).not.toBeNull();
+    expect(isNaN(new Date(match![1]).getTime())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// XML escaping
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — XML escaping in titles', () => {
+  it('escapes & as &amp; in post title', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: 'Lit & Web Components' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<title>Lit &amp; Web Components</title>');
+    expect(xml).not.toContain('<title>Lit & Web Components</title>');
+  });
+
+  it('escapes < and > as &lt; / &gt; in post title', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: '<Lit>' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<title>&lt;Lit&gt;</title>');
+  });
+});
+
+describe('rss.xml — XML escaping in descriptions', () => {
+  it('escapes & in description', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: 'T', description: 'A & B' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<description>A &amp; B</description>');
+  });
+
+  it('escapes < and > in description', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: 'T', description: '<b>bold</b>' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<description>&lt;b&gt;bold&lt;/b&gt;</description>');
+  });
+
+  it('escapes " as &quot; in description', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: 'T', description: 'Say "hello"' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('&quot;hello&quot;');
+  });
+
+  it("escapes ' as &apos; in description", async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/t', title: 'T', description: "it's fine" }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('it&apos;s fine');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe('rss.xml — non-blog post filtering', () => {
+  it('excludes posts that do not start with /content/blog/', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/real', title: 'Real Post' }),
+      makePost({ url: '/content/docs/page', title: 'Doc Page' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('blog/real');
+    expect(xml).not.toContain('/docs/page');
+    expect(xml.match(/<item>/g)).toHaveLength(1);
+  });
+});

--- a/docs/src/__tests__/seo.test.ts
+++ b/docs/src/__tests__/seo.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for docs/src/seo.ts — buildSeoHead() and buildJsonLd().
+ *
+ * Both functions are pure (no I/O, no DOM), so no mocking is needed.
+ * SITE_URL env var is not set in tests, so siteUrl defaults to 'https://litro.dev'.
+ *
+ * Run with: pnpm test:docs
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSeoHead, buildJsonLd } from '../seo.js';
+
+// ---------------------------------------------------------------------------
+// buildSeoHead
+// ---------------------------------------------------------------------------
+
+describe('buildSeoHead — meta description', () => {
+  it('includes a <meta name="description"> tag', () => {
+    const result = buildSeoHead({ title: 'Test', description: 'A test page.', path: '/test' });
+    expect(result).toContain('<meta name="description"');
+  });
+
+  it('embeds the description in the content attribute', () => {
+    const result = buildSeoHead({ title: 'Test', description: 'A test page.', path: '/test' });
+    expect(result).toContain('content="A test page."');
+  });
+});
+
+describe('buildSeoHead — canonical link', () => {
+  it('includes a <link rel="canonical"> tag', () => {
+    const result = buildSeoHead({ title: 'Test', description: 'Desc', path: '/about' });
+    expect(result).toContain('<link rel="canonical"');
+  });
+
+  it('canonical href is the full absolute URL', () => {
+    const result = buildSeoHead({ title: 'Test', description: 'Desc', path: '/about' });
+    expect(result).toContain('href="https://litro.dev/about"');
+  });
+});
+
+describe('buildSeoHead — Open Graph tags', () => {
+  const base = { title: 'My Page', description: 'Page description', path: '/page' };
+
+  it('includes og:title', () => {
+    expect(buildSeoHead(base)).toContain('<meta property="og:title" content="My Page" />');
+  });
+
+  it('includes og:description', () => {
+    expect(buildSeoHead(base)).toContain(
+      '<meta property="og:description" content="Page description" />',
+    );
+  });
+
+  it('defaults og:type to "website"', () => {
+    expect(buildSeoHead(base)).toContain('<meta property="og:type" content="website" />');
+  });
+
+  it('uses "article" og:type when specified', () => {
+    expect(buildSeoHead({ ...base, type: 'article' })).toContain(
+      '<meta property="og:type" content="article" />',
+    );
+  });
+
+  it('includes og:url as the full absolute URL', () => {
+    expect(buildSeoHead(base)).toContain(
+      '<meta property="og:url" content="https://litro.dev/page" />',
+    );
+  });
+
+  it('includes og:image', () => {
+    expect(buildSeoHead(base)).toContain('og:image');
+  });
+});
+
+describe('buildSeoHead — Twitter card tags', () => {
+  const base = { title: 'Blog Post', description: 'A blog post.', path: '/blog/post' };
+
+  it('includes twitter:card set to summary_large_image', () => {
+    expect(buildSeoHead(base)).toContain(
+      '<meta name="twitter:card" content="summary_large_image" />',
+    );
+  });
+
+  it('includes twitter:title', () => {
+    expect(buildSeoHead(base)).toContain('<meta name="twitter:title" content="Blog Post" />');
+  });
+
+  it('includes twitter:description', () => {
+    expect(buildSeoHead(base)).toContain(
+      '<meta name="twitter:description" content="A blog post." />',
+    );
+  });
+});
+
+describe('buildSeoHead — sitemap link', () => {
+  it('includes a link to /sitemap.xml', () => {
+    const result = buildSeoHead({ title: 'T', description: 'D', path: '/' });
+    expect(result).toContain(
+      '<link rel="sitemap" type="application/xml" href="/sitemap.xml" />',
+    );
+  });
+});
+
+describe('buildSeoHead — attribute escaping', () => {
+  it('escapes & in title', () => {
+    const result = buildSeoHead({ title: 'Lit & Friends', description: 'Desc', path: '/' });
+    expect(result).toContain('Lit &amp; Friends');
+    expect(result).not.toContain('Lit & Friends');
+  });
+
+  it('escapes " in description', () => {
+    const result = buildSeoHead({ title: 'T', description: 'Say "hello"', path: '/' });
+    expect(result).toContain('Say &quot;hello&quot;');
+  });
+
+  it('escapes < and > in description', () => {
+    const result = buildSeoHead({ title: 'T', description: '<b>bold</b>', path: '/' });
+    expect(result).toContain('&lt;b&gt;bold&lt;/b&gt;');
+  });
+
+  it('escapes & in description', () => {
+    const result = buildSeoHead({ title: 'T', description: 'A & B', path: '/' });
+    expect(result).toContain('A &amp; B');
+    expect(result).not.toContain('content="A & B"');
+  });
+});
+
+describe('buildSeoHead — return type', () => {
+  it('returns a string', () => {
+    const result = buildSeoHead({ title: 'T', description: 'D', path: '/' });
+    expect(typeof result).toBe('string');
+  });
+
+  it('returns a non-empty string', () => {
+    const result = buildSeoHead({ title: 'T', description: 'D', path: '/' });
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildJsonLd
+// ---------------------------------------------------------------------------
+
+describe('buildJsonLd — output structure', () => {
+  it('returns a <script type="application/ld+json"> tag', () => {
+    const result = buildJsonLd({ '@type': 'SoftwareApplication' });
+    expect(result).toMatch(/^<script type="application\/ld\+json">/);
+    expect(result).toMatch(/<\/script>$/);
+  });
+
+  it('embeds the JSON-stringified data inside the script tag', () => {
+    const data = { '@context': 'https://schema.org', '@type': 'BlogPosting', headline: 'Test' };
+    const result = buildJsonLd(data);
+    expect(result).toContain(JSON.stringify(data));
+  });
+
+  it('the embedded JSON is parseable', () => {
+    const data = { name: 'Litro', version: '0.2.0', active: true };
+    const result = buildJsonLd(data);
+    const json = result
+      .replace('<script type="application/ld+json">', '')
+      .replace('</script>', '');
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(JSON.parse(json)).toEqual(data);
+  });
+});
+
+describe('buildJsonLd — data types', () => {
+  it('handles nested objects', () => {
+    const data = { author: { '@type': 'Organization', name: 'beatzball' } };
+    const result = buildJsonLd(data);
+    expect(result).toContain('"beatzball"');
+    expect(result).toContain('"author"');
+  });
+
+  it('handles arrays', () => {
+    const data = { programmingLanguage: ['TypeScript', 'JavaScript'] };
+    const result = buildJsonLd(data);
+    expect(result).toContain('["TypeScript","JavaScript"]');
+  });
+
+  it('handles numeric values', () => {
+    const data = { offers: { price: 0 } };
+    const result = buildJsonLd(data);
+    expect(result).toContain('"price":0');
+  });
+
+  it('handles an empty object', () => {
+    const result = buildJsonLd({});
+    expect(result).toBe('<script type="application/ld+json">{}</script>');
+  });
+});
+
+describe('buildJsonLd — SoftwareApplication schema (integration)', () => {
+  it('produces a valid structured data script for a SoftwareApplication', () => {
+    const data = {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'Litro',
+      applicationCategory: 'DeveloperApplication',
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    };
+    const result = buildJsonLd(data);
+    expect(result).toContain('"@type":"SoftwareApplication"');
+    expect(result).toContain('"applicationCategory":"DeveloperApplication"');
+    expect(result).toContain('"price":"0"');
+  });
+});

--- a/docs/src/__tests__/sitemap.test.ts
+++ b/docs/src/__tests__/sitemap.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for docs/server/routes/sitemap.xml.ts
+ *
+ * The handler is a plain async function (defineEventHandler is mocked as a
+ * passthrough). litro:content is mocked so no real file system is needed.
+ *
+ * Run with: pnpm test:docs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Post } from '@beatzball/litro/content';
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before imports
+// ---------------------------------------------------------------------------
+
+vi.mock('litro:content', () => ({
+  getPosts: vi.fn(),
+}));
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: Function) => fn,
+  setResponseHeader: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import { getPosts } from 'litro:content';
+import { setResponseHeader } from 'h3';
+import handler from '../../server/routes/sitemap.xml.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockEvent = {};
+
+function makePost(overrides: Partial<Post> & { url: string }): Post {
+  return {
+    slug: overrides.url.split('/').pop() ?? 'slug',
+    title: 'Test Post',
+    date: new Date('2026-01-01'),
+    description: 'A test post.',
+    tags: [],
+    draft: false,
+    body: '',
+    rawBody: '',
+    frontmatter: {},
+    ...overrides,
+  };
+}
+
+async function getXml(): Promise<string> {
+  return (handler as (event: unknown) => Promise<string>)(mockEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.mocked(getPosts).mockResolvedValue([]);
+  vi.mocked(setResponseHeader).mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Response headers
+// ---------------------------------------------------------------------------
+
+describe('sitemap.xml — response headers', () => {
+  it('sets content-type to application/xml; charset=utf-8', async () => {
+    await getXml();
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      mockEvent,
+      'content-type',
+      'application/xml; charset=utf-8',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// XML structure
+// ---------------------------------------------------------------------------
+
+describe('sitemap.xml — XML structure', () => {
+  it('starts with an XML declaration', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+  });
+
+  it('wraps entries in <urlset> with the sitemap namespace', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('</urlset>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Static routes
+// ---------------------------------------------------------------------------
+
+describe('sitemap.xml — static routes', () => {
+  it('includes the homepage', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<loc>https://litro.dev/</loc>');
+  });
+
+  it('includes the /blog route', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<loc>https://litro.dev/blog</loc>');
+  });
+
+  it('includes /docs/introduction', async () => {
+    const xml = await getXml();
+    expect(xml).toContain('<loc>https://litro.dev/docs/introduction</loc>');
+  });
+
+  it('gives the homepage priority 1.0', async () => {
+    const xml = await getXml();
+    // Find the homepage entry and check its priority
+    const homepageEntry = xml.slice(xml.indexOf('<loc>https://litro.dev/</loc>'));
+    const priorityMatch = homepageEntry.match(/<priority>([^<]+)<\/priority>/);
+    expect(priorityMatch?.[1]).toBe('1.0');
+  });
+
+  it('gives the homepage changefreq "weekly"', async () => {
+    const xml = await getXml();
+    const homepageEntry = xml.slice(xml.indexOf('<loc>https://litro.dev/</loc>'));
+    expect(homepageEntry).toContain('<changefreq>weekly</changefreq>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blog post entries
+// ---------------------------------------------------------------------------
+
+describe('sitemap.xml — blog post entries', () => {
+  it('includes <loc> for each blog post', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/hello-world' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<loc>https://litro.dev/blog/hello-world</loc>');
+  });
+
+  it('strips the /content/blog/ prefix to derive the blog slug', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/shadow-dom-seo' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('/blog/shadow-dom-seo');
+    expect(xml).not.toContain('/content/blog/shadow-dom-seo');
+  });
+
+  it('includes <lastmod> formatted as YYYY-MM-DD', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/dated-post', date: new Date('2026-03-15') }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('<lastmod>2026-03-15</lastmod>');
+  });
+
+  it('gives blog posts priority 0.7', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/post' }),
+    ]);
+    const xml = await getXml();
+    const postEntry = xml.slice(xml.indexOf('/blog/post'));
+    expect(postEntry).toContain('<priority>0.7</priority>');
+  });
+
+  it('gives blog posts changefreq "monthly"', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/post' }),
+    ]);
+    const xml = await getXml();
+    const postEntry = xml.slice(xml.indexOf('/blog/post'));
+    expect(postEntry).toContain('<changefreq>monthly</changefreq>');
+  });
+
+  it('includes multiple blog posts', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/post-one' }),
+      makePost({ url: '/content/blog/post-two' }),
+      makePost({ url: '/content/blog/post-three' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('/blog/post-one');
+    expect(xml).toContain('/blog/post-two');
+    expect(xml).toContain('/blog/post-three');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+describe('sitemap.xml — non-blog post filtering', () => {
+  it('excludes posts that do not start with /content/blog/', async () => {
+    vi.mocked(getPosts).mockResolvedValue([
+      makePost({ url: '/content/blog/real-post' }),
+      makePost({ url: '/content/docs/some-page', title: 'Doc Page' }),
+    ]);
+    const xml = await getXml();
+    expect(xml).toContain('/blog/real-post');
+    expect(xml).not.toContain('/content/docs/some-page');
+    expect(xml).not.toContain('some-page');
+  });
+});

--- a/docs/src/route-meta.ts
+++ b/docs/src/route-meta.ts
@@ -18,6 +18,7 @@ const umamiScript = process.env.UMAMI_WEBSITE_ID
 
 export const starlightHead = [
   '<link rel="icon" type="image/png" href="/logo.png" />',
+  '<link rel="alternate" type="application/rss+xml" title="Litro Blog" href="/blog/rss.xml" />',
   '<link rel="stylesheet" href="/shoelace/themes/light.css" />',
   '<link rel="stylesheet" href="/styles/starlight.css" />',
   '<link rel="stylesheet" href="/styles/highlight.css" />',

--- a/docs/src/seo.ts
+++ b/docs/src/seo.ts
@@ -26,6 +26,10 @@ export function buildSeoHead(options: SeoOptions): string {
   ].join('\n');
 }
 
+export function buildJsonLd(data: object): string {
+  return `<script type="application/ld+json">${JSON.stringify(data)}</script>`;
+}
+
 function escapeAttr(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/packages/create-litro/package.json
+++ b/packages/create-litro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beatzball/create-litro",
   "version": "0.4.0",
-  "description": "Create a new Litro app",
+  "description": "Scaffold a new Litro app — fullstack SSR, Markdown blog, or docs site. Built on Lit web components and Nitro server.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,6 +20,20 @@
     "dev": "tsc -p tsconfig.json --watch",
     "test": "vitest run"
   },
+  "keywords": [
+    "create",
+    "scaffold",
+    "cli",
+    "lit",
+    "web-components",
+    "fullstack",
+    "ssr",
+    "ssg",
+    "nitro",
+    "starter",
+    "template",
+    "typescript"
+  ],
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.7.3",

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -58,8 +58,6 @@ export default class IndexPage extends LitroPage {
 | Virtual DOM         | —           | ✓           | ✓           |
 | W3C standard comps  | ✓           | —           | —           |
 
-[Full comparison →](https://litro.dev/compare/nextjs)
-
 ---
 
 ## SEO

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -58,6 +58,8 @@ export default class IndexPage extends LitroPage {
 | Virtual DOM         | —           | ✓           | ✓           |
 | W3C standard comps  | ✓           | —           | —           |
 
+> **Note on Hello World JS figures**: approximate figures based on widely-cited community benchmarks and published framework documentation — not independently measured by this project. Lit's ~5 kB runtime size is documented on [lit.dev](https://lit.dev). Next.js and Nuxt.js figures reflect commonly reported baseline JS payloads for a minimal page and vary by framework version and configuration.
+
 ---
 
 ## SEO

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -13,21 +13,69 @@ A fullstack web framework for [Lit](https://lit.dev) components, powered by [Nit
 
 ---
 
-## Documentation
-
-Full documentation, quick start, and API reference are in the [repository README](https://github.com/beatzball/litro#readme).
-
----
-
 ## Quick start
 
 ```bash
-# Scaffold a new app (once published to npm)
 npm create @beatzball/litro@latest my-app
 cd my-app
 npm install
 npm run dev
 ```
+
+---
+
+## Hello World
+
+```typescript
+// pages/index.ts
+import { LitroPage, definePageData, html } from '@beatzball/litro/runtime';
+import { customElement } from 'lit/decorators.js';
+
+const pageData = definePageData(async () => ({
+  message: 'Hello from the server!',
+}));
+
+@customElement('page-index')
+export default class IndexPage extends LitroPage {
+  override render() {
+    const data = this.serverData as typeof pageData | null;
+    return html`<h1>${data?.message}</h1>`;
+  }
+}
+```
+
+---
+
+## How It Compares
+
+|                     | Litro       | Next.js     | Nuxt.js     |
+|---------------------|-------------|-------------|-------------|
+| Component model     | Lit         | React       | Vue         |
+| File-based routing  | ✓           | ✓           | ✓           |
+| SSR / SSG           | ✓           | ✓           | ✓           |
+| Server engine       | Nitro       | custom      | Nitro       |
+| Hello World JS      | ~8kB        | ~90kB       | ~60kB       |
+| Virtual DOM         | —           | ✓           | ✓           |
+| W3C standard comps  | ✓           | —           | —           |
+
+[Full comparison →](https://litro.dev/compare/nextjs)
+
+---
+
+## SEO
+
+Litro renders all pages server-side via Declarative Shadow DOM before sending HTML to the
+browser. Search engines receive fully-rendered content — the same approach used by Next.js
+and Nuxt.js. Client-side-only web components have SEO limitations; Litro's SSR eliminates
+them by default.
+
+[How this works →](https://litro.dev/docs/core-concepts/ssr)
+
+---
+
+## Documentation
+
+Full documentation at [litro.dev](https://litro.dev).
 
 ---
 

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beatzball/litro",
   "version": "0.2.0",
-  "description": "Litro — fullstack Lit framework powered by Nitro",
+  "description": "Fullstack web framework for Lit components — file-based routing, streaming SSR, SSG, and Nitro deployment adapters. A standards-based Next.js / Nuxt.js alternative.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -116,6 +116,23 @@
     "vitest": "^2.1.8",
     "jsdom": "^25.0.0"
   },
+  "keywords": [
+    "lit",
+    "web-components",
+    "ssr",
+    "ssg",
+    "static-site-generation",
+    "server-side-rendering",
+    "fullstack",
+    "framework",
+    "nitro",
+    "vite",
+    "file-based-routing",
+    "declarative-shadow-dom",
+    "nextjs-alternative",
+    "nuxt-alternative",
+    "typescript"
+  ],
   "peerDependencies": {
     "typescript": "^5.x"
   }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -96,7 +96,7 @@
     "@beatzball/litro-router": "workspace:*",
     "execa": "^8.0.1",
     "nitropack": "^2.13.1",
-    "h3": "^1.13.0",
+    "h3": "^1.15.6",
     "vite": "^5.4.11",
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",

--- a/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
+++ b/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for createPageHandler() — specifically the seoHead / seoTitle
+ * extraction from pageData and injection into the HTML shell.
+ *
+ * Heavy dependencies (@lit-labs/ssr, H3 streams, Lit) are mocked so the test
+ * runs in a plain Node environment without a browser or Nitro server.
+ *
+ * Run with: pnpm --filter @beatzball/litro test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports of the modules under test.
+// Vitest hoists vi.mock() calls to the top of the file automatically.
+// ---------------------------------------------------------------------------
+
+vi.mock('../shell.js', () => ({
+  buildShell: vi.fn().mockReturnValue({ head: '', foot: '' }),
+}));
+
+vi.mock('../ssr.js', () => ({
+  renderToStream: vi.fn().mockReturnValue(
+    (async function* () {
+      // empty stream
+    })(),
+  ),
+}));
+
+vi.mock('@lit-labs/ssr/lib/render-result-readable.js', async () => {
+  const { PassThrough } = await import('node:stream');
+  return {
+    RenderResultReadable: class MockRenderResultReadable extends PassThrough {
+      constructor(_iterable: AsyncIterable<string>) {
+        super();
+        // End the stream after the current tick so pipe() can be set up first.
+        process.nextTick(() => this.end());
+      }
+    },
+  };
+});
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: Function) => fn,
+  setResponseHeader: vi.fn(),
+  sendStream: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('lit/static-html.js', () => ({
+  html: vi.fn().mockReturnValue({}),
+  unsafeStatic: vi.fn().mockReturnValue('mock-tag'),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — resolved after mocks are registered
+// ---------------------------------------------------------------------------
+
+import { buildShell } from '../shell.js';
+import { createPageHandler } from '../create-page-handler.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRoute(tag = 'page-test') {
+  return { filePath: '/fake/page.ts', componentTag: tag, path: '/', pattern: '/' };
+}
+
+function makePageData(fetcher: (event: unknown) => Promise<unknown>) {
+  return { __litroPageData: true as const, fetcher };
+}
+
+// Call the handler with a minimal fake H3 event.
+async function callHandler(handler: unknown): Promise<void> {
+  await (handler as (event: unknown) => Promise<void>)({});
+}
+
+// Return the options object passed to buildShell in the last call.
+function lastBuildShellOpts(): Parameters<typeof buildShell>[2] {
+  const calls = vi.mocked(buildShell).mock.calls;
+  return calls[calls.length - 1]?.[2];
+}
+
+// ---------------------------------------------------------------------------
+// seoHead injection
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — seoHead from pageData', () => {
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+  });
+
+  it('passes seoHead string to buildShell as head option', async () => {
+    const seoHead = '<meta name="description" content="Test page" />';
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ seoHead })) },
+    });
+
+    await callHandler(handler);
+
+    expect(vi.mocked(buildShell)).toHaveBeenCalledOnce();
+    expect(lastBuildShellOpts()?.head).toBe(seoHead);
+  });
+
+  it('ignores non-string seoHead values (number, object, null)', async () => {
+    for (const badValue of [42, {}, null, true]) {
+      vi.mocked(buildShell).mockClear();
+      const handler = createPageHandler({
+        route: makeRoute(),
+        pageModule: { pageData: makePageData(async () => ({ seoHead: badValue })) },
+      });
+      await callHandler(handler);
+      // head should be undefined (empty staticHead + empty dynamicHead → falsy → undefined)
+      expect(lastBuildShellOpts()?.head).toBeUndefined();
+    }
+  });
+
+  it('uses only seoHead when routeMeta.head is absent', async () => {
+    const seoHead = '<meta property="og:title" content="My Post" />';
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ seoHead })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.head).toBe(seoHead);
+  });
+
+  it('omits head option when neither routeMeta.head nor seoHead are present', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hello' })) },
+    });
+
+    await callHandler(handler);
+
+    // '' + '' = '' which is falsy → '' || undefined = undefined
+    expect(lastBuildShellOpts()?.head).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeMeta.head + seoHead concatenation
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — routeMeta.head + seoHead concatenation', () => {
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+  });
+
+  it('concatenates routeMeta.head and seoHead in that order', async () => {
+    const staticHead = '<link rel="stylesheet" href="/styles.css" />';
+    const seoHead = '<meta name="description" content="SEO desc" />';
+    const handler = createPageHandler({
+      route: makeRoute(),
+      routeMeta: { head: staticHead },
+      pageModule: { pageData: makePageData(async () => ({ seoHead })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.head).toBe(staticHead + seoHead);
+  });
+
+  it('uses only routeMeta.head when pageData returns no seoHead', async () => {
+    const staticHead = '<link rel="preload" href="/font.woff2" as="font" />';
+    const handler = createPageHandler({
+      route: makeRoute(),
+      routeMeta: { head: staticHead },
+      pageModule: { pageData: makePageData(async () => ({ message: 'data' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.head).toBe(staticHead);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seoTitle injection
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — seoTitle from pageData', () => {
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+  });
+
+  it('passes seoTitle from pageData as title option', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ seoTitle: 'Dynamic Title' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.title).toBe('Dynamic Title');
+  });
+
+  it('seoTitle overrides routeMeta.title', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      routeMeta: { title: 'Static Title' },
+      pageModule: { pageData: makePageData(async () => ({ seoTitle: 'Dynamic Title' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.title).toBe('Dynamic Title');
+  });
+
+  it('falls back to routeMeta.title when seoTitle is absent', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      routeMeta: { title: 'Static Title' },
+      pageModule: { pageData: makePageData(async () => ({ message: 'data' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.title).toBe('Static Title');
+  });
+
+  it('title is undefined when neither seoTitle nor routeMeta.title are present', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'data' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.title).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pageData fetch failure
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — pageData.fetcher failure', () => {
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('still calls buildShell with routeMeta values when fetcher throws', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      routeMeta: { title: 'Static Title', head: '<link rel="stylesheet" />' },
+      pageModule: {
+        pageData: makePageData(async () => {
+          throw new Error('Data fetch failed');
+        }),
+      },
+    });
+
+    await callHandler(handler);
+
+    expect(vi.mocked(buildShell)).toHaveBeenCalledOnce();
+    const opts = lastBuildShellOpts();
+    expect(opts?.title).toBe('Static Title');
+    expect(opts?.head).toBe('<link rel="stylesheet" />');
+  });
+
+  it('emits a console.warn with the component tag and error when fetcher throws', async () => {
+    const warnSpy = vi.mocked(console.warn as (...args: unknown[]) => void);
+    const handler = createPageHandler({
+      route: makeRoute('page-blog-slug'),
+      pageModule: {
+        pageData: makePageData(async () => {
+          throw new Error('Network error');
+        }),
+      },
+    });
+
+    await callHandler(handler);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[litro] pageData.fetcher failed for',
+      'page-blog-slug',
+      expect.any(Error),
+    );
+  });
+
+  it('head is undefined (not the error) when fetcher throws and no routeMeta.head', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: {
+        pageData: makePageData(async () => {
+          throw new Error('fail');
+        }),
+      },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.head).toBeUndefined();
+  });
+});

--- a/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
+++ b/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
@@ -63,7 +63,13 @@ import { createPageHandler } from '../create-page-handler.js';
 // ---------------------------------------------------------------------------
 
 function makeRoute(tag = 'page-test') {
-  return { filePath: '/fake/page.ts', componentTag: tag, path: '/', pattern: '/' };
+  return {
+    filePath: '/fake/page.ts',
+    componentTag: tag,
+    path: '/',
+    isDynamic: false,
+    isCatchAll: false,
+  };
 }
 
 function makePageData(fetcher: (event: unknown) => Promise<unknown>) {

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -90,11 +90,20 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // call the fetcher now, before rendering, and serialize the result into
       // the HTML shell. The client reads this via getServerData() on first load.
       let serverDataJson: string | undefined;
+      let dynamicHead = '';
+      let dynamicTitle: string | undefined;
       const pageDataExport = mod.pageData as PageDataFetcher<unknown> | undefined;
       if (pageDataExport?.__litroPageData === true) {
         try {
           const data = await pageDataExport.fetcher(event);
           serverDataJson = JSON.stringify(data);
+          // Extract seoHead / seoTitle from page data for injection into <head>.
+          // Pages return these strings from definePageData() so that per-request
+          // meta tags (description, OG, JSON-LD) land in the actual <head> rather
+          // than being buried inside the __litro_data__ JSON blob.
+          const d = data as Record<string, unknown>;
+          if (typeof d.seoHead === 'string') dynamicHead = d.seoHead;
+          if (typeof d.seoTitle === 'string') dynamicTitle = d.seoTitle;
         } catch (dataErr) {
           // Data fetch failure is non-fatal: log a warning and render without
           // data. The client will call fetchData() as a fallback on navigation.
@@ -117,9 +126,10 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // and foot so we can stream the SSR output between the two halves.
       // serverDataJson is passed here so it is injected into the <head> as
       // <script type="application/json" id="__litro_data__">.
+      const staticHead = typeof routeMeta?.head === 'string' ? routeMeta.head : '';
       const shell = buildShell(route.componentTag, '', {
-        title: routeMeta?.title,
-        head: typeof routeMeta?.head === 'string' ? routeMeta.head : undefined,
+        title: dynamicTitle ?? routeMeta?.title,
+        head: staticHead + dynamicHead || undefined,
         serverDataJson,
         appScriptUrl,
       });

--- a/packages/litro-router/package.json
+++ b/packages/litro-router/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.4",
   "type": "module",
   "types": "./dist/index.d.ts",
-  "description": "Zero-dependency URLPattern client-side router for web components",
+  "description": "Client-side router for Lit web components. Built on the native URLPattern API. Zero dependencies. Works standalone or as part of the Litro framework.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -15,10 +15,16 @@
   },
   "keywords": [
     "router",
+    "client-side-routing",
+    "urlpattern",
     "web-components",
-    "url-pattern",
     "lit",
-    "client-side-routing"
+    "lit-element",
+    "spa",
+    "history-api",
+    "custom-elements",
+    "zero-dependencies",
+    "typescript"
   ],
   "exports": {
     ".": {

--- a/playground-11ty/package.json
+++ b/playground-11ty/package.json
@@ -16,7 +16,7 @@
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
-    "h3": "^1.13.0"
+    "h3": "^1.15.6"
   },
   "devDependencies": {
     "nitropack": "^2.13.1",

--- a/playground-starlight/package.json
+++ b/playground-starlight/package.json
@@ -18,7 +18,7 @@
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
-    "h3": "^1.13.0"
+    "h3": "^1.15.6"
   },
   "devDependencies": {
     "nitropack": "^2.13.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,7 +18,7 @@
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
-    "h3": "^1.13.0"
+    "h3": "^1.15.6"
   },
   "devDependencies": {
     "nitropack": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^2.19.0
         version: 2.20.1(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
       h3:
-        specifier: ^1.13.0
-        version: 1.15.5
+        specifier: ^1.15.6
+        version: 1.15.9
       highlight.js:
         specifier: ^11.10.0
         version: 11.11.1
@@ -110,8 +110,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       h3:
-        specifier: ^1.13.0
-        version: 1.15.5
+        specifier: ^1.15.6
+        version: 1.15.9
       jiti:
         specifier: ^2.0.0
         version: 2.6.1
@@ -1822,6 +1822,9 @@ packages:
 
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
+
+  h3@1.15.9:
+    resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -4658,6 +4661,18 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  h3@1.15.9:
+    dependencies:
+      cookie-es: 1.2.2
+      crossws: 0.3.5
+      defu: 6.1.4
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.3
+      uncrypto: 0.1.3
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -4893,7 +4908,7 @@ snapshots:
       crossws: 0.3.5
       defu: 6.1.4
       get-port-please: 3.2.0
-      h3: 1.15.5
+      h3: 1.15.9
       http-shutdown: 1.2.2
       jiti: 2.6.1
       mlly: 1.8.0
@@ -5352,7 +5367,7 @@ snapshots:
       exsolve: 1.0.8
       globby: 16.1.1
       gzip-size: 7.0.0
-      h3: 1.15.5
+      h3: 1.15.9
       hookable: 5.5.3
       httpxy: 0.1.7
       ioredis: 5.10.0
@@ -6082,7 +6097,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
+      h3: 1.15.9
       lru-cache: 11.2.6
       node-fetch-native: 1.6.7
       ofetch: 1.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
         specifier: ^1.1.7
         version: 1.1.8
       h3:
-        specifier: ^1.13.0
-        version: 1.15.5
+        specifier: ^1.15.6
+        version: 1.15.9
       lit:
         specifier: ^3.2.1
         version: 3.3.2
@@ -205,8 +205,8 @@ importers:
         specifier: ^1.1.7
         version: 1.1.8
       h3:
-        specifier: ^1.13.0
-        version: 1.15.5
+        specifier: ^1.15.6
+        version: 1.15.9
       lit:
         specifier: ^3.2.1
         version: 3.3.2
@@ -236,8 +236,8 @@ importers:
         specifier: ^2.19.0
         version: 2.20.1(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
       h3:
-        specifier: ^1.13.0
-        version: 1.15.5
+        specifier: ^1.15.6
+        version: 1.15.9
       highlight.js:
         specifier: ^11.10.0
         version: 11.11.1
@@ -1819,9 +1819,6 @@ packages:
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  h3@1.15.5:
-    resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
 
   h3@1.15.9:
     resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
@@ -4648,18 +4645,6 @@ snapshots:
   gzip-size@7.0.0:
     dependencies:
       duplexer: 0.1.2
-
-  h3@1.15.5:
-    dependencies:
-      cookie-es: 1.2.2
-      crossws: 0.3.5
-      defu: 6.1.4
-      destr: 2.0.5
-      iron-webcrypto: 1.2.1
-      node-mock-http: 1.0.4
-      radix3: 1.1.2
-      ufo: 1.6.3
-      uncrypto: 0.1.3
 
   h3@1.15.9:
     dependencies:

--- a/seo-prd/MASTER-PLAN.md
+++ b/seo-prd/MASTER-PLAN.md
@@ -1,0 +1,152 @@
+# Litro SEO — Master Plan
+
+## Goal
+
+Establish litro.dev as a discoverable, authoritative resource for developers searching for
+SSR/SSG frameworks, Next.js / Nuxt.js alternatives, and web components tooling. All work
+targets organic search traffic from developers.
+
+## Current State (as of 2026-03-18)
+
+- SEO utility exists (`docs/src/seo.ts`) — meta, OG, canonical, Twitter cards
+- Sitemap at `/sitemap.xml` — static hardcoded list, does NOT include blog posts dynamically
+- Blog system exists but has 1 post ("Welcome to Litro")
+- No JSON-LD structured data on any page
+- No comparison or migration pages
+- No Enhance.dev comparison (closest competitor in the web components SSR space)
+- `og-default.png` shared across all pages — no per-page differentiation
+- npm package keywords not SEO-optimized
+- No RSS feed for the blog
+- GitHub repo topics/tags not set for discoverability
+- Lit ecosystem (Discord, awesome-lit) not engaged
+
+---
+
+## Five PRDs
+
+| PRD | Title | Priority | Effort |
+|-----|-------|----------|--------|
+| [PRD-1](./PRD-1-technical-seo.md) | Technical SEO Foundations | P0 | 1–2 days |
+| [PRD-2](./PRD-2-comparison-pages.md) | Comparison & Migration Pages | P0 | 3–5 days |
+| [PRD-3](./PRD-3-blog-content.md) | Blog Content & Technical Articles | P1 | ongoing |
+| [PRD-4](./PRD-4-npm-discovery.md) | npm Package & Developer Discovery | P1 | 0.5 days |
+| [PRD-5](./PRD-5-community-distribution.md) | Community & Content Distribution | P2 | ongoing |
+
+---
+
+## Phases and Parallelization
+
+### Phase 1 — Foundation (all tracks run in parallel, target: 1 week)
+
+```
+Track A: PRD-1 — Technical SEO
+  - JSON-LD on homepage, docs pages, blog posts
+  - Dynamic sitemap (includes blog posts with <lastmod>)
+  - RSS feed for the blog (/blog/rss.xml)
+  - robots.txt Sitemap: directive
+  - Blog tag pages → noindex
+
+Track B: PRD-4 — npm Package & GitHub Discovery
+  - Add keywords to package.json for all 3 packages
+  - Rewrite package descriptions with comparison hooks
+  - Set GitHub repo topics/tags
+  - Root README.md as a proper landing page
+
+Track C: PRD-3 Posts 1 & 2 — First Blog Posts (writing, no deploy dependency)
+  - Post 1: Shadow DOM & SEO (removes the #1 objection to web components)
+  - Post 2: Why We Built Litro (manifesto/HN material)
+```
+
+No dependencies between A, B, and C. All three can be executed simultaneously.
+
+---
+
+### Phase 2 — Comparison Content (start after Phase 1 deploys, target: weeks 2–3)
+
+```
+Track D: PRD-2 — Comparison & Migration Pages
+  - /compare/nextjs (highest search volume)
+  - /compare/nuxt (shared Nitro foundation angle)
+  - /compare/enhance (nearest web-components competitor)
+  - /why-web-components (philosophical anchor page)
+  - /docs/migrate/from-nextjs
+  - /docs/migrate/from-nuxt
+  - /docs/migrate/from-react
+
+Track E: PRD-3 Posts 3–5 — More Blog Content
+  - Post 3: File-based routing for Next.js devs
+  - Post 4: Streaming SSR with DSD (technical depth)
+  - Post 5: Blog tutorial with litro:content
+```
+
+Phase 2 does not depend on Phase 1 for writing, but Phase 1 (JSON-LD, dynamic sitemap)
+should be deployed before the new pages go live so they are immediately indexed correctly.
+
+---
+
+### Phase 3 — Distribution (after 3+ blog posts are live, target: weeks 4–6)
+
+```
+Track F: PRD-5 — Community Distribution
+  - Submit sitemap to Google Search Console
+  - Submit to Lit Discord #showcase
+  - PR to awesome-lit and awesome-web-components GitHub lists
+  - Dev.to cross-posts for Posts 1–5 (canonical URLs)
+  - r/webdev introduction post
+  - Show HN submission
+  - Remaining blog posts (Posts 6–8): Nitro adapters, LitroRouter, performance benchmarks
+```
+
+Performance benchmarks are intentionally last — publish only after the framework is
+battle-tested and numbers are reproducible and defensible.
+
+---
+
+## Priority Reorder vs. Original Document
+
+The following adjustments are made from the original AI-suggested plan:
+
+| Original suggestion | Decision |
+|--------------------|----------|
+| Performance benchmarks early | Pushed to Phase 3 — risk of scrutiny before framework is stable |
+| Separate `/for-react-developers`, `/for-nextjs-developers` pages | Consolidated into `/compare/*` pages — avoids thin/duplicate content |
+| Topic cluster architecture restructuring | Removed — consulting-speak; existing doc structure is fine |
+| "FAST web components framework" keyword | Removed — FAST is a specific Microsoft library; targeting it misleads |
+| "No virtual DOM" as primary keyword | Demoted to supporting copy, not headline keyword |
+| Twitter/X in Phase 1 | Moved to Phase 3 — low ROI until content base exists |
+| Roundup article outreach | Deferred — too early; authors won't take a brand-new framework seriously |
+| `/sdk` and `/cli` pages | Removed — CLI docs already exist |
+
+Additions not in original document:
+- RSS feed for blog
+- Enhance.dev comparison page
+- GitHub repo health (topics, description)
+- Lit ecosystem engagement (Discord, awesome-lit) as Week 1 activity
+- "Standards will outlast frameworks" as the core philosophical narrative
+
+---
+
+## Success Metrics
+
+| Metric | Baseline | 90-day Target |
+|--------|----------|---------------|
+| Google Search Console impressions | 0 (not submitted) | >5,000/mo |
+| Organic clicks | ~0 | >200/mo |
+| Indexed pages | unknown | 30+ |
+| Comparison page rankings | none | Top 20 for 3+ target keywords |
+| npm weekly downloads (@beatzball/litro) | check current | growing MoM |
+| Blog posts published | 1 | 8+ |
+| GitHub stars | check current | 100+ |
+| Backlinks (non-trivial) | ~0 | 5+ |
+
+---
+
+## Quick Wins (implement first — high signal, low effort)
+
+1. Add JSON-LD `SoftwareApplication` schema to homepage — 30 min
+2. Make sitemap dynamic (include blog posts) — 1 hr
+3. Add RSS feed at `/blog/rss.xml` — 1 hr
+4. Add npm keywords to all 3 `package.json` files — 15 min
+5. Set GitHub repo topics: `lit`, `web-components`, `ssr`, `ssg`, `nitro`, `vite` — 5 min
+6. Submit sitemap to Google Search Console — 15 min
+7. Post in Lit Discord `#showcase` — 15 min

--- a/seo-prd/PRD-1-technical-seo.md
+++ b/seo-prd/PRD-1-technical-seo.md
@@ -1,0 +1,288 @@
+# PRD-1: Technical SEO Foundations
+
+**Priority:** P0
+**Effort:** 1–2 days
+**Phase:** 1 (run in parallel with PRD-4 and first two blog posts)
+**Dependencies:** None — start immediately
+
+---
+
+## Problem
+
+The site has a basic SEO utility (`docs/src/seo.ts`) but is missing several technical signals
+that search engines use to understand, rank, and display developer-tool pages:
+
+- No JSON-LD structured data — search engines get no machine-readable context about what
+  Litro is or what type of content each page contains
+- Sitemap is a hardcoded static list — does not include dynamically published blog posts;
+  will silently fall out of sync as content is added
+- No RSS feed — blog content is undiscoverable by aggregators and newsletter curators
+- robots.txt has not been verified since the site went live
+- Blog tag pages may cause thin-content duplicate penalties
+- No Google Search Console setup — zero crawl error visibility
+
+---
+
+## Goals
+
+1. Every page emits JSON-LD structured data appropriate to its type.
+2. `/sitemap.xml` is generated dynamically and always reflects actual published content.
+3. `/blog/rss.xml` exists and is linked from the blog and from `<head>`.
+4. robots.txt is correct and points to the sitemap.
+5. Blog tag pages do not cause duplicate content penalties.
+6. Site is ready for Google Search Console submission.
+
+---
+
+## Out of Scope
+
+- Per-page dynamically generated OG images (defer — requires infrastructure work)
+- Internationalization / hreflang
+
+---
+
+## Detailed Requirements
+
+### 1. JSON-LD Structured Data
+
+Add JSON-LD `<script type="application/ld+json">` to every page type.
+
+#### 1a. Homepage (`/`)
+
+Schema type: `SoftwareApplication`
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Litro",
+  "description": "A fullstack web framework combining Lit web components, Nitro server, and Vite. File-based routing, streaming SSR, SSG, and Declarative Shadow DOM.",
+  "url": "https://litro.dev",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Node.js",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "beatzball",
+    "url": "https://github.com/beatzball"
+  },
+  "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  "codeRepository": "https://github.com/beatzball/litro",
+  "programmingLanguage": ["TypeScript", "JavaScript"]
+}
+```
+
+#### 1b. Doc pages (`/docs/[...slug]`)
+
+Schema type: `TechArticle`
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "<page title from frontmatter>",
+  "description": "<page description from frontmatter>",
+  "url": "https://litro.dev/docs/<slug>",
+  "author": {
+    "@type": "Organization",
+    "name": "beatzball"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Litro Documentation",
+    "url": "https://litro.dev"
+  }
+}
+```
+
+#### 1c. Blog posts (`/blog/[slug]`)
+
+Schema type: `BlogPosting`
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "<post title>",
+  "description": "<post description>",
+  "datePublished": "<date from frontmatter, ISO 8601>",
+  "url": "https://litro.dev/blog/<slug>",
+  "author": {
+    "@type": "Organization",
+    "name": "beatzball"
+  },
+  "keywords": ["<tags from frontmatter, comma-separated>"]
+}
+```
+
+#### 1d. Comparison pages (`/compare/*`)
+
+Schema type: `WebPage` with `about` entities for both frameworks compared.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Litro vs Next.js",
+  "description": "...",
+  "url": "https://litro.dev/compare/nextjs",
+  "about": [
+    { "@type": "SoftwareApplication", "name": "Litro", "url": "https://litro.dev" },
+    { "@type": "SoftwareApplication", "name": "Next.js", "url": "https://nextjs.org" }
+  ]
+}
+```
+
+#### Implementation note
+
+Add a `buildJsonLd(data: object): string` helper in `docs/src/seo.ts`:
+
+```typescript
+export function buildJsonLd(data: object): string {
+  return `<script type="application/ld+json">${JSON.stringify(data)}</script>`;
+}
+```
+
+Each page's `definePageData` constructs the appropriate schema and passes it through
+`routeMeta.head`. Comparison pages use static `routeMeta` exports since their JSON-LD
+does not depend on dynamic content.
+
+---
+
+### 2. Dynamic Sitemap
+
+**Current problem:** `/docs/pages/sitemap.xml.ts` is a hardcoded list. Blog posts published
+to `/docs/content/blog/` are never reflected in the sitemap unless manually added.
+
+**Fix:** Rewrite `sitemap.xml.ts` as an H3 event handler that:
+
+1. Fetches all blog posts via `getPosts()` (same as `blog/index.ts`) and includes each
+   post URL with its frontmatter `date` as `<lastmod>`
+2. Keeps the static doc routes as a hardcoded list (these are stable and version-controlled)
+3. Concatenates and emits the full XML with correct `Content-Type: application/xml`
+
+Priority tiers:
+- `/` → `1.0`
+- `/compare/*`, `/why-web-components`, `/blog`, core docs → `0.8`
+- Individual blog posts → `0.7`
+- Migration guides, package pages → `0.6`
+
+Change frequency:
+- Homepage → `weekly`
+- Blog posts → `monthly` (after initial publish; they don't change)
+- Docs pages → `monthly`
+
+When a new comparison page is added (PRD-2), add it to the static list in `sitemap.xml.ts`.
+Blog posts are the only routes that need dynamic generation — everything else is code-deployed.
+
+---
+
+### 3. RSS Feed
+
+**New file:** `docs/pages/blog/rss.xml.ts`
+
+An H3 event handler that generates a valid RSS 2.0 feed for all blog posts, ordered by
+date descending.
+
+Required RSS fields per item:
+- `<title>` — post title
+- `<link>` — full URL (`${SITE_URL}/blog/${slug}`)
+- `<description>` — post description from frontmatter
+- `<pubDate>` — RFC 822 date format
+- `<guid isPermaLink="true">` — same as `<link>`
+
+Channel-level fields:
+- `<title>` — "Litro Blog"
+- `<link>` — `https://litro.dev/blog`
+- `<description>` — "Technical articles from the Litro team"
+- `<language>` — `en`
+- `<lastBuildDate>` — date of the most recent post
+
+Add `<link rel="alternate" type="application/rss+xml" title="Litro Blog" href="/blog/rss.xml">`
+to the `<head>` on the `/blog` page and in `starlightHead` for global discovery.
+
+Add `/blog/rss.xml` to the sitemap (priority `0.5`) so crawlers find it.
+
+---
+
+### 4. Per-Page Title and Description Audit
+
+Every doc `.md` file must have a `description` frontmatter field (120–160 characters,
+keyword-rich, benefit-oriented). Audit all 18 files in `docs/content/docs/`.
+
+Files likely missing `description` (verify and add):
+
+| File | Suggested description |
+|------|----------------------|
+| `introduction.md` | "Litro is a fullstack web framework built on Lit, Nitro, and Vite. File-based routing, streaming SSR, SSG, and no virtual DOM overhead." |
+| `getting-started.md` | "Scaffold your first Litro app in under a minute. Supports SSR, SSG, and static deployments with a single command." |
+| `core-concepts/ssr.md` | "How Litro delivers server-side rendering via Declarative Shadow DOM — the technique that makes Lit components fully crawlable by search engines." |
+| `core-concepts/routing.md` | "File-based routing in Litro: map files in pages/ to URLs automatically, with dynamic segments, catch-alls, and optional parameters." |
+| `core-concepts/data-fetching.md` | "Fetch server-side data in Litro using definePageData(). Results are serialized to HTML and available on the client without an extra network request." |
+| `core-concepts/client-router.md` | "LitroRouter: a zero-dependency client-side router for Lit web components, built on the native URLPattern API." |
+| `ssg.md` | "Prerender your Litro app to static HTML at build time. Compatible with GitHub Pages, Cloudflare Pages, and any static host." |
+
+---
+
+### 5. Blog Tag Pages — noindex
+
+`/blog/tags/[tag]` pages have thin, duplicated content (a subset of the posts already on
+`/blog`). They should not be indexed.
+
+Add `<meta name="robots" content="noindex, follow">` to the tag page's `routeMeta.head`.
+The `follow` directive ensures any links on the page still pass crawl credit.
+
+---
+
+### 6. robots.txt
+
+Verify `docs/public/robots.txt` contains:
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: https://litro.dev/sitemap.xml
+```
+
+The `Sitemap:` directive is the key addition. Crawlers that land on `robots.txt` before
+discovering the sitemap will find it immediately.
+
+If the current file disallows `/content/` (raw Markdown), that is acceptable — raw markdown
+files are not indexable content. Do not disallow anything else.
+
+---
+
+### 7. Google Search Console
+
+After deploying PRD-1:
+
+1. Add `litro.dev` as a property in Google Search Console
+2. Verify ownership via DNS TXT record (preferred) or HTML file
+3. Submit `https://litro.dev/sitemap.xml`
+4. Use the URL Inspection tool to request indexing for:
+   - `/` (homepage)
+   - `/docs/introduction`
+   - `/compare/nextjs` and `/compare/nuxt` (once PRD-2 is deployed)
+   - The Shadow DOM SEO blog post (once published)
+
+Check weekly for the first month: Coverage report for crawl errors, Core Web Vitals report
+for any pages flagged as "Poor."
+
+---
+
+## Acceptance Criteria
+
+- [ ] JSON-LD appears in `<head>` on `/`, `/docs/*`, `/blog/*`, and `/compare/*` pages
+- [ ] `buildJsonLd()` helper exists in `docs/src/seo.ts`
+- [ ] `/sitemap.xml` includes all blog posts with `<lastmod>` dates matching frontmatter
+- [ ] `/blog/rss.xml` returns valid RSS 2.0 with all posts
+- [ ] `<link rel="alternate" type="application/rss+xml">` in `<head>` on `/blog` page
+- [ ] All 18 doc `.md` files have `description` frontmatter ≥ 80 characters
+- [ ] Blog tag pages have `<meta name="robots" content="noindex, follow">`
+- [ ] `robots.txt` contains `Sitemap: https://litro.dev/sitemap.xml`
+- [ ] Site submitted to Google Search Console with sitemap

--- a/seo-prd/PRD-2-comparison-pages.md
+++ b/seo-prd/PRD-2-comparison-pages.md
@@ -1,0 +1,323 @@
+# PRD-2: Comparison & Migration Pages
+
+**Priority:** P0
+**Effort:** 3–5 days
+**Phase:** 2 (start writing immediately; deploy after PRD-1 is live so pages get JSON-LD
+from day one)
+**Dependencies:** PRD-1 deployed before going live (for JSON-LD and sitemap); content
+writing can begin in parallel
+
+---
+
+## Problem
+
+The highest-value SEO queries for a new framework are comparison and migration searches:
+"Next.js alternative," "Nuxt.js alternative web components," "Lit framework SSR," etc.
+
+Litro has zero pages targeting these. Every developer who discovers Litro — whether via
+search or word of mouth — must answer "is this for me?" entirely on their own. The
+comparison pages close that gap directly.
+
+**Design principle:** Each comparison page serves double duty as both a technical comparison
+*and* an audience landing page. A separate `/for-nextjs-developers` page alongside a
+`/compare/nextjs` page would produce thin, overlapping content. One well-executed page per
+audience is better than two mediocre ones.
+
+---
+
+## Goals
+
+1. Rank for comparison and migration queries from Next.js, Nuxt.js, and React developers.
+2. Give each audience a page that speaks their vocabulary and maps Litro to concepts they
+   already know.
+3. Address the Enhance.dev comparison — the nearest competitor in the web-components SSR
+   space — so developers researching this category have a clear answer.
+4. Position Litro's philosophical stance: standards-based development as a long-term bet,
+   not just another framework swap.
+
+---
+
+## New Pages
+
+### Group 1: Comparison Pages
+
+These are evergreen SEO landing pages at top-level routes. They serve both the "comparison"
+and "developer audience" purpose — no separate audience pages needed.
+
+#### `/compare/nextjs`
+**Title:** "Litro vs Next.js: File-Based Routing and SSR Without React"
+**Target keywords:** "Next.js alternative," "Next.js vs web components," "SSR without React"
+
+Content structure:
+1. **One-paragraph opener** — both frameworks solve the same core problems (SSR, routing,
+   deployment); the difference is the component model and what you're betting on long-term
+2. **Feature comparison table** (see spec below)
+3. **Side-by-side code: a simple SSR page** — Next.js `page.tsx` vs Litro `index.ts`
+4. **Side-by-side code: data fetching** — Next.js server component vs `definePageData()`
+5. **"What carries over"** — file-based routing, API routes, deployment adapters (Vercel
+   works with Nitro's preset, same as Nuxt), TypeScript throughout
+6. **"What changes"** — React → Lit, JSX → tagged template literals, React runtime
+   eliminated from the client bundle, ~8kB vs ~90kB Hello World
+7. **"Why this trade-off?"** — short version of the standards argument: React will be
+   replaced by something; web components are a W3C standard. Not a prediction — a bet on
+   longevity
+8. **CTA:** Get started → `/docs/getting-started` | Migration guide → `/docs/migrate/from-nextjs`
+
+#### `/compare/nuxt`
+**Title:** "Litro vs Nuxt.js: Same Nitro Server, Different Component Model"
+**Target keywords:** "Nuxt.js alternative," "Nuxt without Vue," "Nitro with web components"
+
+The Nuxt comparison has a unique hook: both Litro and Nuxt.js use Nitro as their server
+engine. This is the single strongest credibility signal Litro has and should be the lede.
+
+Content structure:
+1. **Shared foundation callout** (prominent, near top): "Litro and Nuxt.js both run on
+   Nitro — the same server engine, the same deployment adapters, the same H3 API routes."
+2. **Feature comparison table** (adapted for Vue vs Lit)
+3. **Side-by-side code: a Nuxt page vs a Litro page**
+4. **"What carries over"** — Nitro, H3 event handlers, server middleware, all deployment
+   presets (Cloudflare, Vercel Edge, AWS, etc.) work identically in Litro
+5. **"What changes"** — Vue SFC → Lit class component; `useFetch` → `definePageData()`;
+   `<NuxtLink>` → `<litro-link>`; no `<script setup>` magic
+6. **"Why switch?"** — same argument: Vue will eventually be superseded; web components
+   are a platform primitive; you keep the Nitro investment you already have
+7. **CTA:** Get started | Migration guide → `/docs/migrate/from-nuxt`
+
+#### `/compare/enhance`
+**Title:** "Litro vs Enhance: Two Approaches to SSR Web Components"
+**Target keywords:** "Enhance.dev alternative," "Enhance vs Litro," "SSR web components framework"
+
+Enhance (by Begin.dev) is the closest competitor in the web-components SSR space. Developers
+researching this category will find both. Litro needs a clear, fair answer to "how is this
+different from Enhance?"
+
+Content structure:
+1. **What they share** — both render web components server-first, both avoid React/Vue/Svelte
+2. **Key difference: component authoring** — Enhance uses its own HTML-first single-file
+   component format; Litro uses Lit (a widely-adopted W3C-aligned library with its own
+   ecosystem, SSR tooling, and community)
+3. **Key difference: server** — Enhance is built for Begin's cloud; Litro uses Nitro,
+   giving it Vercel, Cloudflare, AWS, and Node.js targets without custom adapters
+4. **Key difference: client routing** — Enhance is primarily document-navigation (MPA);
+   Litro includes a full client-side router (LitroRouter) for SPA-style navigation
+5. **Feature comparison table**
+6. **When to choose Enhance** — honest answer: if you want zero-JS-by-default and document
+   semantics without client routing, Enhance is excellent
+7. **When to choose Litro** — if you want client routing, the Lit ecosystem (Shoelace, etc.),
+   Nitro's deployment flexibility, or are migrating from Nuxt/Next
+8. **CTA:** Get started | `/docs/getting-started`
+
+#### `/why-web-components`
+**Title:** "Why Web Components? The Case for Standards-Based Development in 2026"
+**Target keywords:** "why web components," "web components vs React 2026," "web standards framework"
+
+This page is the philosophical anchor for the entire site. It answers the meta-question
+behind every comparison: "why should I care about web components at all?"
+
+Content structure:
+1. **The framework treadmill** — React replaced Angular; something will replace React.
+   Every migration is expensive. Developers who've been through two or three of these are
+   paying attention to standards.
+2. **What web components actually are** — not a framework. Custom Elements, Shadow DOM,
+   and `<template>` are W3C specifications implemented natively in every major browser.
+   Baseline 2024. No polyfills needed.
+3. **What Lit adds** — 6kB library on top of the native APIs. Reactive properties, tagged
+   templates, SSR support. The minimum ergonomic layer, not a new runtime.
+4. **The standards longevity argument** — the DOM API from 1998 still works. `<input type="date">`
+   from 2012 still works. Web components defined today will still work in browsers shipping
+   in 2040, without a migration.
+5. **Honest trade-offs** — ecosystem maturity vs React, fewer component libraries, smaller
+   community today. Name it directly rather than letting readers find it themselves.
+6. **Litro as the batteries-included entry point** — you don't have to assemble this from
+   scratch. File-based routing, SSR, data fetching, deployment adapters — all included.
+7. **CTA:** Get started → `/docs/getting-started`
+
+---
+
+### Group 2: Migration Guides
+
+These live in the docs tree at `/docs/migrate/*`. They are practical code-first guides,
+not persuasion. The comparison pages do the persuading; the migration guides do the work.
+
+#### `/docs/migrate/from-nextjs`
+**Title:** "Migrating from Next.js to Litro"
+**Target keywords:** "migrate from Next.js," "Next.js to web components"
+
+Mapping table (concepts only — full code examples inline):
+
+| Next.js | Litro | Notes |
+|---------|-------|-------|
+| `app/page.tsx` | `pages/index.ts` | Same location concept |
+| `export default function Page()` | `@customElement class Page extends LitroPage` | Class vs function |
+| Server Component `fetch()` | `definePageData(async () => {...})` | Server-side data |
+| `getServerSideProps` | `definePageData()` | Same purpose |
+| `useRouter()` | `LitroRouter` | Different API |
+| `<Link href="...">` | `<litro-link href="...">` | SPA navigation |
+| `app/api/route.ts` | `server/api/*.ts` | H3 event handler |
+| CSS Modules | Shadow DOM `static styles = css\`...\`` | Scoping model |
+| `next.config.js` | `nitro.config.ts` + `vite.config.ts` | Split config |
+| `next build` | `litro build` | — |
+| `next dev` | `litro dev` | — |
+
+Content: step-by-step migration with before/after code for each concept. End with
+a complete worked example: migrate a simple blog from Next.js to Litro.
+
+#### `/docs/migrate/from-nuxt`
+**Title:** "Migrating from Nuxt.js to Litro"
+**Target keywords:** "migrate from Nuxt," "Nuxt to Litro"
+
+Same format. Key callout: H3 API route handlers from Nuxt can be copied verbatim to
+Litro's `server/api/` — they are identical. The migration from Nuxt is primarily about
+replacing Vue SFCs with Lit class components.
+
+#### `/docs/migrate/from-react`
+**Title:** "From React to Lit: A Component Migration Guide"
+**Target keywords:** "React to web components," "replace React with Lit"
+
+Focus on the component authoring mental model shift, not the full-framework migration.
+This page serves developers who want to adopt Lit gradually (e.g. in an existing app
+via custom elements) not just those migrating to Litro wholesale.
+
+| React | Lit | Notes |
+|-------|-----|-------|
+| `useState` | `@state()` / `static properties` | Reactive state |
+| `useEffect` | `updated()` / `connectedCallback()` | Lifecycle |
+| Props / JSX attributes | `@property()` / `static override properties` | Observed attributes |
+| Context | `@lit/context` controller | Different API |
+| `dangerouslySetInnerHTML` | `unsafeHTML()` from `lit/directives/` | — |
+| CSS Modules | `static styles = css\`...\`` | Shadow DOM scoping |
+| `React.memo` | N/A — Lit's update batching handles this | — |
+
+---
+
+## Feature Comparison Tables
+
+Used across comparison pages. Keep tables accurate and updated as both frameworks evolve.
+
+### Litro vs Next.js
+
+| Feature | Next.js | Litro |
+|---------|---------|-------|
+| Component model | React (JSX) | Lit (web components) |
+| File-based routing | ✓ | ✓ |
+| SSR | ✓ React Server Components | ✓ Declarative Shadow DOM streaming |
+| SSG | ✓ | ✓ |
+| Data fetching | `fetch` in Server Components | `definePageData()` |
+| API routes | `app/api/route.ts` | `server/api/*.ts` (H3) |
+| Client routing | Next Router | LitroRouter (URLPattern) |
+| Approx. Hello World JS (gzipped) | ~90kB | ~8kB |
+| Server engine | custom | Nitro (same as Nuxt) |
+| Virtual DOM | ✓ | — |
+| W3C standard components | — | ✓ |
+| TypeScript | ✓ | ✓ |
+| License | MIT | Apache 2.0 |
+
+### Litro vs Nuxt.js
+
+| Feature | Nuxt.js | Litro |
+|---------|---------|-------|
+| Component model | Vue 3 (SFC) | Lit (web components) |
+| File-based routing | ✓ | ✓ |
+| SSR | ✓ | ✓ Declarative Shadow DOM |
+| SSG | ✓ | ✓ |
+| Data fetching | `useFetch` / `useAsyncData` | `definePageData()` |
+| API routes | `server/api/*.ts` (H3) | `server/api/*.ts` (H3) — identical |
+| Server engine | Nitro | Nitro — identical |
+| Deployment adapters | All Nitro presets | All Nitro presets — identical |
+| Client routing | vue-router | LitroRouter (URLPattern) |
+| Approx. Hello World JS (gzipped) | ~60kB | ~8kB |
+| Virtual DOM | ✓ (Vue) | — |
+| W3C standard components | — | ✓ |
+
+### Litro vs Enhance
+
+| Feature | Enhance | Litro |
+|---------|---------|-------|
+| Component format | HTML-first SFCs | Lit class components |
+| Server rendering | ✓ | ✓ Declarative Shadow DOM |
+| Client routing | — (MPA by default) | ✓ LitroRouter |
+| Server | Begin cloud / Arc | Nitro (Vercel, Cloudflare, AWS, etc.) |
+| Deployment flexibility | Begin-centric | All Nitro presets |
+| JS-by-default | Opt-in | Opt-in |
+| Lit ecosystem compatible | — | ✓ (Shoelace, etc.) |
+| TypeScript | partial | ✓ |
+
+---
+
+## Implementation Notes
+
+### New page files
+
+```
+docs/pages/compare/nextjs.ts
+docs/pages/compare/nuxt.ts
+docs/pages/compare/enhance.ts
+docs/pages/why-web-components.ts
+```
+
+Migration guides go in docs content:
+
+```
+docs/content/docs/migrate/from-nextjs.md
+docs/content/docs/migrate/from-nuxt.md
+docs/content/docs/migrate/from-react.md
+```
+
+The existing `docs/pages/docs/[...slug].ts` catch-all serves migration guides automatically.
+
+### Comparison page component
+
+Comparison pages (`/compare/*`) are not standard doc pages — they need a distinct layout
+(two-column code comparisons, feature tables with styled cells). Create a new page
+component type or extend the existing layout with a `comparison` flag in `routeMeta`.
+
+### Sitemap
+
+Add all new `/compare/*` and `/why-web-components` routes to the static list in
+`sitemap.xml.ts` with priority `0.8`. Migration guide routes (`/docs/migrate/*`) are
+served by the `[...slug]` catch-all and should also be added explicitly to the sitemap.
+
+### JSON-LD
+
+- `/compare/*` pages: `WebPage` schema with `about` listing both frameworks (see PRD-1 §1d)
+- `/why-web-components`: `Article` schema
+- `/docs/migrate/*` pages: `TechArticle` schema (handled by the `[...slug]` catch-all if
+  it already applies `TechArticle` to all doc pages)
+
+### Internal linking
+
+- Homepage features section: add links to `/compare/nextjs`, `/compare/nuxt`,
+  `/why-web-components`
+- `/docs/introduction`: add "Coming from another framework?" section linking to all three
+  comparison pages and `/why-web-components`
+- Blog posts (PRD-3): each post links back to the most relevant comparison page
+
+---
+
+## SEO Copywriting Guidelines
+
+- **Lead with their vocabulary.** Use `getServerSideProps`, `vue-router`, `<NuxtLink>`, etc.
+  Developers searching for these terms will find these pages.
+- **Don't sell — show.** Every claim backed by a code example or a measurable number.
+- **Be honest about trade-offs.** Naming the downsides (smaller ecosystem, different DX)
+  builds trust and reduces bounce rate from developers who feel misled.
+- **Keywords in H2 and H3.** These headings carry ranking weight. Use target phrases
+  naturally — don't stuff.
+- **No introductory throat-clearing.** Start with the most relevant content. Search visitors
+  will not scroll through two paragraphs of "In this article, we will explore..."
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 4 new page files created and rendering at their routes
+- [ ] All 3 migration guides exist in `docs/content/docs/migrate/`
+- [ ] Each page has unique `<title>` and `<meta description>` ≥ 120 characters
+- [ ] JSON-LD on all new pages (correct schema type per page)
+- [ ] Feature comparison tables render correctly on all `/compare/*` pages
+- [ ] Side-by-side code examples are syntax-highlighted
+- [ ] All new routes in `sitemap.xml` with priority `0.8`
+- [ ] Internal links from homepage and `/docs/introduction` to comparison pages
+- [ ] `/why-web-components` includes honest trade-offs section
+- [ ] `/compare/nuxt` prominently features the shared Nitro foundation
+- [ ] Mobile-responsive at 375px (tables scroll horizontally if needed)

--- a/seo-prd/PRD-3-blog-content.md
+++ b/seo-prd/PRD-3-blog-content.md
@@ -1,0 +1,283 @@
+# PRD-3: Blog Content & Technical Articles
+
+**Priority:** P1
+**Effort:** Ongoing — initial batch of 8 posts; then 1–2/month
+**Phase:** Posts 1–2 begin in Phase 1 (parallel with PRD-1/PRD-4); Posts 3–5 in Phase 2;
+Posts 6–8 in Phase 3
+**Dependencies:** PRD-1 deployed before promoting posts (JSON-LD and dynamic sitemap must
+be live so posts are indexed correctly on publication)
+
+---
+
+## Problem
+
+The blog exists but has exactly one post. Blog posts are the highest-leverage SEO asset for
+a developer-tool brand:
+
+- They target long-tail queries that comparison pages don't cover
+- They establish technical authority, which earns backlinks from other developers
+- Each post is a new indexed URL with its own keyword surface
+- Fresh content improves crawl frequency
+- They are the raw material for Dev.to cross-posts, HN submissions, and newsletter pickups
+
+---
+
+## Goals
+
+1. Publish an initial batch of 8 technical posts covering the highest-value topics.
+2. Each post targets at least one specific long-tail keyword.
+3. Every post links to a relevant comparison page or docs page (internal linking).
+4. Posts are written in priority order — the highest-SEO-value, lowest-risk posts first.
+5. Performance benchmarks are published last, only after numbers are reproducible and
+   the framework is stable enough to withstand scrutiny.
+
+---
+
+## Post Queue (in publish order)
+
+### Post 1: Shadow DOM and SEO — The Problem and Litro's Solution
+**Publish:** Phase 1, Week 1
+**Target keyword:** "web components SEO," "shadow DOM SEO," "are web components bad for SEO"
+**Why first:** This is the #1 objection developers raise when evaluating web components for
+production use. A well-ranked answer to this question removes a purchase blocker for every
+developer who finds Litro through any channel.
+
+Outline:
+- The misconception: "web components are bad for SEO"
+- What's actually true: *client-side-only* web components are invisible to crawlers — the
+  component renders after JS executes, and Googlebot's JS rendering queue is slow and
+  non-deterministic
+- The same problem exists for React, Vue, and Svelte without SSR — this isn't a web
+  components problem, it's a rendering mode problem
+- The solution: server-side rendering with Declarative Shadow DOM (DSD)
+- What DSD looks like in the wire — show the actual serialized HTML a crawler receives
+- How `@lit-labs/ssr` + Litro delivers this — the same mechanism Next.js and Nuxt.js use
+- Practical result: Googlebot sees fully-rendered HTML before any JS executes
+- Internal links: `/compare/nextjs`, `/docs/core-concepts/ssr`
+
+---
+
+### Post 2: Why We Built Litro — The Case for Standards-Based Development
+**Publish:** Phase 1, Week 2
+**Target keyword:** "web standards framework," "no virtual DOM framework," "Lit fullstack framework"
+**Why second:** This is the manifesto post and the primary Hacker News submission. It sets
+the philosophical foundation that all other content references back to.
+
+Outline:
+- **The framework treadmill** — Angular → React → what's next? Every migration costs weeks
+  of developer time and carries real risk. This isn't a criticism of any framework — it's
+  a structural observation about the ecosystem.
+- **The virtual DOM was a workaround** — in 2013, the DOM was slow and inconsistent across
+  browsers. The virtual DOM diffing solved a real problem. Today, that problem is largely
+  gone: browsers are fast, APIs are standardized. The workaround outlasted the problem it
+  solved.
+- **Web components as a different bet** — Custom Elements, Shadow DOM, and `<template>` are
+  W3C specifications. They will be in browsers in 2040 in the same way `<input type="date">`
+  from 2012 is still in browsers today. The bet is on longevity, not on today's performance
+  numbers.
+- **Lit as the minimum ergonomic layer** — not a new runtime, a 6kB library that adds
+  reactive properties and tagged template rendering on top of the native APIs. If Lit
+  disappeared tomorrow, the components it produces still run natively.
+- **Nitro as the deployment layer** — rather than building a custom server, Litro uses Nitro
+  — the server engine behind Nuxt.js. All of Nitro's deployment adapters (Vercel, Cloudflare
+  Workers, AWS Lambda, Deno Deploy) work without any custom Litro code.
+- **What Litro is NOT trying to be** — not a React replacement for large enterprise
+  organizations with years of React investment. The migration cost is real and for many
+  teams, not worth it.
+- **Who it IS for** — developers starting new projects, teams that want to reduce their
+  dependency on proprietary runtimes, developers who have been through two or three framework
+  migrations and want to bet on the platform.
+- Internal links: `/why-web-components`, `/compare/nextjs`, `/compare/nuxt`
+
+---
+
+### Post 3: File-Based Routing with Lit — A Next.js Developer's Guide
+**Publish:** Phase 2, Week 3
+**Target keyword:** "file-based routing web components," "Next.js routing Lit," "Lit SSR routing"
+**Why:** Directly targets Next.js developers using vocabulary they already know. Captures
+searches from the comparison page's audience who want technical depth.
+
+Outline:
+- Next.js page conventions as the starting point (assume reader knows them)
+- Litro's equivalent: `pages/index.ts` → `/`, `pages/[id].ts` → `/:id`, `pages/[...slug].ts`
+- How the page scanner works (fast-glob pattern, virtual module, no runtime `require()`)
+- The `default export` pattern: Lit class component as the page
+- `routeMeta` for head injection (title, description, canonical)
+- Navigation: `<litro-link>` vs Next's `<Link>` — same concept, different element
+- Data fetching: `definePageData()` vs Next.js server components — side-by-side
+- Deployment: Nitro presets, including Vercel (same one Nuxt uses)
+- Internal links: `/compare/nextjs`, `/docs/migrate/from-nextjs`
+
+---
+
+### Post 4: Streaming SSR with Declarative Shadow DOM — How It Works
+**Publish:** Phase 2, Week 4
+**Target keyword:** "streaming SSR web components," "Declarative Shadow DOM streaming,"
+"DSD server rendering"
+**Why:** Technical depth post for developers who want to understand the mechanism, not just
+the result. Earns credibility with senior engineers and generates backlinks from technical blogs.
+
+Outline:
+- Traditional SSR: blocking render, full HTML buffered before first byte sent to client
+- Streaming SSR: server sends chunks as they're ready (HTTP chunked transfer encoding)
+- How React/Next.js does it: Suspense boundaries as the flush points
+- How Litro does it: `@lit-labs/ssr` → `RenderResultReadable` → Nitro `sendStream()`
+- What DSD looks like on the wire — annotated HTML example showing `<template shadowrootmode>`
+- Why this matters for Core Web Vitals: earlier First Contentful Paint, improved LCP
+- The hydration step: `@lit-labs/ssr-client/lit-element-hydrate-support.js` must load first;
+  why import order matters
+- Edge adapter consideration: `RenderResultReadable` is Node-only; Cloudflare Workers
+  need `ReadableStream` conversion
+- Full working code example: a streaming Litro page with async `definePageData`
+- Internal links: `/docs/core-concepts/ssr`, `/compare/nextjs`
+
+---
+
+### Post 5: Building a Blog with Litro's Content Layer
+**Publish:** Phase 2, Week 5
+**Target keyword:** "Lit SSG blog," "web components markdown blog," "litro content layer"
+**Why:** Tutorial post that converts "I want to build a blog/docs site with web components"
+searches. Lower competition than the framework comparison queries.
+
+Outline:
+- What `litro:content` is: a virtual module, not a filesystem API — available server-side
+  only, delivered to the client via `definePageData` → `getServerData`
+- Start from the `11ty-blog` recipe vs. building from scratch: trade-offs
+- Complete working blog: content directory, frontmatter schema, `getPosts()`, rendering
+- Tags and filtering
+- Static generation: `generateRoutes()` for prerendering every post at build time
+- Deploying to GitHub Pages: `LITRO_BASE_PATH`, `.nojekyll`, GitHub Actions
+- Optional: adding an RSS feed (connects back to PRD-1 RSS work)
+- Internal links: `/docs/content-layer`, `/docs/ssg`, `/docs/deployment/github-pages`
+
+---
+
+### Post 6: How Nitro's Deployment Adapters Work — and Why Litro Gets Them for Free
+**Publish:** Phase 3, Week 6
+**Target keyword:** "Nitro deployment adapters," "deploy web components Cloudflare Vercel,"
+"framework deployment flexibility"
+**Why:** Targets developers who care about avoiding vendor lock-in (a growing concern).
+The Nitro shared-foundation angle is Litro's strongest credibility signal; this post
+makes it concrete.
+
+Outline:
+- What Nitro is: the server engine behind Nuxt, Analog, and Litro
+- What a "preset" is: a self-contained output target that rewrites the server for a
+  specific runtime
+- Available presets: `node`, `vercel`, `cloudflare-workers`, `deno-deploy`, `aws-lambda`,
+  `netlify`, static, and more
+- How Litro uses them: `NITRO_PRESET=cloudflare-workers litro build` — no custom code
+- Edge-specific considerations: `externals.inline: ['@lit-labs/ssr']`, Node vs Workers
+  streaming API differences
+- Comparison: Next.js is Vercel-optimized (adapters exist but are community-maintained);
+  Litro's adapters are Nitro's adapters, which are first-party and used by Nuxt
+- Internal links: `/compare/nuxt`, `/docs/deployment/coolify`, `/docs/deployment/github-pages`
+
+---
+
+### Post 7: LitroRouter — A URLPattern Router for Web Components
+**Publish:** Phase 3, Week 7
+**Target keyword:** "URLPattern router," "web component router," "client-side routing
+web components"
+**Why:** Introduces `@beatzball/litro-router` as a standalone package. Targets developers
+who want a client-side router for Lit components without the full framework.
+
+Outline:
+- Why client-side routing in web components requires care (window/history access, shadow
+  DOM subtree management, SSR safety)
+- The URLPattern API: native browser routing, Baseline Sep 2025
+- LitroRouter's design decisions: no global `<a>` click interceptor (deliberate), `<litro-link>`
+  for SPA navigation, pushState only
+- Code: setting up routes, `onBeforeEnter(location: LitroLocation)`, params
+- Shadow DOM scroll-to-hash after navigation — the `_findDeep()` recursive traversal
+- Using `@beatzball/litro-router` standalone, without Litro (it's a zero-dependency package)
+- Internal links: `/docs/core-concepts/client-router`, `/docs/litro-router`
+
+---
+
+### Post 8: Litro vs Next.js vs Nuxt.js — Hello World Performance Comparison
+**Publish:** Phase 3, Week 8 — only after framework is stable and numbers are verified
+**Target keyword:** "Next.js bundle size comparison," "web framework performance 2026,"
+"smallest JavaScript framework"
+**Why last:** This is the most backlink-worthy post if done right — and the most damaging
+if methodology is sloppy or numbers are challenged. Publish only when:
+  1. The framework is past v1.0 and not undergoing significant changes
+  2. A reproducible test setup exists (public GitHub repo, documented methodology)
+  3. The numbers have been verified by at least one person other than the author
+
+Outline:
+- Methodology: identical "Hello World" page, cold start, measured with Lighthouse +
+  `source-map-explorer`; link to reproducible test repo
+- Metrics: JS transferred (gzipped), JS parsed, TTFB, FCP, LCP, TBT, Lighthouse score
+- Results table: Next.js 15, Nuxt 3, SvelteKit, Astro (static), Litro
+- Why Litro wins on bundle size: no virtual DOM library, no framework runtime, Lit is 6kB
+- Where Litro doesn't win: ecosystem maturity (name it honestly)
+- What the bundle difference means in practice: parse time on low-end mobile, Core Web
+  Vitals score impact
+- "Run these benchmarks yourself" — link to the test repo
+- Internal links: `/compare/nextjs`, `/compare/nuxt`, `/why-web-components`
+
+---
+
+## Content Standards
+
+### Frontmatter requirements (all posts)
+
+```yaml
+---
+title: "..."           # 50–60 characters; include the primary keyword
+description: "..."     # 120–160 characters; includes primary keyword; benefit-oriented
+date: YYYY-MM-DD
+tags: [tag1, tag2]     # 2–4 tags; used by blog index and RSS feed
+---
+```
+
+### Post structure
+
+- No fluffy introductions. First paragraph states the problem or the conclusion.
+- At least one working, verified code example per post.
+- End every post with a CTA linking to one of: `/docs/getting-started`, a comparison page,
+  or a related migration guide.
+- Avoid "In this post we will..." constructions.
+- Acknowledge trade-offs honestly — developer audiences distrust marketing language.
+
+### Internal linking
+
+Every post must link to 2–3 of:
+- A relevant docs page
+- A comparison page (once live)
+- A related blog post (once 3+ posts exist)
+
+### Length
+
+- Technical explainers (Posts 1–4, 6–8): 1,200–2,500 words + code
+- Tutorials (Post 5): 800–1,500 words + code
+
+Longer is fine if the content earns it. Padding for word count is not.
+
+---
+
+## Publication Schedule
+
+| Post | Phase | Promoted To |
+|------|-------|------------|
+| Post 1: Shadow DOM SEO | Phase 1, Week 1 | Dev.to, r/webdev, Lit Discord |
+| Post 2: Why We Built Litro | Phase 1, Week 2 | Hacker News Show HN |
+| Post 3: File-Based Routing | Phase 2, Week 3 | Dev.to, r/javascript |
+| Post 4: Streaming SSR | Phase 2, Week 4 | Dev.to, r/webdev |
+| Post 5: Blog Tutorial | Phase 2, Week 5 | Dev.to tutorials, r/webdev |
+| Post 6: Nitro Adapters | Phase 3, Week 6 | r/javascript, Nuxt Discord |
+| Post 7: LitroRouter | Phase 3, Week 7 | r/webcomponents, Lit Discord |
+| Post 8: Performance | Phase 3, Week 8+ | r/webdev, JavaScript Weekly |
+
+---
+
+## Acceptance Criteria (initial batch)
+
+- [ ] Posts 1–5 published before Phase 3 community distribution begins
+- [ ] Every post has `title`, `description`, `date`, `tags` frontmatter
+- [ ] Every post is syntax-highlighted (blog `[slug].ts` handles this via `applyHighlighting`)
+- [ ] Every post links to at least one comparison page or docs page
+- [ ] All post slugs appear in the dynamic `/sitemap.xml` automatically (handled by PRD-1)
+- [ ] OG tags on each post use the post's specific `title` and `description`
+- [ ] Post 8 (benchmarks) is NOT published until methodology is reproducible and verified

--- a/seo-prd/PRD-4-npm-discovery.md
+++ b/seo-prd/PRD-4-npm-discovery.md
@@ -1,0 +1,250 @@
+# PRD-4: npm Package & Developer Discovery
+
+**Priority:** P1
+**Effort:** 0.5 days
+**Phase:** 1 (run in parallel with PRD-1 and first two blog posts)
+**Dependencies:** None — purely additive changes, no code impact
+
+---
+
+## Problem
+
+Developers discover JavaScript tools through two channels before ever visiting a project
+website: npm search and GitHub. Litro is currently under-optimized for both:
+
+- `keywords` arrays in all three `package.json` files are minimal or missing
+- `description` fields are short and contain no comparison hooks
+- `packages/framework/README.md` is 46 lines with no Hello World example, no comparison
+  context, and no answer to the "will this hurt my SEO?" concern
+- The GitHub repository has no topics/tags set — it does not appear in GitHub's "Explore"
+  results for `web-components`, `ssr`, `lit`, or `nitro`
+- The monorepo root `README.md` (GitHub landing page) may not exist or may be sparse
+
+These are free wins that take effect within 24–48 hours of the next publish/push.
+
+---
+
+## Goals
+
+1. All three packages appear in npm search results for target keywords.
+2. A developer landing on any npm package page can understand what Litro solves and
+   get started in under 60 seconds.
+3. The GitHub repository appears in Explore results for `lit`, `web-components`, `ssr`,
+   `ssg`, and `nitro`.
+4. The root README serves as a compelling landing page for developers who find the
+   repository directly.
+
+---
+
+## Changes Required
+
+### 1. `packages/framework/package.json`
+
+**Updated description:**
+
+```json
+"description": "Fullstack web framework for Lit components — file-based routing, streaming SSR, SSG, and Nitro deployment adapters. A standards-based Next.js / Nuxt.js alternative."
+```
+
+**Updated keywords:**
+
+```json
+"keywords": [
+  "lit",
+  "web-components",
+  "ssr",
+  "ssg",
+  "static-site-generation",
+  "server-side-rendering",
+  "fullstack",
+  "framework",
+  "nitro",
+  "vite",
+  "file-based-routing",
+  "declarative-shadow-dom",
+  "nextjs-alternative",
+  "nuxt-alternative",
+  "typescript"
+]
+```
+
+---
+
+### 2. `packages/litro-router/package.json`
+
+**Updated description:**
+
+```json
+"description": "Client-side router for Lit web components. Built on the native URLPattern API. Zero dependencies. Works standalone or as part of the Litro framework."
+```
+
+**Updated keywords:**
+
+```json
+"keywords": [
+  "router",
+  "client-side-routing",
+  "urlpattern",
+  "web-components",
+  "lit",
+  "lit-element",
+  "spa",
+  "history-api",
+  "custom-elements",
+  "zero-dependencies",
+  "typescript"
+]
+```
+
+---
+
+### 3. `packages/create-litro/package.json`
+
+**Updated description:**
+
+```json
+"description": "Scaffold a new Litro app — fullstack SSR, Markdown blog, or docs site. Built on Lit web components and Nitro server."
+```
+
+**Updated keywords:**
+
+```json
+"keywords": [
+  "create",
+  "scaffold",
+  "cli",
+  "lit",
+  "web-components",
+  "fullstack",
+  "ssr",
+  "ssg",
+  "nitro",
+  "starter",
+  "template",
+  "typescript"
+]
+```
+
+---
+
+### 4. `packages/framework/README.md` — Expand
+
+The current 46-line README should be expanded with three additions:
+
+#### Addition 1: Hello World Example
+
+Place after the features list, before any package table.
+
+```typescript
+// pages/index.ts
+import { LitroPage, definePageData, html } from '@beatzball/litro/runtime';
+import { customElement } from 'lit/decorators.js';
+
+const pageData = definePageData(async () => ({
+  message: 'Hello from the server!',
+}));
+
+@customElement('page-index')
+export default class IndexPage extends LitroPage {
+  override render() {
+    const data = this.serverData as typeof pageData | null;
+    return html`<h1>${data?.message}</h1>`;
+  }
+}
+```
+
+#### Addition 2: How It Compares
+
+```markdown
+## How It Compares
+
+|                    | Litro       | Next.js     | Nuxt.js     |
+|--------------------|-------------|-------------|-------------|
+| Component model    | Lit         | React       | Vue         |
+| File-based routing | ✓           | ✓           | ✓           |
+| SSR / SSG          | ✓           | ✓           | ✓           |
+| Server engine      | Nitro       | custom      | Nitro       |
+| Hello World JS     | ~8kB        | ~90kB       | ~60kB       |
+| Virtual DOM        | —           | ✓           | ✓           |
+| W3C components     | ✓           | —           | —           |
+
+[Full comparison →](https://litro.dev/compare/nextjs)
+```
+
+#### Addition 3: SEO Callout
+
+```markdown
+## SEO
+
+Litro renders all pages server-side via Declarative Shadow DOM before sending HTML to the
+browser. Search engines receive fully-rendered content — the same approach used by Next.js
+and Nuxt.js. Client-side-only web components have SEO limitations; Litro's SSR eliminates
+them by default.
+
+[How this works →](https://litro.dev/blog/shadow-dom-seo)
+```
+
+(The blog link can be added once Post 1 from PRD-3 is published.)
+
+---
+
+### 5. Root `README.md`
+
+The monorepo root `README.md` is the GitHub landing page for the repository. It should be
+short, focused, and link out to the docs site rather than duplicating it.
+
+Required sections:
+
+1. **One-sentence pitch** — "Litro is a fullstack web framework built on Lit web components,
+   Nitro server, and Vite."
+2. **How It Compares table** — same as the framework README addition above
+3. **Quick start** — `npm create @beatzball/litro@latest`
+4. **Links** — Documentation, Packages, Playground, Contributing
+5. **Badges** — License, npm version (for `@beatzball/litro`), build status if CI exists
+
+Keep the root README under 100 lines. Its job is to orient a first-time visitor and route
+them to the right place, not to be a documentation mirror.
+
+---
+
+### 6. GitHub Repository Topics
+
+Set via the repository Settings page (or via the GitHub API). Target topics:
+
+```
+lit
+web-components
+ssr
+ssg
+server-side-rendering
+nitro
+vite
+typescript
+fullstack
+framework
+```
+
+GitHub's Explore feature surfaces repositories tagged with these topics to developers
+who have starred or contributed to similar repos. This is free passive discovery.
+
+---
+
+## npm Search Ranking Notes
+
+npm ranks packages by: keyword match in `keywords` array (highest weight), keyword in
+`description` (medium), download count (trust signal), and recency.
+
+The `keywords` and `description` changes take effect within 24 hours of the next
+`npm publish`. They cost nothing and require zero code changes.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 3 `package.json` files have updated `description` and `keywords`
+- [ ] `packages/framework/README.md` includes Hello World example, comparison table, and
+      SEO callout
+- [ ] Root `README.md` exists with pitch, comparison table, quick start, and links
+- [ ] GitHub repository topics set (10 topics listed above)
+- [ ] Changes published in the next npm release for all 3 packages
+- [ ] npm search for "lit ssr framework" returns `@beatzball/litro` (verify 24–48h after publish)

--- a/seo-prd/PRD-5-community-distribution.md
+++ b/seo-prd/PRD-5-community-distribution.md
@@ -1,0 +1,280 @@
+# PRD-5: Community & Content Distribution
+
+**Priority:** P2
+**Effort:** Ongoing — each distribution cycle is 1–2 hours per post
+**Phase:** 3 (after PRD-1 is deployed and at least 3 blog posts are live)
+**Dependencies:** PRD-1 deployed (for correct indexing signals); PRD-3 Posts 1–3 published
+
+---
+
+## Problem
+
+SEO without distribution is slow. Google's ranking algorithm weighs backlinks and engagement
+signals. A technically perfect site with zero inbound links will still rank poorly for
+competitive queries.
+
+The web components and JavaScript framework communities are active and reachable — Litro
+needs to meet them where they are. The Lit community in particular is a pre-qualified
+audience: they already use Lit, they already believe in web components, and they are
+actively looking for a batteries-included framework around it.
+
+---
+
+## Goals
+
+1. Each blog post reaches its target developer audience within 48 hours of publication.
+2. Litro earns at least 5 organic backlinks from non-trivial developer sites within 90 days.
+3. GitHub repository reaches 100 stars within 90 days.
+4. Litro is listed in the Lit ecosystem, awesome-lit, and awesome-web-components — all
+   of which are actively maintained lists that developers browse.
+
+---
+
+## Distribution Channels (in priority order)
+
+### 1. Lit Ecosystem — Week 1, Before Anything Else
+
+The Lit community is the most receptive possible first audience. These developers are
+already sold on web components; Litro just needs to show them there's a batteries-included
+framework for it.
+
+**Actions (do these in Phase 1, not Phase 3):**
+
+- Post in Lit Discord `#showcase` channel — short description, link to litro.dev, mention
+  that it uses `@lit-labs/ssr` with DSD
+- Open a PR to add `@beatzball/litro` to the `awesome-lit` GitHub list (if it exists and
+  accepts framework entries)
+- Open a PR to add `@beatzball/litro` to `awesome-web-components` GitHub list
+- If the Lit team maintains a "built with Lit" page or showcase, submit Litro there
+
+These cost 30 minutes and reach exactly the right audience. Do this before any Reddit or
+HN activity.
+
+---
+
+### 2. Dev.to — Starting Phase 3
+
+Dev.to has an active web components and Lit community. The canonical URL mechanism means
+cross-posting does NOT create duplicate content penalties — the original litro.dev URL
+remains the indexed version.
+
+**How to cross-post:**
+1. Create a `beatzball` organization on Dev.to
+2. For each post: publish the full content with `canonical_url: https://litro.dev/blog/<slug>`
+   set in the Dev.to editor
+3. Wait 24 hours after publishing on litro.dev before cross-posting (gives Google time to
+   index the canonical URL first)
+4. Respond to every comment within 24 hours
+
+**Post-to-tag mapping:**
+
+| Post | Dev.to Tags |
+|------|------------|
+| Shadow DOM SEO | `#webcomponents #seo #javascript` |
+| Why We Built Litro | `#webcomponents #javascript #showdev` |
+| File-Based Routing | `#nextjs #webcomponents #javascript` |
+| Streaming SSR | `#webcomponents #performance #ssr` |
+| Blog Tutorial | `#tutorial #webcomponents #ssg` |
+| Nitro Adapters | `#javascript #devops #webcomponents` |
+| LitroRouter | `#webcomponents #javascript #opensource` |
+| Performance | `#performance #javascript #nextjs` |
+
+---
+
+### 3. Reddit — Starting Phase 3
+
+**Target subreddits:**
+
+| Subreddit | Audience | Post Types |
+|-----------|----------|------------|
+| r/webdev | General web devs | Framework introduction, tutorials |
+| r/javascript | JS developers | Technical explainers, architecture posts |
+| r/webcomponents | Web component enthusiasts | All posts |
+| r/reactjs | React developers | "From React to Lit" post only — approach carefully |
+
+**Rules:**
+- Space out posts across subreddits — never the same content to multiple subreddits
+  simultaneously
+- Title the Reddit post differently from the blog post (Reddit rewards curiosity gaps)
+- Include a brief TL;DR in the post body; link is insufficient
+- r/reactjs: lead with "I built a thing" not "React is bad." The community is defensive
+  about comparisons. The post about migrating from React should acknowledge React's
+  strengths, not attack them.
+- Respond to every comment within the first 4 hours (Reddit algorithm rewards early
+  engagement)
+
+**Initial high-priority post:** After 3 posts are live, post a "Show Reddit: I built a
+fullstack framework combining Lit web components and Nitro" introduction to r/webdev.
+Lead with the "why" — the standards longevity argument — and link to the homepage. This
+is a brand introduction, not a content post.
+
+**Best posting time:** Tuesday–Thursday, 9am–12pm EST.
+
+---
+
+### 4. Hacker News — Phase 3, after Show Reddit succeeds
+
+HN front-page appearances generate hundreds of high-authority backlinks. It is also the
+community most likely to engage substantively with the "why we built this" architectural
+argument.
+
+**Show HN post** — the primary HN play:
+
+```
+Show HN: Litro – fullstack web framework built on Lit web components and Nitro
+
+We built Litro because we wanted Next.js-style file-based routing and SSR but with native
+web components (Lit) instead of React.
+
+It uses the same Nitro server as Nuxt.js, so all deployment adapters (Vercel, Cloudflare
+Workers, AWS Lambda, etc.) work out of the box. For SSR, it uses @lit-labs/ssr with
+Declarative Shadow DOM — the same technique that makes React SSR SEO-friendly, but for
+standards-based components.
+
+Would love feedback on the DX and any questions about the architecture.
+
+[link to litro.dev]
+```
+
+**When to post:** After 5+ blog posts are live and the docs are solid. HN rewards substance.
+Post on a weekday, 9–10am EST.
+
+**Other HN activity:**
+- Comment on existing threads about web components, Next.js alternatives, or Nitro with
+  a genuine contribution and a mention of Litro where relevant. Not link-dropping — only
+  where Litro is directly applicable.
+- Submit the "Why We Built Litro" post as an article link (not Show HN) after it's published.
+
+---
+
+### 5. Twitter / X — Phase 3 only, low priority
+
+Useful for distribution once content exists. Not worth investing time in before Phase 3.
+
+Follow and engage with:
+- `@buildWithLit` (Lit team)
+- `@pi0` (Nitro/Nuxt author — Litro is built on his work; engaging here is authentic)
+- Web components community accounts
+
+**Content types:**
+- Code snippets: comparison "Next.js vs Litro side by side" screenshots
+- Announcements of new blog posts
+- Facts about DSD / architecture
+
+No engagement-bait. Developer Twitter rewards technical depth.
+
+---
+
+### 6. Newsletter Outreach — Phase 3, opportunistic
+
+Reach out only when you have something genuinely newsletter-worthy (a post with strong
+Dev.to engagement is a credible signal). Do not mass-email.
+
+| Newsletter | Audience | What to Submit |
+|-----------|----------|---------------|
+| JavaScript Weekly | General JS devs | Blog post or Show HN link |
+| Web Components Weekly | WC enthusiasts | Framework announcement |
+| Bytes.dev | Frontend devs | Comparison post or tutorial |
+| This Week in Lit | Lit ecosystem | Direct submission to Lit team |
+| UnJS Discord | Nitro/UnJS users | `#showcase` — Litro is a Nitro consumer |
+
+The UnJS/Nitro Discord is particularly valuable because Litro is a legitimate Nitro
+consumer. Posting in `#showcase` is not self-promotion — it's relevant to the community.
+
+---
+
+### 7. Earned Backlinks — Ongoing, No Outreach Needed
+
+The following links can be earned without asking anyone:
+
+1. **awesome-lit GitHub list** — open a PR to add `@beatzball/litro` (do this in Phase 1)
+2. **awesome-web-components GitHub list** — same, open a PR
+3. **Lit's "built with Lit" showcase** (if it exists) — submit directly
+4. **Nitro's ecosystem list** — submit as a Nitro-based framework
+5. **"Alternatives to Next.js/Nuxt.js" articles** — search for existing articles once
+   Litro has 100+ GitHub stars; reaching out before that will be ignored
+
+Do NOT chase roundup articles before the framework has enough traction to be taken
+seriously. A rejection at this stage closes the door for later. Wait.
+
+---
+
+## Roundup Outreach — Explicitly Deferred
+
+The original recommendation to pitch Litro for "alternatives to Next.js" roundup articles
+is deferred until:
+- GitHub stars ≥ 200
+- npm weekly downloads showing consistent growth
+- At least 2 positive HN/Reddit threads on record
+
+Authors of "best alternatives to Next.js" articles need social proof before they will
+include an unknown project. Pitching too early wastes the contact and may result in a
+permanent no.
+
+---
+
+## Google Search Console Setup
+
+This is a prerequisite for all distribution measurement. Do this in Phase 1.
+
+1. Add `litro.dev` as a property in Google Search Console
+2. Verify via DNS TXT record (preferred) or HTML file in `/docs/public/`
+3. Submit `https://litro.dev/sitemap.xml`
+4. Use URL Inspection to manually request indexing for the homepage and any high-priority
+   new pages immediately after they go live
+5. Check the Coverage report weekly for the first month for crawl errors
+
+---
+
+## Timing Summary
+
+```
+Phase 1 (now):
+  - Google Search Console setup
+  - Lit Discord #showcase post
+  - awesome-lit and awesome-web-components PRs
+  - UnJS/Nitro Discord #showcase
+
+Phase 3 (after 3+ blog posts live):
+  - Dev.to cross-posts for Posts 1–3
+  - r/webdev introduction post
+  - Dev.to cross-posts for Posts 4–5 as they publish
+
+Phase 3 (after Show Reddit traction):
+  - Hacker News Show HN submission
+  - JavaScript Weekly / Web Components Weekly outreach
+
+Ongoing (per post):
+  - Dev.to cross-post (24h after litro.dev publish)
+  - Relevant subreddit post
+  - Twitter announcement
+```
+
+---
+
+## Metrics to Track
+
+| Metric | Tool | Frequency |
+|--------|------|-----------|
+| Organic impressions | Google Search Console | Weekly |
+| CTR by page | Google Search Console | Weekly |
+| Indexed page count | Google Search Console | Weekly |
+| GitHub stars | GitHub | Weekly |
+| npm weekly downloads | npmtrends.com | Monthly |
+| Dev.to views + reactions | Dev.to dashboard | Per post |
+| Reddit upvotes / comments | Reddit | Per post |
+| Referring domains (backlinks) | Google Search Console | Monthly |
+
+---
+
+## Acceptance Criteria
+
+- [ ] Google Search Console set up and sitemap submitted (Phase 1)
+- [ ] Lit Discord `#showcase` post published (Phase 1)
+- [ ] PR opened to `awesome-lit` (Phase 1)
+- [ ] PR opened to `awesome-web-components` (Phase 1)
+- [ ] Dev.to organization created for beatzball (Phase 3)
+- [ ] Posts 1–3 cross-posted to Dev.to with canonical URLs (Phase 3)
+- [ ] Introduction post published to r/webdev (Phase 3)
+- [ ] Show HN submitted (Phase 3, after 5+ posts live)
+- [ ] Roundup outreach deferred until GitHub stars ≥ 200


### PR DESCRIPTION
## Summary

- **Framework**: `create-page-handler` now extracts `seoHead` and `seoTitle` from `definePageData()` results and injects them into the HTML `<head>` — previously they were buried in the `__litro_data__` JSON blob and invisible to crawlers
- **Docs**: dynamic XML sitemap (`/sitemap.xml`) with blog post `<lastmod>` dates, RSS 2.0 feed (`/blog/rss.xml`), JSON-LD structured data on every page type (SoftwareApplication / TechArticle / BlogPosting), `noindex` on tag pages, RSS `<link rel="alternate">` in every page head
- **Content**: two new blog posts — "Shadow DOM and SEO" and "Why We Built Litro"
- **npm discovery**: updated descriptions and keywords for all three packages; rewrote `packages/framework/README.md`; added comparison table to root `README.md`
- **Tests**: 84 new unit tests across `create-page-handler`, `seo.ts`, `sitemap.xml`, and `rss.xml`

## Changed packages

| Package | Bump | Reason |
|---|---|---|
| `@beatzball/litro` | minor | New `seoHead`/`seoTitle` injection in `create-page-handler` |
| `@beatzball/litro-router` | patch | Description + keyword improvements |
| `@beatzball/create-litro` | patch | Description + keyword improvements |

## Technical notes

- **Sitemap/RSS as dedicated server routes**: `pages/sitemap.xml.ts` would route through the catch-all H3 handler and produce HTML (not XML). `docs/server/routes/sitemap.xml.ts` takes priority over the catch-all, allowing raw XML responses with correct content-type headers. Same for RSS.
- **`/blog/rss.xml` prerendering**: added explicitly to `prerender.routes` — `crawlLinks` does not reliably follow `<link rel="alternate">` tags.
- **seoHead concatenation**: `staticHead + dynamicHead` — static (routeMeta) comes first; an empty result (`'' || undefined`) passes `undefined` to `buildShell` rather than an empty string.

## Test plan

- [x] `pnpm --filter @beatzball/litro test` — 209 tests pass (13 new)
- [x] `pnpm test:docs` — 97 tests pass (71 new)
- [ ] Verify sitemap and RSS render correctly at `/sitemap.xml` and `/blog/rss.xml` in production build
- [ ] Confirm JSON-LD appears in `<head>` (not inside `__litro_data__`) via view-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)