### PR TITLE
feat(docs): SEO Phase 3 — blog posts 6-7, README updates, blog highlighting fix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,8 @@ litro/                          ← Git repo root (pnpm workspace root)
     src/seo.ts                  ← buildSeoHead() helper for per-page meta tags
     public/.nojekyll            ← Required for GitHub Pages
   .github/workflows/
-    docs.yml                    ← GitHub Actions: build + deploy docs to GitHub Pages
+    ci.yml                      ← GitHub Actions: test, build, dependency audit on PRs
+    release.yml                 ← GitHub Actions: publish packages to npm via Changesets
   package.json                  ← Workspace root (private, no deps)
   pnpm-workspace.yaml
   tsconfig.json

--- a/README.md
+++ b/README.md
@@ -50,9 +50,56 @@ litro/
 
 ---
 
-## Quick start — scaffold a new app (local)
+## Quick start — scaffold a new app
 
-**Step 1 — build the framework and scaffolder from source:**
+```bash
+# npm
+npm create @beatzball/litro@latest my-app
+
+# pnpm
+pnpm create @beatzball/litro my-app
+
+# yarn
+yarn create @beatzball/litro my-app
+
+# bun
+bun create @beatzball/litro my-app
+
+# deno
+deno create npm:@beatzball/litro@latest -- my-app
+```
+
+Follow the interactive prompts to choose a recipe and rendering mode, or pass flags to skip them:
+
+```bash
+# Non-interactive — fullstack SSR app:
+npm create @beatzball/litro@latest my-app -- --recipe fullstack --mode ssr
+
+# Non-interactive — 11ty-compatible Markdown blog, static output:
+npm create @beatzball/litro@latest my-app -- --recipe 11ty-blog --mode ssg
+
+# Non-interactive — Starlight docs + blog, static output:
+npm create @beatzball/litro@latest my-docs -- --recipe starlight
+
+# List all available recipes:
+npm create @beatzball/litro@latest -- --list-recipes
+```
+
+Then:
+
+```bash
+cd my-app
+pnpm install
+pnpm dev           # dev server on http://localhost:3030
+pnpm build         # Stage 0: page scan → Stage 1: vite build → Stage 2: nitro build
+pnpm preview       # preview the production build
+```
+
+---
+
+## Quick start — from source (monorepo contributors)
+
+**Step 1 — build the framework and scaffolder:**
 
 ```bash
 git clone <this-repo> litro
@@ -63,7 +110,7 @@ pnpm --filter @beatzball/litro build          # compiles packages/framework → 
 pnpm --filter @beatzball/create-litro build   # compiles packages/create-litro → dist/
 ```
 
