### PR TITLE
feat: Phase 3.6 — accessibility audit (WCAG 2.1 AA)

### DIFF
--- a/.changeset/a11y-audit-phase-3-6.md
+++ b/.changeset/a11y-audit-phase-3-6.md
@@ -1,0 +1,30 @@
+---
+"@beatzball/litro": minor
+"@beatzball/litro-router": patch
+"@beatzball/litro-docs-ui": patch
+"@beatzball/create-litro": patch
+---
+
+feat(framework): skip links API — `skipLinks` array on ShellOptions, `DEFAULT_SKIP_LINKS` constant, `SkipLink` type export
+
+feat(framework): SPA focus management — focus outlet after page swap, announce new page title via `aria-live` region
+
+feat(litro-router): screen reader announcements after SPA navigation via persistent `aria-live="polite"` region
+
+feat(docs-ui): WAI-ARIA Tabs Pattern for `litro-tabs` — roving tabindex, arrow keys, `aria-controls`/`aria-labelledby`
+
+feat(docs-ui): sidebar `inert` when closed on mobile, drawer mode detection via `matchMedia`
+
+fix(docs-ui): visible focus indicators on search inputs (`.search-input:focus-visible`)
+
+fix(docs-ui): GitHub link `aria-label` includes "(opens in new tab)"
+
+fix(docs-ui): touch targets meet 44px minimum (menu button, GitHub link, search pill)
+
+fix(docs-ui): sidebar group labels use `<h3>` instead of `<p>` for heading navigation
+
+fix(docs-ui): preview banner `role="status"` for screen reader announcement
+
+fix(docs-ui): search modal uses `aria-labelledby` with sr-only heading instead of `aria-label`
+
+feat(create-litro): starlight recipe uses `skipLinks` array API with `DEFAULT_SKIP_LINKS`

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -551,3 +551,49 @@ This rule is present in `starlight/template/public/styles/starlight.css`, `playg
 **Decision**: Accept that Escape requires two presses to close the search modal when the input has content — the first press clears the `<input type="search">` value (browser default behavior), the second closes the modal.
 
 **Rationale**: Browsers implement Escape-to-clear as a native behavior for `<input type="search">` that cannot be reliably prevented across all engines. Changing to `type="text"` was tested and did not resolve the issue consistently. Many documentation sites (Algolia DocSearch, Stripe, etc.) exhibit the same double-Escape behavior. The document-level Escape handler in `app.ts` reliably closes the modal when the input is empty.
+
+---
+
+## Skip links: `skipLinks` array API over boolean flags
+
+**Decision**: Replace `skipNav`/`skipSearch` boolean options on `ShellOptions` and `PageHandlerOptions` with a `skipLinks?: SkipLink[]` array. Export `DEFAULT_SKIP_LINKS` (a single "Skip to content" link) and `SkipLink` type from `@beatzball/litro`.
+
+**Rationale**: Boolean flags couple the framework to specific recipe landmarks (sidebar, search). Not all Litro sites have navigation sidebars or search — the fullstack recipe has neither. The array API lets each site declare exactly which skip links it needs by extending the default:
+
+```ts
+skipLinks: [...DEFAULT_SKIP_LINKS, { label: 'Skip to navigation', href: '#_litro_nav' }]
+```
+
+The framework shell keeps the generic infrastructure (shadow DOM traversal for focus, MutationObserver for dynamic visibility during SPA navigation) but delegates recipe-specific behavior (e.g. opening a search modal on skip link click) to the site layer. `docs-ssr/app.ts` handles the `#_litro_search` skip link via a capture-phase click listener that opens the search modal.
+
+---
+
+## Skip links: shadow DOM traversal in framework, special actions in recipe
+
+**Decision**: The inline `SKIP_LINK_SCRIPT` in `shell.ts` provides generic shadow DOM traversal (find element by id across shadow roots, focus it) and MutationObserver-based visibility toggling. Recipe-specific actions (like dispatching `sl-search-open` for search) are handled in the site's `app.ts`.
+
+**Rationale**: Fragment navigation (`#id`) cannot reach elements inside shadow roots — a JS traversal is necessary. This traversal is framework-level infrastructure that all Litro sites benefit from. However, intercepting a skip link click to open a modal (rather than focusing an element) is recipe-specific behavior that belongs in the consumer code, not the framework. The docs-ssr site registers a capture-phase click handler on `a.skip-link[href="#_litro_search"]` that opens the search modal and stops propagation before the framework's generic handler runs.
+
+---
+
+## A11y: SPA focus management and screen reader announcements
+
+**Decision**: After each SPA page swap in `LitroRouter`, focus the outlet element and announce the new page title via an `aria-live="polite"` region.
+
+**Rationale**: SPA navigation replaces DOM content without a full page load, so the browser does not reset focus or announce the new page. Keyboard users lose their focus position; screen reader users hear nothing. The router creates a persistent `<div role="status" aria-live="polite">` appended to `document.body` in `setRoutes()`, sets `tabindex="-1"` on the outlet for programmatic focus, and after each page swap: (1) focuses the outlet with `preventScroll`, (2) announces the new `<h1>` text (or `document.title`) via the live region on the next microtick.
+
+---
+
+## A11y: sidebar `inert` when closed on mobile
+
+**Decision**: Add `?inert="${this._isDrawerMode && !this._navOpen}"` to the sidebar `<aside>` in `starlight-page.ts`, with drawer mode tracked via `window.matchMedia('(max-width: 72rem)')`.
+
+**Rationale**: When the sidebar is visually hidden (off-screen via `transform: translateX(-100%)`), it remains in the tab order. Keyboard users tab through invisible sidebar links. The `inert` attribute removes the sidebar from the accessibility tree and tab order when it is not visible. A `matchMedia` listener ensures `inert` is only applied in drawer mode (narrow viewports) — at desktop widths the sidebar is always visible.
+
+---
+
+## A11y: `litro-tabs` WAI-ARIA Tabs Pattern
+
+**Decision**: Implement the full WAI-ARIA Tabs Pattern in `litro-tabs.ts`: roving tabindex, `aria-controls`/`aria-labelledby` linking, arrow key navigation (Left/Right, Home/End), and `role="tabpanel"` on panels.
+
+**Rationale**: Without ARIA wiring, tab buttons have no programmatic relationship to their panels. Screen readers cannot navigate between tabs and panels. Without arrow key navigation, keyboard users must tab through every tab button to reach the content. The WAI-ARIA Tabs Pattern is the established accessible pattern for tabbed interfaces.

