### PR TITLE
fix: always scan routes on dev server start

### DIFF
--- a/.changeset/fix-dev-route-scan.md
+++ b/.changeset/fix-dev-route-scan.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": patch
+---
+
+Fix dev server skipping route scan when pre-built client bundle exists

--- a/packages/framework/src/cli/index.ts
+++ b/packages/framework/src/cli/index.ts
@@ -55,14 +55,18 @@ function run(
 
 switch (command) {
   case 'dev': {
+    // Always scan pages and write routes.generated.ts so Vite's dev middleware
+    // can resolve the import in app.ts. Without this file, page components
+    // never get defined and remain hidden behind :not(:defined) CSS.
+    console.log('[litro] Scanning pages...');
+    await scanAndWriteClientRoutes(cwd);
+
     // If dist/client/app.js doesn't exist, run vite build once so the static
     // asset handler has something to serve. Vite's dev middleware will still
     // intercept /_litro/app.js on the fly (serving app.ts) when available;
     // the pre-built file is the reliable fallback.
     const distClientApp = join(cwd, 'dist', 'client', 'app.js');
     if (!existsSync(distClientApp)) {
-      console.log('[litro] Scanning pages...');
-      await scanAndWriteClientRoutes(cwd);
       console.log('[litro] Building client bundle...');
       const binPath = join(cwd, 'node_modules', '.bin');
       const pathSep = process.platform === 'win32' ? ';' : ':';


### PR DESCRIPTION
## Summary
- Fix `litro dev` skipping `scanAndWriteClientRoutes()` when `dist/client/app.js` already exists from a previous build
- Without the route scan, `routes.generated.ts` is never written, so Vite can't resolve the routes import in `app.ts` — page components never get defined and remain hidden behind `:not(:defined) { visibility: hidden }` CSS

## Packages changed
- `@beatzball/litro` — patch: fix dev server skipping route scan when pre-built client bundle exists

## Test plan
- [x] Existing unit tests pass (228/228)
- [x] All 45 docs-ssr e2e tests pass (previously 13 failing)
- [x] Framework tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)