-**Step 2 — scaffold your app:**
+**Step 2 — scaffold your app from the local build:**
 
 ```bash
 cd /path/to/your/projects
@@ -272,10 +319,14 @@ Litro delegates all deployment to Nitro's adapter system. Set `NITRO_PRESET` or 
 
 | Target                | Preset                            |
 | --------------------- | --------------------------------- |
-| Node.js server        | `node-server` (default)           |
+| Node.js server        | `node` (default)                  |
 | Cloudflare Workers    | `cloudflare-workers`              |
-| Vercel Edge           | `vercel-edge`                     |
-| Netlify Edge          | `netlify-edge`                    |
+| Cloudflare Pages      | `cloudflare-pages`                |
+| Vercel                | `vercel`                          |
+| Netlify               | `netlify`                         |
+| AWS Lambda            | `aws-lambda`                      |
+| Deno Deploy           | `deno-deploy`                     |
+| Bun                   | `bun`                             |
 | Static / GitHub Pages | `static` (or `LITRO_MODE=static`) |
 
 See [Nitro deployment docs](https://nitro.unjs.io/deploy) for the full list.
@@ -408,7 +459,8 @@ pnpm --filter @beatzball/litro build            # compile framework (required on
 pnpm --filter @beatzball/litro-router test      # run router unit tests (16 tests)
 pnpm --filter @beatzball/litro test             # run framework unit tests (196 tests)
 pnpm --filter @beatzball/create-litro test      # run scaffolding tests (17 tests)
-pnpm test:e2e                                   # Playwright e2e tests (32 tests, 3 playgrounds)
+pnpm test:docs                                  # run docs unit tests (97 tests)
+pnpm test:e2e                                   # Playwright e2e tests (32 tests, 4 projects: playground/11ty/starlight/docs)
 pnpm --filter @beatzball/litro dev              # watch-compile framework
 
 # Playgrounds

--- a/docs/content/blog/litro-router-urlpattern.md
+++ b/docs/content/blog/litro-router-urlpattern.md
@@ -1,0 +1,246 @@
+---
+title: "LitroRouter — A URLPattern Router for Web Components"
+description: "LitroRouter is a zero-dependency client-side router for Lit components built on the URLPattern API. This post covers the design decisions, the API, shadow DOM scroll-to-hash, and how to use it standalone without the full Litro framework."
+date: 2026-03-22
+tags: [router, urlpattern, web-components, client-side-routing]
+---
+
+# LitroRouter — A URLPattern Router for Web Components
+
+Client-side routing in web components has a few requirements that generic routers don't always handle well: the router must never execute server-side (no `window` or `history` access at module evaluation time), navigation must work across shadow DOM boundaries, and scroll-to-hash needs to find elements inside shadow roots — not just in the light DOM.
+
+`@beatzball/litro-router` is a zero-dependency router built on the URLPattern API that addresses all three. It ships as a standalone package so you can use it with Lit components without adopting the full Litro framework.
+
+## The URLPattern API
+
+[URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) is a web platform API for matching URLs against patterns. It reached Baseline in September 2025 — available in Chrome, Firefox, and Safari without a polyfill.
+
+```ts
+const pattern = new URLPattern({ pathname: '/blog/:slug' });
+pattern.test({ pathname: '/blog/hello-world' }); // true
+pattern.exec({ pathname: '/blog/hello-world' })?.pathname.groups; // { slug: 'hello-world' }
+```
+
+URLPattern handles the same patterns as path-to-regexp — dynamic segments (`:param`), catch-alls (`:slug*`), optional params — but as a native browser API rather than a library dependency.
+
+LitroRouter converts Litro's h3-style path format (`:param(.*)*` for catch-alls) to URLPattern format (`:param*`) at route registration time. If you're using the router standalone, you can use either format.
+
+## Installing Standalone
+
+```bash
+npm install @beatzball/litro-router
+```
+
+```bash
+pnpm add @beatzball/litro-router
+```
+
+The package is ESM-only and has zero runtime dependencies.
+
+## Basic Setup
+
+```ts
+import { LitroRouter } from '@beatzball/litro-router';
+import type { LitroLocation } from '@beatzball/litro-router';
+
+const router = LitroRouter.instance();
+
+router.setRoutes([
+  {
+    path: '/',
+    component: 'page-home',
+    isDynamic: false,
+    isCatchAll: false,
+  },
+  {
+    path: '/blog/:slug',
+    component: 'page-blog-post',
+    isDynamic: true,
+    isCatchAll: false,
+  },
+  {
+    path: '/docs/:slug*',
+    component: 'page-docs',
+    isDynamic: true,
+    isCatchAll: true,
+  },
+]);
+
+router.mount(document.getElementById('outlet')!);
+router.start();
+```
+
+`LitroRouter` is a singleton — `LitroRouter.instance()` returns the same instance every time. This is intentional: only one router should be managing the URL at a time.
+
+## The Route Object
+
+```ts
+interface Route {
+  path: string;       // URL pattern — '/blog/:slug', '/docs/:rest*'
+  component: string;  // Custom element tag name
+  isDynamic: boolean; // true if path contains :params
+  isCatchAll: boolean; // true if path ends with :param*
+}
+```
+
+Routes are sorted automatically: static routes match before dynamic, dynamic before catch-all. You don't need to sort them yourself.
+
+## `onBeforeEnter`
+
+When LitroRouter navigates to a route, it creates a new instance of the component, calls `onBeforeEnter()` if it exists, then appends the element to the outlet. This lets you access route params before the first render.
+
+```ts
+import { html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { LitroPage } from '@beatzball/litro/runtime';
+import type { LitroLocation } from '@beatzball/litro-router';
+
+@customElement('page-blog-post')
+export class BlogPostPage extends LitroPage {
+  private slug = '';
+
+  override onBeforeEnter(location: LitroLocation) {
+    this.slug = location.params.slug ?? '';
+  }
+
+  override render() {
+    return html`<h1>Post: ${this.slug}</h1>`;
+  }
+}
+```
+
+`LitroLocation` has:
+
+```ts
+interface LitroLocation {
+  pathname: string;
+  params: Record<string, string>;
+  search: string;
+  hash: string;
+}
+```
+
+`onBeforeEnter` fires synchronously before the element is mounted. If you need async work (data fetching), kick it off here and store the promise — then resolve it in `render()` or a Lit reactive property.
+
+## Navigation
+
+### `<litro-link>`
+
+```html
+<litro-link href="/blog/hello-world">Read post</litro-link>
+```
+
+`<litro-link>` renders a standard `<a>` tag inside its shadow root for progressive enhancement and accessibility. Click handling runs in the capture phase on the host element, intercepting the navigation before the browser follows the `href`.
+
+Plain `<a>` tags do full page reloads — LitroRouter does not intercept them. This is intentional. If you want SPA navigation, use `<litro-link>`. If you want a full page load (e.g. navigating between separate sections of a large site), use `<a>`.
+
+### Programmatic navigation
+
+```ts
+import { LitroRouter } from '@beatzball/litro-router';
+
+LitroRouter.instance().go('/blog/new-post');
+```
+
+`go()` pushes a new history state and triggers a navigation. Use this for navigation from event handlers, form submissions, or after an async operation completes.
+
+### Back and forward
+
+`LitroRouter` listens for `popstate` events automatically. Browser back and forward navigation works without any additional setup.
+
+Fragment-only `popstate` events (clicking a `#section` link that only changes the hash) are skipped — the router guards on `_lastPathname` and won't re-render the page for hash-only changes.
+
+## Shadow DOM Scroll-to-Hash
+
+Standard `window.location.hash` scrolling doesn't work inside shadow roots because `document.getElementById()` can't see elements inside a closed or open shadow root at arbitrary nesting depth.
+
+LitroRouter's `_scrollToHash()` traverses the shadow DOM recursively to find elements with matching `id` attributes:
+
+```ts
+private _findDeep(root: Element | ShadowRoot, id: string): Element | null {
+  for (const el of root.querySelectorAll(`[id="${id}"], *`)) {
+    if ((el as Element).id === id) return el as Element;
+    const shadow = (el as HTMLElement).shadowRoot;
+    if (shadow) {
+      const found = this._findDeep(shadow, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+```
+
+After each navigation, if `location.hash` is set, the router waits for the mounted component's `updateComplete` promise (if it's a LitElement), then calls `_findDeep()` starting from `document.body`. This handles heading links in server-rendered docs pages where the headings live inside shadow roots.
+
+If you're using the router standalone with non-Lit components, you can call `router.scrollToHash(hash)` directly.
+
+## Using Standalone — Without Litro
+
+The router has no dependency on `@beatzball/litro`. You can use it with any Lit application or even plain custom elements.
+
+```ts
+// app.ts
+import { LitroRouter } from '@beatzball/litro-router';
+
+// Import your page components so they're registered as custom elements
+import './pages/home.js';
+import './pages/about.js';
+import './pages/blog-post.js';
+
+const router = LitroRouter.instance();
+
+router.setRoutes([
+  { path: '/', component: 'page-home', isDynamic: false, isCatchAll: false },
+  { path: '/about', component: 'page-about', isDynamic: false, isCatchAll: false },
+  { path: '/blog/:slug', component: 'page-blog-post', isDynamic: true, isCatchAll: false },
+]);
+
+// Mount to any container element
+router.mount(document.getElementById('app')!);
+router.start();
+```
+
+The outlet element should be in the DOM before calling `mount()`. The router appends the current page component as a child of the outlet element and replaces it on each navigation.
+
+## SSR Safety
+
+LitroRouter accesses `window`, `history`, and `document` at runtime — not at module evaluation time. The import itself is safe on the server. No side effects execute until `start()` is called.
+
+In Litro, the router is dynamically imported inside `LitroOutlet.firstUpdated()`:
+
+```ts
+override async firstUpdated() {
+  const { LitroRouter } = await import('@beatzball/litro-router');
+  // ...
+}
+```
+
+This ensures the module is never evaluated during SSR. If you're using the router standalone in a setup with server rendering, apply the same dynamic import pattern.
+
+## Monotonic Navigation Token
+
+Concurrent navigations — triggered by rapid clicks or programmatic `go()` calls — used to be a source of subtle bugs: a slow async operation from an earlier navigation could resolve after a faster one, overwriting the correct state.
+
+LitroRouter uses a monotonic counter (`_resolveToken`) to prevent this:
+
+```ts
+const token = ++this._resolveToken;
+const result = await this._resolve(url);
+if (token !== this._resolveToken) return; // stale — a newer navigation won
+```
+
+Only the most recently initiated navigation can commit. Earlier navigations that are still in flight are discarded when they resolve. This is particularly relevant if you're doing async data loading in `onBeforeEnter`.
+
+## Design Decisions
+
+**No global `<a>` click interceptor.** Some routers intercept every click on every anchor tag on the page. This breaks third-party components that use `<a>` for non-navigation purposes (toggles, downloads, external links). LitroRouter requires explicit opt-in via `<litro-link>` or `LitroRouter.go()`.
+
+**pushState only — no hash routing.** Hash routing is a workaround for environments that don't support HTML5 history. In 2026, all deployment targets Litro supports handle pushState correctly (including static hosting on Cloudflare Pages and GitHub Pages with proper `_redirects` / `404.html` fallbacks).
+
+**Singleton.** One router per page. If you need sub-routers for deeply nested components, use conditional rendering inside `onBeforeEnter` rather than nested `LitroRouter` instances.
+
+## Further Reading
+
+- [Client Router documentation](/docs/core-concepts/client-router) — covers outlet setup, `<litro-link>`, and integration with Litro's SSR pipeline
+- [litro-router package reference](/docs/litro-router) — full API reference including TypeScript types
+- [Getting Started](/docs/getting-started) — start here if you're new to Litro

