### PR TITLE
fix(shell): escape </script in serverDataJson to prevent early script termination

### DIFF
--- a/.changeset/fix-json-script-escape.md
+++ b/.changeset/fix-json-script-escape.md
@@ -1,0 +1,13 @@
+---
+"@beatzball/litro": patch
+---
+
+fix(shell): escape `</script` in serverDataJson to prevent early script tag termination
+
+When page data contains rendered HTML (e.g. a CHANGELOG entry that mentions `</script>` in a
+code span), the HTML parser terminates the `<script type="application/json">` element early at
+the first literal `</script` sequence. This corrupts the embedded JSON, causing `getServerData()`
+to return null and the page to render with no server data.
+
+Fixed by replacing `</script` with `<\/script` in the JSON string before embedding it in the
+HTML shell. JSON parsers treat `\/` as `/`, so the data round-trips correctly.

--- a/e2e/playground-11ty/content.spec.ts
+++ b/e2e/playground-11ty/content.spec.ts
@@ -33,8 +33,10 @@ test('blog post renders title', async ({ page }) => {
 test('blog post has rendered HTML body', async ({ page }) => {
   await page.goto('/blog/hello-world');
   await page.waitForSelector('page-blog-slug');
-  // The post body is inside shadow DOM — use evaluate to reach shadow root text
-  const text = await page.locator('page-blog-slug').evaluate(
+  // The post body is inside shadow DOM — use evaluate to reach shadow root text.
+  // Use .first() to avoid a strict-mode violation during the router's atomic
+  // DOM swap, when a hidden new element briefly coexists with the SSR'd one.
+  const text = await page.locator('page-blog-slug').first().evaluate(
     el => (el.shadowRoot?.textContent ?? '').trim(),
   );
   expect(text.length).toBeGreaterThan(0);

--- a/packages/framework/src/runtime/__tests__/shell.test.ts
+++ b/packages/framework/src/runtime/__tests__/shell.test.ts
@@ -137,6 +137,21 @@ describe('buildShell — head: serverDataJson', () => {
     expect(head).toContain('type="application/json"');
   });
 
+  it('escapes </script sequences in the JSON to prevent early script termination', () => {
+    // If page data (e.g. rendered CHANGELOG HTML) contains </script, the HTML
+    // parser would terminate the <script type="application/json"> element early,
+    // corrupting the JSON and causing getServerData() to return null.
+    // The fix: replace </script with <\/script (valid JSON escape, safe in HTML).
+    const json = JSON.stringify({ html: '<code>&lt;/script&gt;</code>', raw: '</script>' });
+    const { head } = buildDefault('page-home', { serverDataJson: json });
+    // Must not contain the literal </script sequence inside the data element
+    const dataScript = head.match(/<script type="application\/json"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? '';
+    expect(dataScript).not.toMatch(/<\/script/i);
+    // Must still be parseable JSON that round-trips correctly
+    const parsed = JSON.parse(dataScript) as { html: string; raw: string };
+    expect(parsed.raw).toBe('</script>');
+  });
+
   it('the data script appears inside <head> (before </head>)', () => {
     const { head } = buildDefault('page-home', { serverDataJson: '{"x":1}' });
     const dataIdx = head.indexOf('__litro_data__');

--- a/packages/framework/src/runtime/shell.ts
+++ b/packages/framework/src/runtime/shell.ts
@@ -109,8 +109,14 @@ export function buildShell(
   const title = options?.title ?? 'Litro';
   const extraHead = options?.head ?? '';
   const bodyAttrs = options?.bodyAttrs ? ` ${options.bodyAttrs}` : '';
+  // Escape </script sequences so the HTML parser does not terminate the
+  // <script type="application/json"> element early. This happens when page
+  // data includes rendered HTML (e.g. CHANGELOG entries mentioning </script>
+  // in code spans). JSON parsers treat \/ as /, so the data round-trips
+  // correctly: JSON.parse('<\/script>') === '</script>'.
+  const safeJson = options?.serverDataJson?.replace(/<\/script/gi, '<\\/script') ?? '';
   const serverDataScript = options?.serverDataJson
-    ? `\n  <script type="application/json" id="__litro_data__">${options.serverDataJson}</script>`
+    ? `\n  <script type="application/json" id="__litro_data__">${safeJson}</script>`
     : '';
   const appScriptUrl = options?.appScriptUrl ?? '/_litro/app.js';
 


### PR DESCRIPTION
## Summary

- **Root cause**: `packages/framework/CHANGELOG.md` contains a code span with `` `</script>` `` (added in #39). When rendered to HTML and JSON-stringified into `<script type="application/json" id="__litro_data__">`, the HTML parser sees the literal `</script` byte sequence and terminates the script element early — corrupting the embedded JSON. `getServerData()` returns null, `serverData` stays null, and the component renders "Loading…" with no shadow DOM content. This caused all 7 `/docs/packages/litro` e2e tests to fail.
- **Fix** (`shell.ts`): replace `</script` with `<\/script` in the JSON string before embedding. JSON parsers treat `\/` as `/`, so values round-trip correctly.
- **Flaky fix** (`content.spec.ts`): add `.first()` to the `page-blog-slug` locator to avoid Playwright strict-mode violations during the router's atomic DOM swap (two elements briefly coexist).

## Changes

- `packages/framework/src/runtime/shell.ts` — escape `</script` sequences in `serverDataJson` before embedding
- `packages/framework/src/runtime/__tests__/shell.test.ts` — new test verifying the escaping and round-trip correctness
- `e2e/playground-11ty/content.spec.ts` — add `.first()` to flaky locator
- `.changeset/fix-json-script-escape.md` — patch changeset for `@beatzball/litro`

## Test plan

- [x] `pnpm --filter @beatzball/litro test` — all shell unit tests pass (including new escape test)
- [x] `pnpm test:e2e` — all 32 e2e tests pass (no more `/docs/packages/litro` failures, no flaky blog-slug test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)