### PR TITLE
fix: ignore internal docs packages in changeset config

### DIFF
--- a/.changeset/a11y-audit-phase-3-6.md
+++ b/.changeset/a11y-audit-phase-3-6.md
@@ -1,7 +1,6 @@
 ---
 "@beatzball/litro": minor
 "@beatzball/litro-router": patch
-"@beatzball/litro-docs-ui": patch
 "@beatzball/create-litro": patch
 ---
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,10 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@beatzball/litro-docs"]
+  "ignore": [
+    "@beatzball/litro-docs",
+    "@beatzball/litro-docs-content",
+    "@beatzball/litro-docs-ui",
+    "@beatzball/litro-docs-ssr"
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds `@beatzball/litro-docs-content`, `@beatzball/litro-docs-ui`, and `@beatzball/litro-docs-ssr` to the changesets `ignore` list — they are internal packages, not published to npm
- Removes `@beatzball/litro-docs-ui` from the `a11y-audit-phase-3-6` changeset to fix the "mixed changeset" error in the release workflow

## Test plan
- [ ] Merge and verify the `changesets/action@v1` CI job passes without the "mixed changeset" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)