--- a/docs/content/blog/nitro-adapters.md
+++ b/docs/content/blog/nitro-adapters.md
@@ -1,0 +1,175 @@
+---
+title: "How Nitro's Deployment Adapters Work — and Why Litro Gets Them for Free"
+description: "Nitro powers both Nuxt.js and Litro. That means every Nitro deployment preset — Vercel, Cloudflare Workers, AWS Lambda, Deno Deploy — works in Litro without a single line of custom adapter code."
+date: 2026-03-22
+tags: [nitro, deployment, cloudflare, vercel]
+---
+
+# How Nitro's Deployment Adapters Work — and Why Litro Gets Them for Free
+
+Litro doesn't ship deployment adapters. It doesn't need to. Every deployment target Litro supports — Vercel, Cloudflare Workers, AWS Lambda, Netlify, Deno Deploy, Bun, Node.js standalone — comes from Nitro, the server engine underneath.
+
+This post explains what Nitro presets actually do, which ones work with Litro, and the two edge-specific considerations you need to know about before deploying a Lit SSR app to a Workers environment.
+
+## What Nitro Is
+
+Nitro is the server engine that powers Nuxt.js. It's a standalone package (`nitropack`) that handles routing, middleware, API handlers (via H3), and — most importantly — output targets.
+
+Litro's server is a Nitro server. The `litro.config.ts` you write in your project is a thin wrapper around `nitro.config.ts`. Every H3 handler, every middleware, every route rule you configure goes through Nitro. If you've used Nuxt, you've already used Nitro.
+
+Analog (the Angular meta-framework) also builds on Nitro. So does SolidStart. Litro is one of several frameworks that made the same bet: use Nitro for the server layer and inherit everything it provides. For a comparison of how this plays out vs Nuxt specifically, see [Litro vs Nuxt.js](/compare/nuxt).
+
+## What a Preset Is
+
+A Nitro "preset" is a self-contained output configuration that transforms the server into a form suitable for a specific runtime. When you run a build with a preset, Nitro:
+
+1. Bundles the server into a single entry file (or a set of files)
+2. Transforms imports to match the target runtime's available APIs
+3. Generates any runtime-specific wrapper code or configuration files
+4. Copies assets into the output directory structure the target expects
+
+The output of `NITRO_PRESET=vercel litro build` is a directory structure that matches exactly what Vercel's build infrastructure expects to find. No Litro-specific code is involved — Nitro handles it entirely.
+
+## Available Presets
+
+These presets work with Litro today:
+
+| Preset | Command | Output |
+|--------|---------|--------|
+| `node` (default) | `litro build` | `dist/server/server/index.mjs` — Node.js ESM server |
+| `node-cluster` | `NITRO_PRESET=node-cluster litro build` | Clustered Node.js for multi-core use |
+| `vercel` | `NITRO_PRESET=vercel litro build` | `.vercel/output/` directory |
+| `cloudflare-workers` | `NITRO_PRESET=cloudflare-workers litro build` | `dist/` for `wrangler publish` |
+| `cloudflare-pages` | `NITRO_PRESET=cloudflare-pages litro build` | `dist/` for Cloudflare Pages |
+| `netlify` | `NITRO_PRESET=netlify litro build` | `.netlify/` directory |
+| `aws-lambda` | `NITRO_PRESET=aws-lambda litro build` | Lambda handler bundle |
+| `deno-deploy` | `NITRO_PRESET=deno-deploy litro build` | Deno-compatible output |
+| `bun` | `NITRO_PRESET=bun litro build` | Bun-compatible server |
+| `static` | `NITRO_PRESET=static litro build` | Pre-rendered static HTML |
+
+The `static` preset is what `litro build` uses when you configure SSG mode. The others are SSR presets.
+
+You can also set the preset in your config:
+
+```ts
+// litro.config.ts
+import { defineNitroConfig } from 'nitropack/config';
+
+export default defineNitroConfig({
+  preset: 'vercel',
+});
+```
+
+Or via environment variable, which is useful for CI where you want one config file to target different environments:
+
+```bash
+NITRO_PRESET=cloudflare-workers litro build
+```
+
+## Edge Adapters — Two Things to Know
+
+Deploying to Cloudflare Workers or Vercel Edge requires two configuration additions. Both are in `nitro.config.ts`.
+
+### 1. Inline `@lit-labs/ssr`
+
+Cloudflare Workers and Vercel Edge Functions don't use Node.js module resolution — they run in a V8 isolate. `@lit-labs/ssr` relies on `node:` built-ins in some of its internal paths.
+
+By default, Nitro marks `@lit-labs/ssr` as an external dependency and expects the runtime to provide it. Edge runtimes can't. The fix is to tell Nitro to inline it — bundle it directly into the output:
+
+```ts
+// nitro.config.ts
+export default defineNitroConfig({
+  preset: 'cloudflare-workers',
+  externals: {
+    inline: ['@lit-labs/ssr', '@lit-labs/ssr-client'],
+  },
+});
+```
+
+Without this, you'll get a module-not-found error at runtime on Workers.
+
+### 2. Streaming API Differences
+
+`RenderResultReadable` from `@lit-labs/ssr` is a Node.js `Readable` stream. Node.js `Readable` is not available in Cloudflare Workers.
+
+Litro's page handler uses Nitro's `sendStream()`, which accepts either a Node.js `Readable` or a standard WHATWG `ReadableStream`. For edge targets, you need to convert:
+
+```ts
+import { render } from '@lit-labs/ssr';
+import { collectResult } from '@lit-labs/ssr/lib/render-result.js';
+
+// Node.js targets — use RenderResultReadable directly
+import { RenderResultReadable } from '@lit-labs/ssr/lib/render-result-readable.js';
+const readable = new RenderResultReadable(renderResult);
+return sendStream(event, readable);
+
+// Edge targets — convert to WHATWG ReadableStream
+const html = await collectResult(renderResult);
+return html;
+```
+
+Litro's built-in page handler detects the runtime automatically. If you're writing a custom handler for an edge target, keep this difference in mind.
+
+## Vercel Deployment Example
+
+```bash
+# Build for Vercel
+NITRO_PRESET=vercel litro build
+
+# The .vercel/output directory is ready for deployment
+vercel deploy --prebuilt
+```
+
+The output follows Vercel's [Build Output API](https://vercel.com/docs/build-output-api/v3). The SSR function lands in `.vercel/output/functions/index.func/`, static assets in `.vercel/output/static/`.
+
+## Cloudflare Workers Example
+
+```bash
+# Build for Cloudflare Workers
+NITRO_PRESET=cloudflare-workers litro build
+
+# Deploy with Wrangler
+wrangler publish dist/server/index.mjs
+```
+
+The `wrangler.toml` for a Litro Workers deployment:
+
+```toml
+name = "my-litro-app"
+main = "dist/server/index.mjs"
+compatibility_date = "2025-09-01"
+
+[site]
+bucket = "./dist/server/public"
+```
+
+Static assets are served by the Worker via KV bindings — Nitro generates the necessary asset manifest automatically.
+
+## Coolify and Self-Hosted Node.js
+
+For self-hosted deployments, the default `node` preset builds a standalone Node.js server. Litro's docs cover [deploying to Coolify](/docs/deployment/coolify) and [GitHub Pages](/docs/deployment/github-pages) in detail.
+
+The Node.js output:
+
+```bash
+litro build
+node dist/server/server/index.mjs
+```
+
+The server listens on `PORT` (default 3000) and serves both the SSR handler and static assets from the same process.
+
+## How This Compares to Next.js
+
+Next.js deployment adapters for non-Vercel targets are community-maintained. The official documentation targets Vercel; AWS, Cloudflare, and other adapters are separate packages with their own maintenance burden and compatibility lag.
+
+Nitro's presets are first-party, used by Nuxt.js, and maintained by the UnJS team. When Cloudflare changes its Workers API, the Nitro preset is updated — and Litro inherits the fix without any action on our end.
+
+This is the same shared-foundation argument made on the [Litro vs Nuxt.js](/compare/nuxt) page. The server layer is not a differentiator. Using the same server as Nuxt means using the same battle-tested deployment infrastructure.
+
+## The Framework Maintenance Difference
+
+When you evaluate a new framework, deployment adapter maintenance is often invisible until it isn't. The question isn't "does it have a Cloudflare adapter today?" — it's "who maintains that adapter and what's the upgrade path when the underlying platform changes?"
+
+Litro's answer: the same team that maintains Nuxt's server layer.
+
+Ready to deploy? See [Getting Started](/docs/getting-started) for the full setup, or check the [Coolify deployment guide](/docs/deployment/coolify) for a self-hosted walkthrough.

