### PR TITLE
fix(changeset): remove private docs package from mixed changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@beatzball/litro-docs"]
 }

--- a/.changeset/seo-phase-2.md
+++ b/.changeset/seo-phase-2.md
@@ -1,5 +1,4 @@
 ---
-'@beatzball/litro-docs': minor
 '@beatzball/litro': patch
 ---
 


### PR DESCRIPTION
## Summary

- Removes `@beatzball/litro-docs: minor` from `.changeset/seo-phase-2.md` — it's a private package and changesets automatically treats it as ignored, so mixing it with a non-private package (`@beatzball/litro`) fails with _"Mixed changesets that contain both ignored and not ignored packages are not allowed"_
- Adds `@beatzball/litro-docs` to the explicit `ignore` list in `.changeset/config.json` to prevent the same mistake in future changesets

## Root cause

`@beatzball/litro-docs` has `"private": true` in its `package.json`. Changesets silently treats private packages as ignored. The `seo-phase-2` changeset included it alongside `@beatzball/litro`, which triggered the CI failure on the release job.

## Test plan

- [ ] CI release job (`changesets/action`) passes on merge
- [ ] `pnpm version-packages` runs locally without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)