--- a/docs-ssr/app.ts
+++ b/docs-ssr/app.ts
@@ -86,6 +86,20 @@ void import('@beatzball/litro-docs-ui/src/components/search-modal.js').then(() =
     modal.open = false;
   });
 
+  // "Skip to search" skip link — intercept click and open the modal instead
+  // of focusing the search pill. The skip link href is #_litro_search; the
+  // framework's generic handler would try to focus that element, but opening
+  // the modal is the better UX for keyboard/screen reader users.
+  document.addEventListener('click', (e: MouseEvent) => {
+    const link = (e.target as Element)?.closest?.('a.skip-link[href="#_litro_search"]');
+    if (!link) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    modal.query = '';
+    modal.results = [];
+    modal.open = true;
+  }, true);
+
   // Header pill dispatches sl-search-open (composed, crosses shadow DOM)
   document.addEventListener('sl-search-open', () => {
     modal.query = '';

--- a/docs-ssr/server/routes/[...].ts
+++ b/docs-ssr/server/routes/[...].ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeader, getRequestURL } from 'h3';
 import { createPageHandler } from '@beatzball/litro/runtime/create-page-handler.js';
+import { DEFAULT_SKIP_LINKS } from '@beatzball/litro';
 import type { LitroRoute } from '@beatzball/litro';
 import { routes, pageModules } from '#litro/page-manifest';
 
@@ -50,6 +51,11 @@ export default defineEventHandler(async (event) => {
     route: matched,
     routeMeta: (mod?.routeMeta as { title?: string; head?: string } | undefined),
     pageModule: mod,
+    skipLinks: [
+      ...DEFAULT_SKIP_LINKS,
+      { label: 'Skip to navigation', href: '#_litro_nav' },
+      { label: 'Skip to search', href: '#_litro_search' },
+    ],
   });
   return handler(event);
 });

--- a/docs/server/routes/[...].ts
+++ b/docs/server/routes/[...].ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeader, getRequestURL } from 'h3';
 import { createPageHandler } from '@beatzball/litro/runtime/create-page-handler.js';
+import { DEFAULT_SKIP_LINKS } from '@beatzball/litro';
 import type { LitroRoute } from '@beatzball/litro';
 import { routes, pageModules } from '#litro/page-manifest';
 
@@ -50,6 +51,10 @@ export default defineEventHandler(async (event) => {
     route: matched,
     routeMeta: (mod?.routeMeta as { title?: string; head?: string } | undefined),
     pageModule: mod,
+    skipLinks: [
+      ...DEFAULT_SKIP_LINKS,
+      { label: 'Skip to navigation', href: '#_litro_nav' },
+    ],
   });
   return handler(event);
 });