--- a/docs/pages/blog/[slug].ts
+++ b/docs/pages/blog/[slug].ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, css } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
@@ -8,6 +8,7 @@ import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
 import { siteConfig } from '../../server/starlight.config.js';
 import { extractHeadings, addHeadingIds } from '../../src/extract-headings.js';
+import { applyHighlighting } from '../../src/highlight.js';
 import { starlightHead } from '../../src/route-meta.js';
 import { buildSeoHead, buildJsonLd } from '../../src/seo.js';
 import { formatDate, isoDate } from '../../src/date-utils.js';
@@ -37,7 +38,7 @@ export const pageData = definePageData(async (event) => {
   }
 
   const toc = extractHeadings(post.rawBody);
-  const body = addHeadingIds(post.body);
+  const body = applyHighlighting(addHeadingIds(post.body));
   const blogSlug = post.url.slice('/content/blog/'.length);
   const postDescription = (post as Post & { description?: string }).description ?? '';
   const seoTitle = `${post.title} — Litro Blog`;
@@ -82,6 +83,72 @@ export const routeMeta = {
 
 @customElement('page-blog-slug')
 export class BlogPostPage extends LitroPage {
+  static override styles = css`
+    /* ── Typography ──────────────────────────────────────────────────── */
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.5em; margin-bottom: 0.5em;
+      font-weight: 600; line-height: 1.25;
+      color: var(--sl-color-text);
+    }
+    h1 { font-size: var(--sl-text-4xl, 2.25rem); }
+    h2 { font-size: var(--sl-text-2xl, 1.5rem); border-bottom: 1px solid var(--sl-color-border, #e8e8e8); padding-bottom: 0.25em; }
+    h3 { font-size: var(--sl-text-xl, 1.25rem); }
+    h4 { font-size: var(--sl-text-lg, 1.125rem); }
+    p  { margin-top: 0; margin-bottom: 1rem; line-height: 1.7; }
+    a  { color: var(--sl-color-text-accent, var(--sl-color-accent)); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code {
+      font-family: var(--sl-font-mono, ui-monospace, monospace);
+      font-size: 0.875em;
+      background-color: var(--sl-color-bg-inline-code, #e8e8e8);
+      border: 1px solid var(--sl-color-border, #e8e8e8);
+      border-radius: 0.25rem;
+      padding: 0.15em 0.4em;
+    }
+    pre {
+      background-color: #0d0e11;
+      color: #e2e4e9;
+      border-radius: 0.375rem;
+      padding: 1rem 1.25rem;
+      overflow-x: auto;
+      margin: 1.5rem 0;
+      font-size: var(--sl-text-sm, 0.875rem);
+      line-height: 1.6;
+    }
+    pre code { background: none; border: none; padding: 0; font-size: inherit; }
+    ul, ol { padding-left: 1.5rem; margin: 0 0 1rem; }
+    li { margin-bottom: 0.25rem; line-height: 1.7; }
+    blockquote {
+      margin: 1.5rem 0; padding: 0.75rem 1rem;
+      border-left: 4px solid var(--sl-color-accent, #ea580c);
+      background-color: var(--sl-color-accent-low, #fff7ed);
+      border-radius: 0 0.375rem 0.375rem 0;
+    }
+    hr { border: none; border-top: 1px solid var(--sl-color-border, #e8e8e8); margin: 2rem 0; }
+    img { max-width: 100%; height: auto; }
+    table { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: var(--sl-text-sm, 0.875rem); }
+    th, td { border: 1px solid var(--sl-color-border, #e8e8e8); padding: 0.5rem 0.75rem; text-align: left; }
+    th { background-color: var(--sl-color-gray-1, #f6f6f6); font-weight: 600; }
+
+    /* ── highlight.js fire theme ─────────────────────────────────────── */
+    pre:has(.hljs) { background-color: #0d0d10; color: #cbd5e1; }
+    .hljs { color: #cbd5e1; background: transparent; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-tag { color: #f97316; }
+    .hljs-string, .hljs-attr, .hljs-attribute { color: #38bdf8; }
+    .hljs-number, .hljs-literal { color: #fbbf24; }
+    .hljs-title, .hljs-title.class_, .hljs-title.function_, .hljs-built_in { color: #fb923c; }
+    .hljs-comment { color: #6b7280; font-style: italic; }
+    .hljs-variable, .hljs-params { color: #cbd5e1; }
+    .hljs-operator, .hljs-punctuation { color: #94a3b8; }
+    .hljs-meta, .hljs-meta .hljs-keyword { color: #38bdf8; }
+    .hljs-type { color: #fb923c; }
+    .hljs-deletion { color: #f87171; background: rgba(248,113,113,.1); }
+    .hljs-addition { color: #4ade80; background: rgba(74,222,128,.1); }
+    .hljs-section, .hljs-selector-class, .hljs-selector-id { color: #fb923c; }
+    .hljs-symbol, .hljs-bullet, .hljs-link { color: #38bdf8; }
+    .hljs-emphasis { font-style: italic; }
+    .hljs-strong { font-weight: bold; }
+  `;
 
   override render() {
     const data = this.serverData as BlogPostData | null;

--- a/packages/create-litro/README.md
+++ b/packages/create-litro/README.md
@@ -5,21 +5,33 @@ Scaffold a new [Litro](https://github.com/beatzball/litro) app.
 ## Usage
 
 ```bash
+# npm
 npm create @beatzball/litro@latest my-app
-# or
+
+# pnpm
 pnpm create @beatzball/litro my-app
-# or
+
+# yarn
 yarn create @beatzball/litro my-app
+
+# bun
+bun create @beatzball/litro my-app
+
+# deno
+deno create npm:@beatzball/litro@latest -- my-app
 ```
 
 Follow the interactive prompts to choose a recipe and rendering mode, or pass flags directly to skip them:
 
 ```bash
 # Fullstack SSR app (default)
-npm create @beatzball/litro@latest my-app --recipe fullstack --mode ssr
+npm create @beatzball/litro@latest my-app -- --recipe fullstack --mode ssr
 
-# 11ty-compatible blog (SSG or SSR)
-npm create @beatzball/litro@latest my-app --recipe 11ty-blog --mode ssg
+# 11ty-compatible Markdown blog, static output
+npm create @beatzball/litro@latest my-app -- --recipe 11ty-blog --mode ssg
+
+# Starlight docs + blog, static output
+npm create @beatzball/litro@latest my-docs -- --recipe starlight
 
 # List all available recipes
 npm create @beatzball/litro@latest -- --list-recipes
@@ -52,18 +64,34 @@ Generated app includes:
 - `server/api/posts.ts` — JSON API for posts (optional `?tag=` filter)
 - `litro.recipe.json` — written to the project root so the content plugin knows where to find posts
 
+### `starlight`
+
+An Astro Starlight-inspired docs + blog site. SSG-only (no `--mode` flag needed).
+
+Generated app includes:
+- `content/docs/*.md` — documentation pages with sidebar ordering frontmatter
+- `content/blog/*.md` — blog posts with title, date, tags, description
+- Layout components: `<starlight-page>`, `<starlight-header>`, `<starlight-sidebar>`, `<starlight-toc>`
+- UI components: `<litro-card>`, `<litro-card-grid>`, `<litro-badge>`, `<litro-aside>`, `<litro-tabs>`
+- [Shoelace](https://shoelace.style) web components available (`<sl-*>` names reserved for Shoelace; Litro's own primitives use `litro-*`)
+- `server/starlight.config.js` — site title, nav links, sidebar groups
+- `public/styles/starlight.css` — full `--sl-*` CSS token layer with dark/light mode
+- Syntax highlighting via `highlight.js` (fire theme, applied at SSG build time)
+
 ## After scaffolding
 
 ```bash
 cd my-app
 pnpm install
 pnpm dev      # start dev server on http://localhost:3030
+pnpm build    # production build
+pnpm preview  # preview the production build
 ```
 
-For static site generation:
+For static site generation (SSG):
 
 ```bash
-LITRO_MODE=static pnpm build   # prerenders all routes to HTML
+LITRO_MODE=static pnpm build   # prerenders all routes to HTML → dist/static/
 ```
 
 ## The `litro:content` virtual module

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -16,10 +16,26 @@ A fullstack web framework for [Lit](https://lit.dev) components, powered by [Nit
 ## Quick start
 
 ```bash
+# npm
 npm create @beatzball/litro@latest my-app
+
+# pnpm
+pnpm create @beatzball/litro my-app
+
+# yarn
+yarn create @beatzball/litro my-app
+
+# bun
+bun create @beatzball/litro my-app
+
+# deno
+deno create npm:@beatzball/litro@latest -- my-app
+```
+
+```bash
 cd my-app
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
 
 ---
@@ -28,17 +44,19 @@ npm run dev
 
 ```typescript
 // pages/index.ts
-import { LitroPage, definePageData, html } from '@beatzball/litro/runtime';
+import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { LitroPage } from '@beatzball/litro/runtime';
+import { definePageData } from '@beatzball/litro';
 
-const pageData = definePageData(async () => ({
+export const pageData = definePageData(async () => ({
   message: 'Hello from the server!',
 }));
 
 @customElement('page-index')
 export default class IndexPage extends LitroPage {
   override render() {
-    const data = this.serverData as typeof pageData | null;
+    const data = this.serverData as { message: string } | null;
     return html`<h1>${data?.message}</h1>`;
   }
 }
@@ -85,7 +103,7 @@ Full documentation at [litro.dev](https://litro.dev).
 |---|---|
 | `@beatzball/litro` | This package — core framework |
 | [`@beatzball/litro-router`](https://www.npmjs.com/package/@beatzball/litro-router) | Standalone URLPattern router (zero dependencies) |
-| `@beatzball/create-litro` | `npm create @beatzball/litro` scaffolding CLI |
+| `@beatzball/create-litro` | `npm create @beatzball/litro` scaffolding CLI — `fullstack`, `11ty-blog`, and `starlight` recipes |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add blog posts 6 and 7 (nitro-adapters, litro-router-urlpattern), both dated 2026-03-22
- Fix blog post syntax highlighting: `BlogPostPage` was missing `applyHighlighting()` and `static override styles` with hljs rules — global CSS cannot pierce the shadow DOM boundary
- Update root README and package READMEs: add npm/pnpm/yarn/bun/deno scaffold commands, fix deployment preset names (`node-server`→`node`, etc.), add starlight recipe, fix Hello World example imports
- Update `ARCHITECTURE.md`: replace stale `docs.yml` reference with actual `ci.yml` + `release.yml`

## Packages changed
No package source changes — docs, blog content, and README updates only. No changeset needed.

## Test plan
- [x] Existing unit tests pass (`pnpm test`, `pnpm test:docs`)
- [x] Blog posts render with syntax highlighting in dev (`pnpm dev:docs`, visit `/blog/nitro-adapters` and `/blog/litro-router-urlpattern`)
- [x] Existing blog posts still render correctly with highlighting
- [x] README scaffold commands are accurate (`npm create @beatzball/litro@latest`, `deno create npm:@beatzball/litro@latest -- my-app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)