### PR TITLE
fix: Coolify deployment failing due to missing playground/tsconfig.json

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ node_modules
 .claude
 research
 benchmarks
+!benchmarks/results
 e2e
 playground
 playground-11ty

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
   "references": [
     { "path": "./packages/litro-router" },
     { "path": "./packages/framework" },
-    { "path": "./packages/create-litro" },
-    { "path": "./playground" }
+    { "path": "./packages/create-litro" }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `playground` from root `tsconfig.json` references — `playground/` is in `.dockerignore`, so Vite's esbuild fails with ENOENT when resolving the tsconfig reference chain during docs client build
- Allow `benchmarks/results/` through `.dockerignore` so `docs/pages/benchmarks.ts` can read `latest.json` at SSG build time

## Test plan
- [x] Existing unit tests pass (`pnpm test` — 228/228)
- [ ] Coolify deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)