--- a/e2e/docs-ssr/search.spec.ts
+++ b/e2e/docs-ssr/search.spec.ts
@@ -113,7 +113,7 @@ test('Escape closes search modal', async ({ page }) => {
 test('header pill click opens search modal', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
-  const pill = page.locator('starlight-header').locator('.search-pill');
+  const pill = page.locator('starlight-header').first().locator('.search-pill');
   await pill.click();
   await expect(page.locator('search-modal')).toHaveAttribute('open', '');
 });

--- a/e2e/docs-ssr/search.spec.ts
+++ b/e2e/docs-ssr/search.spec.ts
@@ -184,7 +184,7 @@ test('search modal has correct ARIA attributes', async ({ page }) => {
   await page.keyboard.press('Meta+k');
   const dialog = page.locator('search-modal').locator('[role="dialog"]');
   await expect(dialog).toHaveAttribute('aria-modal', 'true');
-  await expect(dialog).toHaveAttribute('aria-label', 'Search documentation');
+  await expect(dialog).toHaveAttribute('aria-labelledby', 'search-modal-title');
   const listbox = page.locator('search-modal').locator('[role="listbox"]');
   await expect(listbox).toBeVisible();
 });

--- a/e2e/playground-starlight/pages.spec.ts
+++ b/e2e/playground-starlight/pages.spec.ts
@@ -21,7 +21,7 @@ test('home page renders site title in h1', async ({ page }) => {
 test('home page renders starlight-header', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('page-home:not([hidden])');
-  await expect(page.locator('starlight-header')).toBeVisible();
+  await expect(page.locator('starlight-header').first()).toBeVisible();
 });
 
 test('home page renders feature cards', async ({ page }) => {

--- a/e2e/playground-starlight/toc.spec.ts
+++ b/e2e/playground-starlight/toc.spec.ts
@@ -21,7 +21,7 @@ test('TOC aside has sticky positioning', async ({ page }) => {
 test('header has sticky positioning', async ({ page }) => {
   await page.goto('/docs/getting-started');
   await page.waitForSelector('starlight-header');
-  const position = await page.locator('starlight-header').evaluate((el) => {
+  const position = await page.locator('starlight-header').first().evaluate((el) => {
     return getComputedStyle(el).position;
   });
   expect(position).toBe('sticky');

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "serialize-javascript": ">=7.0.3",
       "tar": ">=7.5.11",
       "node-forge": ">=1.4.0",
-      "picomatch": ">=4.0.4"
+      "picomatch": ">=4.0.4",
+      "lodash": ">=4.18.0"
     }
   }
 }

--- a/packages/create-litro/recipes/starlight/template/server/routes/[...].ts
+++ b/packages/create-litro/recipes/starlight/template/server/routes/[...].ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeader, getRequestURL } from 'h3';
 import { createPageHandler } from '@beatzball/litro/runtime/create-page-handler.js';
+import { DEFAULT_SKIP_LINKS } from '@beatzball/litro';
 import type { LitroRoute } from '@beatzball/litro';
 import { routes, pageModules } from '#litro/page-manifest';
 
@@ -52,6 +53,10 @@ export default defineEventHandler(async (event) => {
     route: matched,
     routeMeta: (mod?.routeMeta as { title?: string; head?: string } | undefined),
     pageModule: mod,
+    skipLinks: [
+      ...DEFAULT_SKIP_LINKS,
+      { label: 'Skip to navigation', href: '#_litro_nav' },
+    ],
   });
   return handler(event);
 });

--- a/packages/docs-ui/src/components/litro-tabs.ts
+++ b/packages/docs-ui/src/components/litro-tabs.ts
@@ -10,6 +10,12 @@ import type { LitroTabItem } from './litro-tab-item.js';
  *
  * Reads slotted <litro-tab-item> elements via the slotchange event.
  * Renders a tab bar in Shadow DOM; clicking selects the tab.
+ *
+ * Implements the WAI-ARIA Tabs Pattern with automatic activation:
+ * - Arrow keys move focus and activate tabs
+ * - Home/End jump to first/last tab
+ * - Roving tabindex on tab buttons
+ * - aria-controls / aria-labelledby link tabs to panels
  */
 @customElement('litro-tabs')
 export class LitroTabs extends LitElement {
@@ -56,6 +62,11 @@ export class LitroTabs extends LitElement {
       border-bottom-color: var(--sl-color-accent, #7c3aed);
     }
 
+    .tab-btn:focus-visible {
+      outline: 2px solid var(--sl-color-accent, #7c3aed);
+      outline-offset: -2px;
+    }
+
     .tab-content {
       padding-top: 1rem;
     }
@@ -63,6 +74,15 @@ export class LitroTabs extends LitElement {
 
   _labels: string[] = [];
   _selectedIndex = 0;
+  private _uid = Math.random().toString(36).slice(2, 8);
+
+  private _tabId(i: number): string {
+    return `litro-tab-${this._uid}-${i}`;
+  }
+
+  private _panelId(i: number): string {
+    return `litro-panel-${this._uid}-${i}`;
+  }
 
   private _items(): LitroTabItem[] {
     const slot = this.shadowRoot?.querySelector('slot');
@@ -83,6 +103,40 @@ export class LitroTabs extends LitElement {
     this._selectedIndex = index;
     all.forEach((item, i) => {
       item.selected = i === index;
+      item.setAttribute('role', 'tabpanel');
+      item.setAttribute('id', this._panelId(i));
+      item.setAttribute('aria-labelledby', this._tabId(i));
+      item.setAttribute('tabindex', '0');
+    });
+  }
+
+  private _onTabKeydown(e: KeyboardEvent) {
+    const count = this._labels.length;
+    if (count === 0) return;
+
+    let newIndex = this._selectedIndex;
+
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      newIndex = (this._selectedIndex + 1) % count;
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      newIndex = this._selectedIndex <= 0 ? count - 1 : this._selectedIndex - 1;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      newIndex = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      newIndex = count - 1;
+    } else {
+      return;
+    }
+
+    this._selectIndex(newIndex);
+    // Focus the newly selected tab button.
+    requestAnimationFrame(() => {
+      const btn = this.shadowRoot?.querySelector(`#${this._tabId(newIndex)}`) as HTMLElement | null;
+      btn?.focus();
     });
   }
 
@@ -93,8 +147,12 @@ export class LitroTabs extends LitElement {
           <button
             class="tab-btn"
             role="tab"
+            id="${this._tabId(i)}"
             aria-selected="${this._selectedIndex === i ? 'true' : 'false'}"
+            aria-controls="${this._panelId(i)}"
+            tabindex="${this._selectedIndex === i ? '0' : '-1'}"
             @click=${() => this._selectIndex(i)}
+            @keydown=${(e: KeyboardEvent) => this._onTabKeydown(e)}
           >${label}</button>
         `)}
       </div>

--- a/packages/docs-ui/src/components/preview-banner.ts
+++ b/packages/docs-ui/src/components/preview-banner.ts
@@ -43,7 +43,7 @@ export class PreviewBanner extends LitElement {
 
   override render() {
     return html`
-      <div class="banner">
+      <div class="banner" role="status">
         <span>Preview Mode — Draft content visible</span>
         <a class="exit-link" href="?preview=0">Exit preview</a>
       </div>

--- a/packages/docs-ui/src/components/search-modal.ts
+++ b/packages/docs-ui/src/components/search-modal.ts
@@ -98,6 +98,10 @@ export class SearchModal extends LitElement {
       min-width: 0;
     }
 
+    .search-input:focus-visible {
+      box-shadow: 0 0 0 2px var(--sl-color-accent, #ea580c);
+    }
+
     .search-input::placeholder {
       color: var(--sl-color-gray-4, #888);
     }
@@ -362,7 +366,8 @@ export class SearchModal extends LitElement {
 
     return html`
       <div class="backdrop" @click="${this._onBackdropClick}">
-        <div class="modal" role="dialog" aria-modal="true" aria-label="Search documentation">
+        <div class="modal" role="dialog" aria-modal="true" aria-labelledby="search-modal-title">
+          <h2 class="sr-only" id="search-modal-title">Search documentation</h2>
           <div class="search-header">
             <svg class="search-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />

--- a/packages/docs-ui/src/components/starlight-header.ts
+++ b/packages/docs-ui/src/components/starlight-header.ts
@@ -47,8 +47,8 @@ export class StarlightHeader extends LitElement {
       background: none;
       border: 1px solid var(--sl-color-border, #e8e8e8);
       border-radius: var(--sl-border-radius, 0.375rem);
-      width: 2.25rem;
-      height: 2.25rem;
+      min-width: 2.75rem;
+      min-height: 2.75rem;
       align-items: center;
       justify-content: center;
       cursor: pointer;
@@ -135,7 +135,7 @@ export class StarlightHeader extends LitElement {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      height: 2rem;
+      min-height: 2.75rem;
       padding: 0 0.75rem;
       border: 1px solid var(--sl-color-border, #e8e8e8);
       border-radius: 9999px;
@@ -203,6 +203,11 @@ export class StarlightHeader extends LitElement {
       outline: none;
     }
 
+    .search-input:focus-visible {
+      border-color: var(--sl-color-accent, #ea580c);
+      box-shadow: 0 0 0 1px var(--sl-color-accent, #ea580c);
+    }
+
     @media (scripting: none) {
       .search-pill {
         display: none;
@@ -216,8 +221,8 @@ export class StarlightHeader extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 2rem;
-      height: 2rem;
+      min-width: 2.75rem;
+      min-height: 2.75rem;
       border-radius: var(--sl-border-radius, 0.375rem);
       color: var(--sl-color-gray-5, #4b4b4b);
       text-decoration: none;
@@ -414,6 +419,7 @@ export class StarlightHeader extends LitElement {
         </nav>
         <div class="header-actions">
           <button
+            id="_litro_search"
             class="search-pill"
             ?hidden="${!this.spaNav}"
             @click="${this._openSearch}"
@@ -434,7 +440,7 @@ export class StarlightHeader extends LitElement {
             href="${githubItem?.href ?? ''}"
             target="_blank"
             rel="noopener"
-            aria-label="GitHub"
+            aria-label="GitHub (opens in new tab)"
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path

--- a/packages/docs-ui/src/components/starlight-page.ts
+++ b/packages/docs-ui/src/components/starlight-page.ts
@@ -38,6 +38,7 @@ export class StarlightPage extends LitElement {
     noSidebar:   { type: Boolean },
     spaNav:      { type: Boolean },
     _navOpen:    { state: true },
+    _isDrawerMode: { state: true },
   };
 
   static override styles = css`
@@ -208,6 +209,25 @@ export class StarlightPage extends LitElement {
   noSidebar = false;
   spaNav = false;
   _navOpen = false;
+  _isDrawerMode = false;
+  private _drawerMql: MediaQueryList | null = null;
+  private _drawerMqlHandler = (e: MediaQueryListEvent) => {
+    this._isDrawerMode = e.matches;
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    if (typeof window !== 'undefined') {
+      this._drawerMql = window.matchMedia('(max-width: 72rem)');
+      this._isDrawerMode = this._drawerMql.matches;
+      this._drawerMql.addEventListener('change', this._drawerMqlHandler);
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._drawerMql?.removeEventListener('change', this._drawerMqlHandler);
+  }
 
   override updated(changed: Map<string, unknown>) {
     if (changed.has('currentPath') && this._navOpen) {
@@ -245,6 +265,7 @@ export class StarlightPage extends LitElement {
           <aside
             class="sidebar-wrap${this._navOpen ? ' nav-open' : ''}"
             ?hidden="${!hasSidebar}"
+            ?inert="${this._isDrawerMode && !this._navOpen}"
           >
             <starlight-sidebar
               .groups="${this.sidebar}"

--- a/packages/docs-ui/src/components/starlight-sidebar.ts
+++ b/packages/docs-ui/src/components/starlight-sidebar.ts
@@ -109,10 +109,10 @@ export class StarlightSidebar extends LitElement {
 
   override render() {
     return html`
-      <nav aria-label="Site navigation">
+      <nav id="_litro_nav" aria-label="Site navigation" tabindex="-1">
         ${this.groups.map(group => html`
           <div class="group">
-            <p class="group-label">${group.label}</p>
+            <h3 class="group-label">${group.label}</h3>
             <ul>
               ${group.items.map(item => html`
                 <li>

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -43,7 +43,11 @@ export const version = '0.0.1';
 export { definePageData, getServerData } from './runtime/page-data.js';
 export { LitroPage, LitroPageMixin } from './runtime/LitroPage.js';
 
+// Skip links — exported so sites can extend DEFAULT_SKIP_LINKS.
+export { DEFAULT_SKIP_LINKS } from './runtime/shell.js';
+
 // Type-only exports — erased at runtime, never cause module graph issues.
 export type { LitroRoute, LitroRouteMeta } from './types/route.js';
 export type { PageHandlerOptions } from './runtime/create-page-handler.js';
 export type { PageDataFetcher } from './runtime/page-data.js';
+export type { SkipLink } from './runtime/shell.js';

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -29,6 +29,7 @@ import type { EventHandler } from 'h3';
 import { RenderResultReadable } from '@lit-labs/ssr/lib/render-result-readable.js';
 import { renderToStream } from './ssr.js';
 import { buildShell } from './shell.js';
+import type { SkipLink } from './shell.js';
 import type { LitroRoute } from '../types/route.js';
 import type { PageDataFetcher } from './page-data.js';
 
@@ -45,6 +46,14 @@ export interface PageHandlerOptions {
    * when the pages plugin generates the #litro/page-manifest virtual module.
    */
   pageModule?: Record<string, unknown>;
+  /**
+   * Skip links rendered at the top of the page. Defaults to
+   * DEFAULT_SKIP_LINKS (a single "Skip to content" link).
+   *
+   * Sites with sidebars/search can extend:
+   *   skipLinks: [...DEFAULT_SKIP_LINKS, { label: 'Skip to navigation', href: '#_litro_nav' }]
+   */
+  skipLinks?: SkipLink[];
 }
 
 /**
@@ -67,7 +76,7 @@ export interface PageHandlerOptions {
  * @returns An H3 EventHandler.
  */
 export function createPageHandler(options: PageHandlerOptions): EventHandler {
-  const { route, routeMeta, pageModule } = options;
+  const { route, routeMeta, pageModule, skipLinks } = options;
 
   return defineEventHandler(async (event) => {
     // Content negotiation: if the client wants JSON, skip SSR and return only
@@ -172,6 +181,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
         serverDataJson,
         appScriptUrl,
         devMode: process.env.LITRO_DEV === 'true',
+        skipLinks,
       });
 
       // Construct the Lit template for this component. Dynamic tag names in
@@ -253,6 +263,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
         title: routeMeta?.title,
         head: typeof routeMeta?.head === 'string' ? routeMeta.head : undefined,
         appScriptUrl,
+        skipLinks,
       });
 
       // Client-only fallback: emit the shell with a bare component tag.

--- a/packages/framework/src/runtime/shell.ts
+++ b/packages/framework/src/runtime/shell.ts
@@ -57,6 +57,43 @@
 const DSD_POLYFILL =
   `(function(){if(!HTMLTemplateElement.prototype.hasOwnProperty('shadowRootMode')){const t=new MutationObserver(e=>{for(const n of e)for(const o of n.addedNodes)if(o instanceof HTMLTemplateElement&&o.getAttribute('shadowrootmode')){const e=o.getAttribute('shadowrootmode'),t=o.parentNode;if(t){const n=t.attachShadow({mode:e});n.appendChild(o.content.cloneNode(!0));o.remove()}}});t.observe(document.documentElement,{childList:!0,subtree:!0})}})();`;
 
+/** Inline script that powers skip links across shadow DOM boundaries.
+ *
+ * Three responsibilities:
+ * 1. Click handler — walks shadow roots to find the target element and focuses it.
+ * 2. Visibility — hides skip links (via `hidden`) when their target doesn't exist
+ *    on the current page. "Skip to navigation" is hidden on pages without a sidebar.
+ * 3. SPA reactivity — a MutationObserver on `<litro-outlet>` re-checks visibility
+ *    after each SPA page swap so skip links stay in sync during client navigation.
+ *
+ * Recipe/site layers can handle special skip link actions (e.g. opening a search
+ * modal) by listening for click events on their own skip link anchors.
+ */
+const SKIP_LINK_SCRIPT =
+  `(function(){function f(r,id){var s='#'+CSS.escape(id),d=r.querySelector(s);if(d)return d;var a=r.querySelectorAll('*');for(var i=0;i<a.length;i++){if(a[i].shadowRoot){var x=f(a[i].shadowRoot,id);if(x)return x}}return null}function u(){var ls=document.querySelectorAll('.skip-link[href^=\"#\"]');for(var i=0;i<ls.length;i++){var id=ls[i].getAttribute('href').slice(1);if(id==='_litro_main')continue;var t=document.getElementById(id)||f(document,id);if(t)ls[i].removeAttribute('hidden');else ls[i].setAttribute('hidden','')}}document.addEventListener('click',function(e){var l=e.target.closest('.skip-link');if(!l||l.hasAttribute('hidden'))return;var h=l.getAttribute('href');if(!h||h[0]!=='#')return;var id=h.slice(1);e.preventDefault();var t=document.getElementById(id)||f(document,id);if(t){if(!t.hasAttribute('tabindex'))t.setAttribute('tabindex','-1');t.focus({preventScroll:true});t.scrollIntoView()}});document.addEventListener('DOMContentLoaded',function(){requestAnimationFrame(u);var o=document.querySelector('litro-outlet');if(o)new MutationObserver(function(){requestAnimationFrame(u)}).observe(o,{childList:true})})})();`;
+
+/** A single skip link rendered at the top of the document body. */
+export interface SkipLink {
+  /** Visible text shown when the link is focused (e.g. "Skip to content"). */
+  label: string;
+  /** Fragment href (e.g. "#_litro_main"). Must start with "#". */
+  href: string;
+}
+
+/**
+ * Default skip links included in every Litro shell. Contains a single
+ * "Skip to content" link targeting the `<litro-outlet>` wrapper.
+ *
+ * Sites can extend this with spread syntax:
+ *   skipLinks: [...DEFAULT_SKIP_LINKS, { label: 'Skip to navigation', href: '#_litro_nav' }]
+ *
+ * Or replace it entirely:
+ *   skipLinks: [{ label: 'Skip to main', href: '#main' }]
+ */
+export const DEFAULT_SKIP_LINKS: SkipLink[] = [
+  { label: 'Skip to content', href: '#_litro_main' },
+];
+
 export interface ShellOptions {
   /** Document <title> text. Defaults to 'Litro'. */
   title?: string;
@@ -88,6 +125,16 @@ export interface ShellOptions {
    * browser calls location.reload(). Only injected in dev mode.
    */
   devMode?: boolean;
+  /**
+   * Skip links rendered at the top of `<body>`. Each link is visually hidden
+   * until focused, allowing keyboard/screen reader users to jump to key
+   * landmarks.
+   *
+   * Defaults to `DEFAULT_SKIP_LINKS` (a single "Skip to content" link).
+   * Links whose target doesn't exist on the current page are automatically
+   * hidden via a MutationObserver (the "#_litro_main" link is always visible).
+   */
+  skipLinks?: SkipLink[];
 }
 
 /**
@@ -130,6 +177,11 @@ export function buildShell(
     ? `\n  <script>(function(){var v=null;setInterval(function(){fetch('/_litro/_litro-version.json?_t='+Date.now()).then(function(r){return r.json()}).then(function(d){if(v===null){v=d.v}else if(v!==d.v){location.reload()}}).catch(function(){})},2500)})();</script>`
     : '';
 
+  const skipLinks = options?.skipLinks ?? DEFAULT_SKIP_LINKS;
+  const skipLinksHtml = skipLinks
+    .map((link) => `\n<a class="skip-link" href="${link.href}">${link.label}</a>`)
+    .join('');
+
   const head = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -144,9 +196,11 @@ export function buildShell(
     making it too late to upgrade them.
   -->
   <script>${DSD_POLYFILL}</script>${extraHead}${serverDataScript}${devReloadScript}
+  <style>.skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;z-index:999}.skip-link:focus{position:fixed;top:0.5rem;left:50%;transform:translateX(-50%);width:auto;height:auto;padding:0.5rem 1.5rem;background:#fff;color:#23262f;border:2px solid currentColor;border-radius:0.375rem;font-size:0.875rem;font-weight:600;z-index:999;box-shadow:0 2px 8px rgba(0,0,0,0.15)}.skip-link[hidden]{display:none}</style>
+  <script>${SKIP_LINK_SCRIPT}</script>
 </head>
-<body${bodyAttrs}>
-<litro-outlet>
+<body${bodyAttrs}>${skipLinksHtml}
+<litro-outlet id="_litro_main" tabindex="-1" style="outline:none">
 `;
 
   const foot = `</litro-outlet>

--- a/packages/litro-router/src/index.ts
+++ b/packages/litro-router/src/index.ts
@@ -92,6 +92,8 @@ export class LitroRouter {
   private _resolveToken = 0;
   /** Last pathname+search rendered by `_resolve()`. Used to skip re-renders on hash-only navigations. */
   private _lastPathAndSearch = '';
+  /** Screen-reader live region for announcing page changes after SPA navigation. */
+  private _announceEl: HTMLElement | null = null;
 
   constructor(outlet: HTMLElement) {
     this.outlet = outlet;
@@ -105,6 +107,25 @@ export class LitroRouter {
         component: r.component,
         action: r.action ?? (() => {}),
       }));
+
+    // Make the outlet programmatically focusable for post-navigation focus management.
+    if (!this.outlet.hasAttribute('tabindex')) {
+      this.outlet.setAttribute('tabindex', '-1');
+      this.outlet.style.outline = 'none';
+    }
+
+    // Create a persistent live region for screen reader route announcements.
+    if (!this._announceEl) {
+      this._announceEl = document.createElement('div');
+      this._announceEl.id = '_litro_announce';
+      this._announceEl.setAttribute('role', 'status');
+      this._announceEl.setAttribute('aria-live', 'polite');
+      this._announceEl.setAttribute('aria-atomic', 'true');
+      this._announceEl.className = 'sr-only';
+      this._announceEl.style.cssText =
+        'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
+      document.body.appendChild(this._announceEl);
+    }
 
     // Fragment navigations (clicking <a href="#section">) fire popstate per the
     // HTML spec. Guard against re-rendering the same page when only the hash changes.
@@ -202,6 +223,23 @@ export class LitroRouter {
         child = next;
       }
       el.removeAttribute('hidden');
+
+      // Focus the outlet so keyboard users start at the top of the new page.
+      this.outlet.focus({ preventScroll: true });
+
+      // Announce the new page to screen readers via the persistent live region.
+      if (this._announceEl) {
+        this._announceEl.textContent = '';
+        // Use a microtask so the empty→filled transition triggers the live region.
+        Promise.resolve().then(() => {
+          if (this._announceEl) {
+            // Try to find an h1 inside the new page element (may be in shadow DOM).
+            const heading = el.querySelector('h1')
+              ?? el.shadowRoot?.querySelector('h1');
+            this._announceEl.textContent = heading?.textContent?.trim() || document.title;
+          }
+        });
+      }
 
       // Scroll to top of the new page, then override with hash target if present.
       // Heading elements injected via unsafeHTML live inside shadow roots, so

--- a/playground-starlight/server/routes/[...].ts
+++ b/playground-starlight/server/routes/[...].ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeader, getRequestURL } from 'h3';
 import { createPageHandler } from '@beatzball/litro/runtime/create-page-handler.js';
+import { DEFAULT_SKIP_LINKS } from '@beatzball/litro';
 import type { LitroRoute } from '@beatzball/litro';
 import { routes, pageModules } from '#litro/page-manifest';
 
@@ -52,6 +53,10 @@ export default defineEventHandler(async (event) => {
     route: matched,
     routeMeta: (mod?.routeMeta as { title?: string; head?: string } | undefined),
     pageModule: mod,
+    skipLinks: [
+      ...DEFAULT_SKIP_LINKS,
+      { label: 'Skip to navigation', href: '#_litro_nav' },
+    ],
   });
   return handler(event);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   tar: '>=7.5.11'
   node-forge: '>=1.4.0'
   picomatch: '>=4.0.4'
+  lodash: '>=4.18.0'
 
 importers:
 
@@ -2221,8 +2222,8 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4181,7 +4182,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -5131,7 +5132,7 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 


### PR DESCRIPTION
## Summary

Comprehensive WCAG 2.1 AA accessibility audit across the framework shell, client router, and shared docs-ui components.

### Framework — skip links API
- **New `skipLinks` array API** on `ShellOptions` replaces `skipNav`/`skipSearch` booleans — sites declare exactly which skip links they need
- `DEFAULT_SKIP_LINKS` constant and `SkipLink` type exported from `@beatzball/litro`
- Generic shadow DOM traversal + MutationObserver for dynamic visibility during SPA navigation stays in framework
- Recipe-specific actions (e.g. search modal open) moved to site `app.ts`

### Router — SPA focus management
- `LitroRouter` focuses outlet after page swap (`tabindex="-1"`, `focus({ preventScroll: true })`)
- Persistent `aria-live="polite"` region announces new page `<h1>` text after navigation

### docs-ui component fixes
- **`litro-tabs`**: full WAI-ARIA Tabs Pattern — roving tabindex, arrow key navigation (Left/Right/Home/End), `aria-controls`/`aria-labelledby` linking, `role="tabpanel"` on panels
- **`starlight-page`**: sidebar `inert` when closed on mobile via `matchMedia` drawer mode detection
- **`starlight-header`**: 44px minimum touch targets (menu button, GitHub link, search pill), `focus-visible` on search inputs, GitHub link `aria-label` includes "(opens in new tab)"
- **`starlight-sidebar`**: `<h3>` group labels for heading navigation, `id="_litro_nav"` on `<nav>`
- **`search-modal`**: `aria-labelledby` with sr-only heading replaces `aria-label`, `focus-visible` ring
- **`preview-banner`**: `role="status"` for screen reader announcement

## Test plan
- [x] `pnpm --filter @beatzball/litro test` — 228 framework tests pass
- [x] `pnpm --filter @beatzball/litro-router test` — 18 router tests pass
- [x] `pnpm --filter @beatzball/create-litro test` — 17 scaffolding tests pass
- [x] `pnpm test:docs` — 43 docs unit tests pass
- [x] `pnpm test:e2e` — full Playwright suite
- [x] Manual keyboard testing: Tab → skip link → Enter → focus jumps to target
- [ ] Manual screen reader testing (VoiceOver): skip link announced, page changes announced, tabs navigable

🤖 Generated with [Claude Code](https://claude.com/claude-code)