### PR TITLE
feat: framework adapter interface (Phase 0)

### DIFF
--- a/.changeset/add-framework-adapter-interface.md
+++ b/.changeset/add-framework-adapter-interface.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": minor
+---
+
+Add framework adapter interface for pluggable web component framework support (Lit, FAST, Elena). Extract Lit-specific SSR and hydration code behind FrameworkAdapter contract. DSD polyfill is now conditional via shell options. Default adapter is 'lit' — zero breaking changes for existing projects.

--- a/e2e/docs-ssr/streaming.spec.ts
+++ b/e2e/docs-ssr/streaming.spec.ts
@@ -41,15 +41,19 @@ test('home page is served with chunked transfer encoding', async ({ request }) =
 // Shell ordering: hydration support script before app bundle
 // ---------------------------------------------------------------------------
 
-test('hydration support script appears before app bundle in head', async ({ request }) => {
+test('app bundle script appears in the document foot', async ({ request }) => {
   const res = await request.get('/');
   const html = await res.text();
 
-  const hydrateIdx = html.indexOf('lit-element-hydrate-support');
+  // The app bundle <script type="module"> must be present in the HTML.
+  // Hydration support (lit-element-hydrate-support.js) is the first import
+  // inside app.ts and is bundled into app.js — no separate script tag needed.
   const appIdx = html.indexOf('app.js');
-  expect(hydrateIdx).toBeGreaterThan(-1);
   expect(appIdx).toBeGreaterThan(-1);
-  expect(hydrateIdx).toBeLessThan(appIdx);
+  // The script should appear after the main content (in the foot)
+  const outletIdx = html.indexOf('</litro-outlet>');
+  expect(outletIdx).toBeGreaterThan(-1);
+  expect(appIdx).toBeGreaterThan(outletIdx);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -77,6 +77,16 @@
       "import": "./dist/content/plugin.js",
       "types": "./dist/content/plugin.d.ts"
     },
+    "./adapter": {
+      "source": "./src/adapter/index.ts",
+      "import": "./dist/adapter/index.js",
+      "types": "./dist/adapter/index.d.ts"
+    },
+    "./adapter/lit": {
+      "source": "./src/adapter/lit/index.ts",
+      "import": "./dist/adapter/lit/index.js",
+      "types": "./dist/adapter/lit/index.d.ts"
+    },
     "./content/env": {
       "types": "./src/content/env.d.ts"
     }

--- a/packages/framework/src/adapter/index.ts
+++ b/packages/framework/src/adapter/index.ts
@@ -1,0 +1,9 @@
+/**
+ * adapter/index.ts — Public adapter API
+ *
+ * Re-exports the adapter interface, types, and resolver.
+ * Server-side only — do NOT import from client code.
+ */
+
+export type { FrameworkAdapter, AdapterName, PageManifestEntry } from './types.js';
+export { resolveAdapter } from './resolve.js';

--- a/packages/framework/src/adapter/lit/index.ts
+++ b/packages/framework/src/adapter/lit/index.ts
@@ -1,0 +1,98 @@
+/**
+ * adapter/lit/index.ts — Lit framework adapter
+ *
+ * Implements FrameworkAdapter for Lit (Google). This is the default adapter
+ * and represents the extraction of Litro's original Lit-coupled code into
+ * the adapter interface — no new behaviour, just a structural refactor.
+ *
+ * SSR: @lit-labs/ssr renders components as Declarative Shadow DOM (DSD)
+ * Hydration: @lit-labs/ssr-client patches LitElement before component evaluation
+ * Styles: Shadow DOM with adoptedStyleSheets
+ */
+
+import { html, unsafeStatic } from 'lit/static-html.js';
+import { render } from '@lit-labs/ssr';
+import type { RenderResult } from '@lit-labs/ssr';
+import type { FrameworkAdapter } from '../types.js';
+
+/**
+ * Converts Lit SSR's RenderResult (a sync Iterable of strings and Promises)
+ * into an AsyncIterable<string> that the adapter interface expects.
+ *
+ * RenderResult is `Iterable<string | Promise<RenderResult>>`. Items are
+ * either string chunks (emitted synchronously) or Promises that resolve to
+ * nested RenderResults (for async component rendering). This function
+ * flattens both into a single async string stream.
+ */
+async function* renderResultToAsyncIterable(
+  result: RenderResult,
+): AsyncIterable<string> {
+  for (const chunk of result) {
+    if (typeof chunk === 'string') {
+      yield chunk;
+    } else {
+      // chunk is Promise<RenderResult> — await and recurse
+      const nested = await chunk;
+      yield* renderResultToAsyncIterable(nested);
+    }
+  }
+}
+
+/**
+ * Render a Lit component to an AsyncIterable<string> of HTML chunks.
+ *
+ * Uses unsafeStatic for dynamic tag names (required by Lit's template parser)
+ * and optionally binds .serverData as a property during SSR so the component's
+ * render() method sees real data on the server.
+ */
+function renderLitPage(tag: string, serverData: unknown): AsyncIterable<string> {
+  const tagStatic = unsafeStatic(tag);
+  const template = serverData != null
+    ? html`<${tagStatic} .serverData=${serverData}></${tagStatic}>`
+    : html`<${tagStatic}></${tagStatic}>`;
+  return renderResultToAsyncIterable(render(template));
+}
+
+export const litAdapter: FrameworkAdapter = {
+  name: 'lit',
+
+  renderPage(tag: string, serverData: unknown): AsyncIterable<string> {
+    return renderLitPage(tag, serverData);
+  },
+
+  getHeadScripts(_options: { isDev: boolean; basePath: string }): string {
+    // Lit's hydration support is bundled into app.js (first import in client.ts).
+    // No separate <script> tag needed in <head> — the import order inside the
+    // bundle handles it. Return empty string.
+    return '';
+  },
+
+  needsDSDPolyfill: true,
+
+  // Relative to framework package src. Consumed by the build pipeline to know
+  // which client entry to use. The actual client.ts file stays in runtime/ for
+  // backward compat — this path is informational for future adapter-aware builds.
+  clientEntryModule: '../runtime/client.js',
+
+  vitePlugins() {
+    return [];
+  },
+
+  nitroConfig() {
+    return {
+      externals: {
+        inline: ['@lit-labs/ssr', '@lit-labs/ssr-client'],
+      },
+      esbuild: {
+        options: {
+          tsconfigRaw: {
+            compilerOptions: {
+              experimentalDecorators: true,
+              useDefineForClassFields: false,
+            },
+          },
+        },
+      },
+    };
+  },
+};

--- a/packages/framework/src/adapter/resolve.ts
+++ b/packages/framework/src/adapter/resolve.ts
@@ -1,0 +1,51 @@
+/**
+ * adapter/resolve.ts — Adapter resolution
+ *
+ * Reads the adapter name from config (or environment) and returns the
+ * concrete FrameworkAdapter instance. Defaults to 'lit' when no adapter
+ * is specified, ensuring backward compatibility with existing projects.
+ *
+ * Resolution order:
+ *   1. Explicit `adapter` argument (passed by CLI or build pipeline)
+ *   2. LITRO_ADAPTER environment variable
+ *   3. Default: 'lit'
+ */
+
+import type { FrameworkAdapter, AdapterName } from './types.js';
+
+/**
+ * Resolves and returns the FrameworkAdapter for the given adapter name.
+ *
+ * Each adapter is loaded lazily via dynamic import so that unused adapters
+ * (and their framework dependencies) are never pulled into the module graph.
+ *
+ * @param name - Adapter name. Defaults to 'lit'.
+ * @returns The resolved FrameworkAdapter instance.
+ * @throws If the adapter name is not recognised.
+ */
+export async function resolveAdapter(
+  name?: AdapterName | string,
+): Promise<FrameworkAdapter> {
+  const resolved = name ?? process.env.LITRO_ADAPTER ?? 'lit';
+
+  switch (resolved) {
+    case 'lit': {
+      const { litAdapter } = await import('./lit/index.js');
+      return litAdapter;
+    }
+    // Future adapters:
+    // case 'fast': {
+    //   const { fastAdapter } = await import('./fast/index.js');
+    //   return fastAdapter;
+    // }
+    // case 'elena': {
+    //   const { elenaAdapter } = await import('./elena/index.js');
+    //   return elenaAdapter;
+    // }
+    default:
+      throw new Error(
+        `[litro] Unknown adapter "${resolved}". ` +
+        `Supported adapters: lit, fast, elena.`,
+      );
+  }
+}

--- a/packages/framework/src/adapter/stream.ts
+++ b/packages/framework/src/adapter/stream.ts
@@ -1,0 +1,41 @@
+/**
+ * adapter/stream.ts — Framework-agnostic stream utilities
+ *
+ * Converts an AsyncIterable<string> (the common output of all adapter
+ * renderPage() implementations) into a Node.js Readable stream for use
+ * with Nitro's sendStream().
+ *
+ * This replaces the direct dependency on @lit-labs/ssr's RenderResultReadable,
+ * which was Lit-specific. The adapter now returns a standard AsyncIterable
+ * and this utility handles the Node.js stream plumbing.
+ */
+
+import { Readable } from 'node:stream';
+
+/**
+ * Converts an AsyncIterable<string> into a Node.js Readable stream.
+ *
+ * Respects backpressure: pauses iteration when the consumer signals it
+ * can't accept more data (highWaterMark reached), and resumes when drained.
+ *
+ * @param iterable - Async iterable of HTML string chunks.
+ * @returns A Node.js Readable that yields the same chunks.
+ */
+export function iterableToReadable(iterable: AsyncIterable<string>): Readable {
+  const iterator = iterable[Symbol.asyncIterator]();
+  return new Readable({
+    encoding: 'utf-8',
+    async read() {
+      try {
+        const { value, done } = await iterator.next();
+        if (done) {
+          this.push(null);
+        } else {
+          this.push(value);
+        }
+      } catch (err) {
+        this.destroy(err as Error);
+      }
+    },
+  });
+}

--- a/packages/framework/src/adapter/types.ts
+++ b/packages/framework/src/adapter/types.ts
@@ -1,0 +1,106 @@
+/**
+ * adapter/types.ts — Framework adapter interface
+ *
+ * Defines the contract between Litro's infrastructure (SSR pipeline, shell
+ * builder, CLI, Vite/Nitro config) and a concrete web component framework
+ * (Lit, FAST, Elena).
+ *
+ * The adapter is selected per-project via the `adapter` field in
+ * LitroConfig. Each adapter provides:
+ *   - SSR rendering: turn a custom element tag + server data into an HTML stream
+ *   - Shell customisation: hydration scripts, DSD polyfill toggle
+ *   - Build config: Vite plugins, Nitro externals / esbuild options
+ *   - Component registration: how page modules are registered on the server
+ *
+ * Users write native framework classes (LitElement, FASTElement, Elena mixin)
+ * — the adapter does NOT define a component authoring API.
+ */
+
+import type { NitroConfig } from 'nitropack';
+import type { Plugin as VitePlugin } from 'vite';
+
+/** Supported adapter names. */
+export type AdapterName = 'lit' | 'fast' | 'elena';
+
+/**
+ * Minimal page manifest entry used by adapter.registerComponents().
+ * Mirrors the shape of a page manifest entry without depending on the full
+ * LitroRoute type (which carries build-time metadata the adapter doesn't need).
+ */
+export interface PageManifestEntry {
+  /** Custom element tag name, e.g. 'page-home'. */
+  tag: string;
+  /** Pre-imported module for this page (from #litro/page-manifest). */
+  module: Record<string, unknown>;
+}
+
+export interface FrameworkAdapter {
+  /** Framework identifier. */
+  readonly name: AdapterName;
+
+  /**
+   * Render a page component to an async HTML stream.
+   *
+   * The adapter instantiates the custom element identified by `tag`, optionally
+   * binds `serverData` as a property, and runs the framework's SSR engine.
+   *
+   * The returned iterable yields HTML string chunks — DSD-wrapped for Shadow DOM
+   * frameworks (Lit, FAST) or plain HTML for light DOM frameworks (Elena).
+   *
+   * @param tag        - Custom element tag name, e.g. 'page-home'.
+   * @param serverData - Result of definePageData() for this route, or undefined.
+   * @returns Async iterable of HTML string chunks.
+   */
+  renderPage(tag: string, serverData: unknown): AsyncIterable<string>;
+
+  /**
+   * Raw HTML to inject into <head> for hydration and framework bootstrap.
+   *
+   * Called once per HTML response by shell.ts. Lit emits the hydrate-support
+   * script; Elena emits nothing; FAST emits its command buffer bootstrap.
+   *
+   * The app bundle `<script type="module">` is handled separately by shell.ts —
+   * this method only returns framework-specific head content.
+   */
+  getHeadScripts(options: { isDev: boolean; basePath: string }): string;
+
+  /**
+   * Whether the HTML shell should include the DSD polyfill inline script.
+   *
+   * true for Shadow DOM frameworks (Lit, FAST) whose SSR output contains
+   * <template shadowrootmode="open"> elements. false for light DOM
+   * frameworks (Elena) that render plain HTML.
+   */
+  readonly needsDSDPolyfill: boolean;
+
+  /**
+   * Path to the client entry module that bootstraps the framework runtime.
+   *
+   * This module is imported as the app entry point by Vite's client build.
+   * It must set up hydration support (if needed), import the router, and
+   * register the framework's Outlet/Link/Page custom elements.
+   *
+   * Example: './src/adapter/lit/client.ts' (resolved relative to framework package)
+   */
+  readonly clientEntryModule: string;
+
+  /**
+   * Vite plugin(s) the adapter requires in the client build.
+   *
+   * Merged into the project's vite.config.ts plugins array. Return an empty
+   * array if no special Vite plugins are needed (Lit, for example, needs none).
+   */
+  vitePlugins(): VitePlugin[];
+
+  /**
+   * Additional Nitro config the adapter needs merged into the project's
+   * nitro.config.ts.
+   *
+   * Common uses:
+   *   - externals.inline for SSR packages (e.g. '@lit-labs/ssr')
+   *   - esbuild.options for decorator/class field settings
+   *
+   * Return an empty object if no Nitro config overrides are needed.
+   */
+  nitroConfig(): Partial<NitroConfig>;
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -51,3 +51,5 @@ export type { LitroRoute, LitroRouteMeta } from './types/route.js';
 export type { PageHandlerOptions } from './runtime/create-page-handler.js';
 export type { PageDataFetcher } from './runtime/page-data.js';
 export type { SkipLink } from './runtime/shell.js';
+export type { LitroConfig } from './types/config.js';
+export type { FrameworkAdapter, AdapterName } from './adapter/types.js';

--- a/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
+++ b/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for createPageHandler() — specifically the seoHead / seoTitle
  * extraction from pageData and injection into the HTML shell.
  *
- * Heavy dependencies (@lit-labs/ssr, H3 streams, Lit) are mocked so the test
+ * Heavy dependencies (framework adapter, H3 streams) are mocked so the test
  * runs in a plain Node environment without a browser or Nitro server.
  *
  * Run with: pnpm --filter @beatzball/litro test
@@ -19,24 +19,32 @@ vi.mock('../shell.js', () => ({
   buildShell: vi.fn().mockReturnValue({ head: '', foot: '' }),
 }));
 
-vi.mock('../ssr.js', () => ({
-  renderToStream: vi.fn().mockReturnValue(
-    (async function* () {
-      // empty stream
-    })(),
-  ),
+// Mock the adapter resolver to return a minimal adapter that yields an empty stream.
+vi.mock('../../adapter/resolve.js', () => ({
+  resolveAdapter: vi.fn().mockResolvedValue({
+    name: 'lit',
+    renderPage: vi.fn().mockReturnValue(
+      (async function* () {
+        // empty stream
+      })(),
+    ),
+    getHeadScripts: vi.fn().mockReturnValue(''),
+    needsDSDPolyfill: true,
+    clientEntryModule: '../runtime/client.js',
+    vitePlugins: () => [],
+    nitroConfig: () => ({}),
+  }),
 }));
 
-vi.mock('@lit-labs/ssr/lib/render-result-readable.js', async () => {
+// Mock iterableToReadable to return a PassThrough that ends immediately.
+vi.mock('../../adapter/stream.js', async () => {
   const { PassThrough } = await import('node:stream');
   return {
-    RenderResultReadable: class MockRenderResultReadable extends PassThrough {
-      constructor(_iterable: AsyncIterable<string>) {
-        super();
-        // End the stream after the current tick so pipe() can be set up first.
-        process.nextTick(() => this.end());
-      }
-    },
+    iterableToReadable: vi.fn().mockImplementation(() => {
+      const pt = new PassThrough();
+      process.nextTick(() => pt.end());
+      return pt;
+    }),
   };
 });
 
@@ -52,11 +60,6 @@ vi.mock('h3', () => ({
   sendStream: vi.fn().mockResolvedValue(undefined),
   getRequestHeader: vi.fn((_: unknown, name: string) => mockRequestHeaders.current[name.toLowerCase()] ?? undefined),
   getRequestURL: vi.fn(() => new URL('http://localhost/')),
-}));
-
-vi.mock('lit/static-html.js', () => ({
-  html: vi.fn().mockReturnValue({}),
-  unsafeStatic: vi.fn().mockReturnValue('mock-tag'),
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/framework/src/runtime/__tests__/shell.test.ts
+++ b/packages/framework/src/runtime/__tests__/shell.test.ts
@@ -75,6 +75,39 @@ describe('buildShell — head: DSD polyfill', () => {
 });
 
 // ---------------------------------------------------------------------------
+// head — DSD polyfill opt-out (light DOM adapters)
+// ---------------------------------------------------------------------------
+
+describe('buildShell — head: DSD polyfill opt-out', () => {
+  it('omits the DSD polyfill when includeDSDPolyfill is false', () => {
+    const { head } = buildDefault('page-home', { includeDSDPolyfill: false });
+    // The DSD polyfill specifically checks for shadowRootMode on HTMLTemplateElement.
+    // The skip link script also uses MutationObserver, so we check for the DSD-specific string.
+    expect(head).not.toContain('HTMLTemplateElement.prototype.hasOwnProperty');
+    expect(head).not.toContain('shadowrootmode');
+  });
+
+  it('still includes title, meta, and other head content when DSD polyfill is excluded', () => {
+    const { head } = buildDefault('page-home', {
+      includeDSDPolyfill: false,
+      title: 'No Polyfill',
+    });
+    expect(head).toContain('<title>No Polyfill</title>');
+    expect(head).toContain('<meta charset="UTF-8"');
+  });
+
+  it('includes the DSD polyfill by default (includeDSDPolyfill not specified)', () => {
+    const { head } = buildDefault();
+    expect(head).toContain('HTMLTemplateElement.prototype.hasOwnProperty');
+  });
+
+  it('includes the DSD polyfill when includeDSDPolyfill is explicitly true', () => {
+    const { head } = buildDefault('page-home', { includeDSDPolyfill: true });
+    expect(head).toContain('HTMLTemplateElement.prototype.hasOwnProperty');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // head — no separate hydration support script
 // ---------------------------------------------------------------------------
 

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -1,37 +1,29 @@
 /**
  * create-page-handler.ts — SSR handler factory
  *
- * Returns an H3 EventHandler that server-renders a Lit page component and
- * streams the full HTML document to the client using @lit-labs/ssr.
+ * Returns an H3 EventHandler that server-renders a page component and
+ * streams the full HTML document to the client.
  *
  * Streaming architecture (in order):
- *   1. shell.head  — written synchronously: DOCTYPE, <head>, DSD polyfill,
- *                    hydration script, <body>
- *   2. SSR output  — streamed async from @lit-labs/ssr via RenderResultReadable
- *                    (Lit component HTML with Declarative Shadow DOM)
+ *   1. shell.head  — written synchronously: DOCTYPE, <head>, polyfill (if needed),
+ *                    hydration scripts, <body>
+ *   2. SSR output  — streamed async from the framework adapter's renderPage()
  *   3. shell.foot  — written synchronously after stream ends: app bundle
  *                    <script>, </body>, </html>
  *
- * Node.js / Edge note:
- *   RenderResultReadable (from @lit-labs/ssr/lib/render-result-readable.js)
- *   extends Node.js stream.Readable. It is NOT available in Cloudflare Workers
- *   or other edge runtimes that lack Node.js stream APIs. For Cloudflare Workers
- *   support, the SSR output must be converted to a Web ReadableStream manually
- *   (iterate the AsyncIterable<string> returned by renderToStream() and enqueue
- *   into a new ReadableStream controller). This is left as a TODO for the edge
- *   adapter work; the Node.js implementation is correct for all non-edge targets.
+ * The adapter is resolved at handler creation time and determines how
+ * components are rendered on the server (DSD for Lit/FAST, plain HTML for Elena).
  */
 
 import { PassThrough } from 'node:stream';
-import { html, unsafeStatic } from 'lit/static-html.js';
 import { defineEventHandler, setResponseHeader, sendStream, getRequestHeader, getRequestURL } from 'h3';
 import type { EventHandler } from 'h3';
-import { RenderResultReadable } from '@lit-labs/ssr/lib/render-result-readable.js';
-import { renderToStream } from './ssr.js';
 import { buildShell } from './shell.js';
 import type { SkipLink } from './shell.js';
 import type { LitroRoute } from '../types/route.js';
 import type { PageDataFetcher } from './page-data.js';
+import type { FrameworkAdapter } from '../adapter/types.js';
+import { iterableToReadable } from '../adapter/stream.js';
 
 export interface PageHandlerOptions {
   route: LitroRoute;
@@ -54,29 +46,47 @@ export interface PageHandlerOptions {
    *   skipLinks: [...DEFAULT_SKIP_LINKS, { label: 'Skip to navigation', href: '#_litro_nav' }]
    */
   skipLinks?: SkipLink[];
+  /**
+   * Framework adapter instance. Determines how page components are
+   * rendered on the server and what hydration scripts are emitted.
+   *
+   * When omitted, falls back to resolving from the LITRO_ADAPTER env var
+   * (default: 'lit'). Prefer passing explicitly for deterministic builds.
+   */
+  adapter?: FrameworkAdapter;
 }
 
 /**
- * Creates an H3 EventHandler that SSR-renders the given Lit page component.
+ * Creates an H3 EventHandler that SSR-renders the given page component.
  *
  * The handler:
  *   1. Dynamically imports the component module (registers it with the
  *      server-side customElements registry as a side effect).
- *   2. Instantiates the component via a Lit html`` template.
- *   3. Pipes the SSR stream (head → DSD HTML → foot) to the HTTP response.
+ *   2. Delegates rendering to the framework adapter's renderPage().
+ *   3. Pipes the SSR stream (head → HTML → foot) to the HTTP response.
  *
  * Error handling:
  *   If SSR throws (e.g., the component accesses window/document at module
  *   eval time, or render() throws mid-stream), the handler logs a warning
  *   and falls back to serving the client-only HTML shell. This ensures the
- *   page is still usable — Lit will render client-side — rather than serving
- *   a 500 error in production.
+ *   page is still usable — the framework will render client-side — rather
+ *   than serving a 500 error in production.
  *
  * @param options - Route descriptor and optional route metadata.
  * @returns An H3 EventHandler.
  */
 export function createPageHandler(options: PageHandlerOptions): EventHandler {
   const { route, routeMeta, pageModule, skipLinks } = options;
+
+  // Resolve adapter lazily — allows handler creation before adapter is loaded.
+  let adapterPromise: Promise<FrameworkAdapter> | undefined;
+  function getAdapter(): Promise<FrameworkAdapter> {
+    if (options.adapter) return Promise.resolve(options.adapter);
+    if (!adapterPromise) {
+      adapterPromise = import('../adapter/resolve.js').then(m => m.resolveAdapter());
+    }
+    return adapterPromise;
+  }
 
   return defineEventHandler(async (event) => {
     // Content negotiation: if the client wants JSON, skip SSR and return only
@@ -120,6 +130,8 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
     setResponseHeader(event, 'x-nitro-prerender', ogRoute);
 
     try {
+      const adapter = await getAdapter();
+
       // Resolve the page module. The preferred path is the pre-bundled module
       // from the #litro/page-manifest registry (pageModule option), which was
       // statically imported and compiled by Rollup at build time.
@@ -177,6 +189,10 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // handler serves the pre-built dist/client/app.js as a fallback.
       const basePath = process.env.LITRO_BASE_PATH ?? '';
       const appScriptUrl = `${basePath}/_litro/app.js`;
+      const isDev = process.env.LITRO_DEV === 'true';
+
+      // Get any framework-specific head scripts from the adapter.
+      const adapterHeadScripts = adapter.getHeadScripts({ isDev, basePath });
 
       // Build the HTML shell for this component. The shell is split into head
       // and foot so we can stream the SSR output between the two halves.
@@ -185,41 +201,22 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       const staticHead = typeof routeMeta?.head === 'string' ? routeMeta.head : '';
       const shell = buildShell(route.componentTag, '', {
         title: dynamicTitle ?? routeMeta?.title,
-        head: staticHead + dynamicHead || undefined,
+        head: staticHead + dynamicHead + adapterHeadScripts || undefined,
         serverDataJson,
         appScriptUrl,
-        devMode: process.env.LITRO_DEV === 'true',
+        devMode: isDev,
         skipLinks,
+        includeDSDPolyfill: adapter.needsDSDPolyfill,
       });
 
-      // Construct the Lit template for this component. Dynamic tag names in
-      // Lit templates must use unsafeStatic (from lit/static-html.js) — plain
-      // expression interpolation of tag names is an invalid Lit expression
-      // location and causes SSR to throw "Unexpected final partIndex".
-      //
-      // When serverDataJson is available, pass the parsed data as a .serverData
-      // property binding so this.serverData is populated *during* SSR. This means
-      // render() sees the real data and the streamed DSD HTML already shows the
-      // correct content (not "No data yet"). After JS loads, the router creates
-      // a new component instance, calls onBeforeEnter() → getServerData() (reads
-      // the JSON script tag still in the DOM) → sets serverData on the new
-      // instance, producing the same content seamlessly.
-      const tagStatic = unsafeStatic(route.componentTag);
-      const template = serverDataJson
-        ? html`<${tagStatic} .serverData=${JSON.parse(serverDataJson)}></${tagStatic}>`
-        : html`<${tagStatic}></${tagStatic}>`;
+      // Delegate rendering to the framework adapter. The adapter returns an
+      // AsyncIterable<string> of HTML chunks — DSD-wrapped for Shadow DOM
+      // frameworks (Lit, FAST) or plain HTML for light DOM (Elena).
+      const serverData = serverDataJson ? JSON.parse(serverDataJson) : undefined;
+      const ssrIterable = adapter.renderPage(route.componentTag, serverData);
 
-      // Get the AsyncIterable<string> from the SSR engine.
-      const ssrIterable = renderToStream(template);
-
-      // Wrap in RenderResultReadable to get a Node.js Readable stream.
-      // RenderResultReadable extends stream.Readable, pulling from the async
-      // generator on demand and respecting backpressure.
-      //
-      // NOTE: RenderResultReadable is Node.js-only. For Cloudflare Workers /
-      // edge runtimes, convert ssrIterable to a Web ReadableStream instead
-      // (see module-level doc comment for the conversion pattern).
-      const ssrReadable = new RenderResultReadable(ssrIterable);
+      // Convert the async iterable to a Node.js Readable stream.
+      const ssrReadable = iterableToReadable(ssrIterable);
 
       // Use a PassThrough stream to combine head + SSR output + foot into a
       // single Readable that Nitro's sendStream() can consume.
@@ -252,7 +249,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
     } catch (err) {
       // SSR setup failure (e.g., dynamic import threw, or component accesses
       // window/document at module eval time). Log a warning and fall back to
-      // the client-only shell so the page remains usable via client-side Lit.
+      // the client-only shell so the page remains usable via client-side rendering.
       console.warn(
         '[litro] SSR failed for',
         route.componentTag,
@@ -275,7 +272,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       });
 
       // Client-only fallback: emit the shell with a bare component tag.
-      // Lit will render the component entirely on the client side.
+      // The framework will render the component entirely on the client side.
       const fallbackHtml =
         fallbackShell.head +
         `<${route.componentTag}></${route.componentTag}>` +

--- a/packages/framework/src/runtime/shell.ts
+++ b/packages/framework/src/runtime/shell.ts
@@ -1,25 +1,24 @@
 /**
  * shell.ts — HTML document shell builder
  *
- * Produces the full HTML document wrapping an SSR'd Lit component. The shell
+ * Produces the full HTML document wrapping an SSR'd page component. The shell
  * is split into two parts — `head` and `foot` — so the streamed SSR content
  * can be piped between them:
  *
  *   response.write(shell.head)       // DOCTYPE, <head>, <body>, opening wrapper
- *   // ... stream SSR DSD output ... // Lit component with shadow DOM HTML
+ *   // ... stream SSR output ...     // Component HTML (DSD or plain, per adapter)
  *   response.write(shell.foot)       // closing wrapper, </body>, </html>
  *
  * Script loading order in <head> is CRITICAL for hydration correctness:
  *
- *   1. DSD polyfill (inline, synchronous) — must run as the parser encounters
- *      <template shadowrootmode> elements. A type="module" script is deferred
- *      and arrives too late; a plain inline script runs synchronously.
+ *   1. DSD polyfill (inline, synchronous) — included only when the adapter
+ *      sets `needsDSDPolyfill: true` (Shadow DOM frameworks like Lit/FAST).
+ *      Must run as the parser encounters <template shadowrootmode> elements.
+ *      Omitted for light DOM adapters (Elena).
  *
  *   2. app.js (type="module" in the foot) — the Vite-built client bundle.
- *      `@lit-labs/ssr-client/lit-element-hydrate-support.js` is the FIRST
- *      import inside app.ts, so the hydration patch is applied before any
- *      LitElement subclass is evaluated within the same bundle. No separate
- *      hydration-support script tag is needed.
+ *      The framework adapter's client entry is the first import, setting up
+ *      any hydration patches before components are evaluated.
  *
  * The default app script path `/_litro/app.js` maps to `dist/client/app.js`
  * via the `publicAssets` entry in nitro.config.ts. In dev mode, pass
@@ -135,6 +134,15 @@ export interface ShellOptions {
    * hidden via a MutationObserver (the "#_litro_main" link is always visible).
    */
   skipLinks?: SkipLink[];
+  /**
+   * Whether to include the Declarative Shadow DOM polyfill inline script.
+   *
+   * Defaults to true for backward compatibility. Set to false for light DOM
+   * adapters (Elena) where no DSD templates are present in the SSR output.
+   *
+   * @default true
+   */
+  includeDSDPolyfill?: boolean;
 }
 
 /**
@@ -182,12 +190,9 @@ export function buildShell(
     .map((link) => `\n<a class="skip-link" href="${link.href}">${link.label}</a>`)
     .join('');
 
-  const head = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>${title}</title>
+  const includeDSD = options?.includeDSDPolyfill !== false;
+  const dsdPolyfillBlock = includeDSD
+    ? `
   <!--
     DSD polyfill — required for ~4% of browsers (pre-Firefox 119, pre-Safari 16.4)
     that do not natively support Declarative Shadow DOM (shadowrootmode attribute).
@@ -195,7 +200,15 @@ export function buildShell(
     by the browser and arrives after the parser has already processed the DSD templates,
     making it too late to upgrade them.
   -->
-  <script>${DSD_POLYFILL}</script>${extraHead}${serverDataScript}${devReloadScript}
+  <script>${DSD_POLYFILL}</script>`
+    : '';
+
+  const head = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${title}</title>${dsdPolyfillBlock}${extraHead}${serverDataScript}${devReloadScript}
   <style>.skip-link{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;z-index:999}.skip-link:focus{position:fixed;top:0.5rem;left:50%;transform:translateX(-50%);width:auto;height:auto;padding:0.5rem 1.5rem;background:#fff;color:#23262f;border:2px solid currentColor;border-radius:0.375rem;font-size:0.875rem;font-weight:600;z-index:999;box-shadow:0 2px 8px rgba(0,0,0,0.15)}.skip-link[hidden]{display:none}</style>
   <script>${SKIP_LINK_SCRIPT}</script>
 </head>
@@ -206,9 +219,7 @@ export function buildShell(
   const foot = `</litro-outlet>
 
   <!--
-    App bundle — @lit-labs/ssr-client/lit-element-hydrate-support.js is the
-    first import inside app.ts, so the hydration patch runs before any
-    LitElement subclass is evaluated within this bundle.
+    App bundle — framework adapter bootstrap + page components.
     /_litro/ maps to dist/client/ (Vite output) via publicAssets in nitro.config.ts.
   -->
   <script type="module" src="${appScriptUrl}"></script>

--- a/packages/framework/src/types/config.ts
+++ b/packages/framework/src/types/config.ts
@@ -1,0 +1,35 @@
+/**
+ * types/config.ts — Litro configuration types
+ *
+ * Defines the shape of user-facing Litro configuration. Currently the
+ * `adapter` field is the only Litro-specific config; all other settings
+ * (server, build, deploy) are Nitro and Vite config.
+ *
+ * The adapter field can be set:
+ *   - In nitro.config.ts via `runtimeConfig.litro.adapter`
+ *   - Via LITRO_ADAPTER environment variable
+ *   - Via `create-litro --adapter <name>`
+ *
+ * When omitted, defaults to 'lit' for full backward compatibility.
+ */
+
+import type { AdapterName } from '../adapter/types.js';
+
+export interface LitroConfig {
+  /**
+   * Which web component framework adapter to use.
+   *
+   * - `'lit'`   — Lit (default). Shadow DOM, DSD SSR, @lit-labs/ssr hydration.
+   * - `'fast'`  — Microsoft FAST. Shadow DOM, DSD SSR, command buffer hydration.
+   * - `'elena'` — Elena. Light DOM, @scope CSS, progressive enhancement.
+   *
+   * The adapter controls:
+   *   - How page components are SSR-rendered (DSD vs. plain HTML)
+   *   - What hydration scripts appear in <head>
+   *   - Which internal components (Outlet, Link, Page) are registered
+   *   - Nitro and Vite build configuration
+   *
+   * @default 'lit'
+   */
+  adapter?: AdapterName;
+}

--- a/prd/PRD-ADAPTER.md
+++ b/prd/PRD-ADAPTER.md
@@ -1,0 +1,422 @@
+# PRD: Framework-Agnostic Adapter Architecture
+
+**Priority:** P0
+**Effort:** 5-6 weeks across 5 phases
+**Dependencies:** None — current test suite (360 unit + 92 e2e) is the correctness baseline
+
+---
+
+## Problem
+
+Litro is a fullstack web framework built on the Custom Elements standard, but its runtime and SSR pipeline are hard-wired to Lit. This couples the framework to a single rendering library and prevents users from choosing alternatives like Microsoft FAST or Elena — a lightweight, light-DOM-first library gaining community traction. The coupling is concentrated in two well-defined clusters:
+
+1. **Client runtime** — `LitroOutlet`, `LitroLink`, `LitroPage` extend `LitElement`, use `html`/`css` tagged templates, and depend on `@lit-labs/ssr-client` hydration patches
+2. **SSR pipeline** — `ssr.ts` imports `@lit-labs/ssr`; `create-page-handler.ts` uses `lit/static-html.js` for dynamic component instantiation and `RenderResultReadable` for streaming
+
+Meanwhile, the majority of Litro's codebase — router, page scanner, CLI, content system, data layer, Vite plugins, shell generation — is already framework-agnostic.
+
+---
+
+## Goals
+
+1. Users choose a framework adapter (`lit`, `fast`, or `elena`) at project creation time via `create-litro --adapter <name>` or in `litro.config.ts`.
+2. Every page in a project uses the same framework. Users write native framework classes (LitElement, FASTElement, Elena mixin) — no Litro-specific component descriptor or template IR.
+3. Litro's 3 internal runtime components (Outlet, Link, Page) have native implementations for each supported framework.
+4. The SSR pipeline renders any adapter's components to a streamable HTML response via a unified `FrameworkAdapter` interface.
+5. Existing Lit-based projects continue working with zero migration. `lit` is the default adapter.
+6. All 3 adapters pass the same test suite (unit + e2e), with framework-specific test fixtures where DOM output differs (Shadow DOM vs. light DOM).
+
+---
+
+## Non-Goals
+
+- **Per-page framework mixing.** The adapter is project-wide. Per-page dispatch (mixed hydration, framework-aware routing, SSR orchestration across output formats) is deferred unless user demand surfaces. The adapter interface is designed to not preclude this.
+- **Template IR or `LitroComponentDef`.** No framework-neutral component authoring API. Users write native classes.
+- **Custom Elements Manifest (CEM) integration.** CEM is a potential future tooling integration (IDE support, per-page detection if mixing is added), not part of the adapter contract.
+- **Decorator translation.** Users use whatever decorator/property system their chosen framework provides. Litro does not abstract reactive properties.
+
+---
+
+## Architecture
+
+### Adapter interface
+
+The contract between Litro's infrastructure and a framework runtime:
+
+```typescript
+// packages/framework/src/adapter/types.ts
+
+interface FrameworkAdapter {
+  /** Framework identifier */
+  name: 'lit' | 'fast' | 'elena';
+
+  /** Render a page component to an async HTML stream.
+   *  The component is identified by its custom element tag name.
+   *  `serverData` is the result of definePageData() for this route. */
+  renderPage(tag: string, serverData: unknown): AsyncIterable<string>;
+
+  /** Scripts/links to inject into <head> for hydration and bootstrap.
+   *  Called once per HTML response by shell.ts. */
+  getHeadScripts(options: { isDev: boolean; basePath: string }): string;
+
+  /** Whether the HTML shell should include the DSD polyfill.
+   *  true for Shadow DOM frameworks (Lit, FAST), false for Elena. */
+  needsDSDPolyfill: boolean;
+
+  /** Path to the client entry module that bootstraps the framework runtime.
+   *  Replaces the current hardcoded client.ts import. */
+  clientEntryModule: string;
+
+  /** Register all page components on the server before SSR.
+   *  Called during server startup. Each framework has different
+   *  registration mechanics (customElements.define, FASTElement.define,
+   *  Elena Class.define). */
+  registerComponents(manifest: PageManifest): void;
+
+  /** Vite plugin(s) the adapter needs in the client build.
+   *  e.g., Lit needs no special plugin; FAST may need template compilation;
+   *  Elena may need @scope CSS processing. */
+  vitePlugins(): import('vite').Plugin[];
+
+  /** Additional Nitro config the adapter needs.
+   *  e.g., externals, esbuild options, virtual modules. */
+  nitroConfig(): Partial<NitroConfig>;
+}
+```
+
+### What calls the adapter
+
+| Litro subsystem | Currently Lit-specific | After refactor |
+|---|---|---|
+| `ssr.ts` | Imports `@lit-labs/ssr`, calls `render()` | Calls `adapter.renderPage(tag, data)` |
+| `create-page-handler.ts` | Uses `html`/`unsafeStatic` from Lit, `RenderResultReadable` | Calls `adapter.renderPage()`, pipes `AsyncIterable<string>` to Nitro response |
+| `shell.ts` | Hardcoded DSD polyfill, hardcoded hydrate-support script | Calls `adapter.getHeadScripts()`, conditionally includes DSD polyfill via `adapter.needsDSDPolyfill` |
+| `client.ts` | Imports `@lit-labs/ssr-client/lit-element-hydrate-support.js` first | Each adapter provides its own client entry via `adapter.clientEntryModule` |
+| `litro.config.ts` | No adapter field | New `adapter: 'lit' | 'fast' | 'elena'` field (default: `'lit'`) |
+| CLI (`litro dev/build`) | No adapter awareness | Reads adapter from config, loads adapter module, passes to build pipeline |
+| Vite config | Lit-specific esbuild settings | Merges `adapter.vitePlugins()` |
+| Nitro config | Lit-specific externals/esbuild | Merges `adapter.nitroConfig()` |
+
+### What does NOT change
+
+- **LitroRouter** — already framework-agnostic (pure URLPattern + DOM)
+- **Page scanner** (`pages.ts`, `path-to-route.ts`) — scans `.ts` files, emits routes, no framework awareness
+- **Data layer** (`page-data.ts`) — `definePageData()` and `getServerData()` are plain JSON bridges
+- **Content system** (`content/`) — Markdown parsing, `litro:content` virtual module
+- **`#litro/page-manifest`** virtual module — static imports of page files, framework-agnostic
+
+### Internal runtime components (9 files)
+
+Each adapter provides native implementations of 3 components:
+
+| Component | Lit | FAST | Elena |
+|---|---|---|---|
+| **Outlet** | `LitroOutlet` extends `LitElement`, light DOM via `createRenderRoot()` override, `firstUpdated()` mounts router | `LitroOutlet` extends `FASTElement`, `shadowOptions: null`, `connectedCallback` + guard mounts router | `LitroOutlet` extends `Elena(HTMLElement)`, Composite type (no render), `connectedCallback` mounts router |
+| **Link** | `LitroLink` extends `LitElement`, capture-phase click handler, shadow `<a>` for progressive enhancement | `LitroLink` extends `FASTElement`, capture-phase click handler, template with `<a>` | `LitroLink` extends `Elena(HTMLElement)`, Primitive type, light DOM `<a>`, click handler |
+| **Page** | `LitroPage` extends `LitElement`, `serverData`/`loading` reactive state, `connectedCallback` reads `__litro_data__` | `LitroPage` extends `FASTElement`, `@observable serverData`, `connectedCallback` reads `__litro_data__` | `LitroPage` extends `Elena(HTMLElement)`, `static props = ['serverData', 'loading']`, `connectedCallback` reads `__litro_data__` |
+
+All 9 implementations share the same behavioral contract:
+- Outlet: mount router on first DOM attachment, provide a container for route content
+- Link: intercept clicks for SPA navigation, fall back to `<a>` for progressive enhancement
+- Page: read serialized server data from `<script id="__litro_data__">` before first render, expose it as a reactive property
+
+The router (`litro-router`) doesn't care which base class produced the elements — it calls `document.createElement(tag)`, checks for `.onBeforeEnter()`, and appends to the outlet.
+
+---
+
+## Adapter implementations
+
+### Lit adapter (Phase 0 — extraction from current code)
+
+The Lit adapter is not new code — it is the current implementation extracted behind the `FrameworkAdapter` interface.
+
+- `renderPage()`: wraps current `ssr.ts` logic — `render()` from `@lit-labs/ssr` with `unsafeStatic` tag instantiation, piped through `RenderResultReadable`
+- `getHeadScripts()`: emits `<script type="module" src="/@lit-labs/ssr-client/lit-element-hydrate-support.js">` (must be first) + app bundle script
+- `needsDSDPolyfill`: `true`
+- `clientEntryModule`: current `client.ts` (imports hydrate-support, registers Outlet/Link)
+- `nitroConfig()`: `externals.inline: ['@lit-labs/ssr']`, `esbuild.options.tsconfigRaw` with `experimentalDecorators` + `useDefineForClassFields: false`
+- `vitePlugins()`: empty (Lit needs no special Vite plugin beyond what Litro already configures)
+
+**Success criteria:** All 360 unit tests + 92 e2e tests pass with zero behavioral change. The refactor is purely structural.
+
+### FAST adapter (Phase 1)
+
+- `renderPage()`: uses `@microsoft/fast-ssr` which implements the `ElementRenderer` protocol. Creates a `RenderInfo` context and renders the component. FAST SSR is DSD-based like Lit, so streaming output is structurally similar.
+- `getHeadScripts()`: FAST's hydration uses command buffering — emits a `<script>` that queues DOM events until the FAST runtime loads and replays them. No equivalent to Lit's global prototype patch.
+- `needsDSDPolyfill`: `true` (Shadow DOM output)
+- `clientEntryModule`: FAST-specific bootstrap that imports `@microsoft/fast-element` and registers Outlet/Link/Page
+- `nitroConfig()`: `externals.inline: ['@microsoft/fast-ssr']`, esbuild config for FAST's compilation requirements
+- `vitePlugins()`: likely empty — FAST templates compile at definition time, not build time
+
+**Key risk:** `@microsoft/fast-ssr` is beta. If it proves unstable, FAST adapter ships as SSR-optional (client-only rendering with static shell fallback).
+
+### Elena adapter (Phase 2)
+
+- `renderPage()`: Elena components render light DOM HTML. No DSD wrapper. The adapter calls `new Component()`, triggers `render()`, and serializes the resulting DOM string. `@elenajs/ssr` can be used if stable; otherwise, a minimal serializer (call `render()`, collect HTML string) suffices because Elena's output is plain HTML.
+- `getHeadScripts()`: minimal — Elena uses progressive enhancement. The client entry imports the component classes; they upgrade in place via `customElements.define`. No hydration patch needed. Emit `<script type="module" src="/_litro/app.js">` only.
+- `needsDSDPolyfill`: `false`
+- `clientEntryModule`: Elena-specific bootstrap — imports Elena mixin, registers Outlet/Link/Page. No hydration support script.
+- `nitroConfig()`: minimal — Elena has no SSR-specific bundling requirements
+- `vitePlugins()`: may need a plugin to process `@scope` CSS blocks if Elena's build tooling requires it; TBD based on Elena RC API
+
+**Key risk:** Elena is an RC (March 2026). API surface may shift before 1.0. Mitigated by: Phase 2 timing gives months of stabilization; the adapter is a thin wrapper, not deep integration.
+
+**Key architectural difference:** Elena's light DOM output means:
+- No DSD polyfill in `<head>`
+- No `<template shadowrootmode="open">` wrappers in SSR output
+- Global CSS reaches component internals (no `static override styles` needed for Elena page components)
+- `@scope` CSS rules emitted inline or in a `<style>` tag for component-scoped styling
+- Smaller HTML payloads, no DSD parsing cost, true zero-JS initial rendering for content pages
+
+---
+
+## `create-litro` changes
+
+### New `--adapter` flag
+
+```bash
+# Default — Lit (backward-compatible, no flag needed)
+pnpm create @beatzball/litro my-app
+
+# Explicit adapter selection
+pnpm create @beatzball/litro my-app --adapter fast
+pnpm create @beatzball/litro my-app --adapter elena
+```
+
+All existing recipes (`fullstack`, `11ty-blog`, `starlight`) support the `--adapter` flag. The flag controls:
+
+| Scaffolded file | What changes per adapter |
+|---|---|
+| `package.json` | Framework dependency: `lit` vs `@microsoft/fast-element` vs `elenajs` |
+| `litro.config.ts` | `adapter: 'lit'` / `'fast'` / `'elena'` |
+| `app.ts` | Client bootstrap imports (hydrate-support for Lit, nothing for Elena, FAST bootstrap) |
+| `pages/*.ts` | Base class import and `extends` clause. Lit: `extends LitElement`, FAST: `extends FASTElement`, Elena: `extends Elena(HTMLElement)` |
+| `pages/*.ts` | Template syntax — Lit/FAST: `html` from their respective packages. Elena: `html` from `elenajs` |
+| `pages/*.ts` | Style approach — Lit/FAST: `static override styles = css\`...\``. Elena: `@scope` CSS in a `<style>` tag or external stylesheet |
+
+### Implementation approach
+
+The recipe template system already supports `{{placeholder}}` interpolation. Add adapter-conditional blocks:
+
+```
+{{#if adapter === 'lit'}}
+import { LitElement, html, css } from 'lit';
+{{/if}}
+{{#if adapter === 'elena'}}
+import { Elena, html } from 'elenajs';
+{{/if}}
+```
+
+Alternatively (simpler): each recipe has a `template/` directory per adapter (`template-lit/`, `template-fast/`, `template-elena/`) for files that differ entirely, with shared files in `template/`. The scaffolder merges them. This avoids template spaghetti for files where the adapter changes most of the content (like page components).
+
+**Recommendation:** Hybrid approach. Files that differ by 1-2 lines (config, package.json) use interpolation. Files that differ structurally (page components, app.ts) use per-adapter templates.
+
+---
+
+## Phasing and parallelization
+
+### Phase 0: Internal refactor — extract Lit adapter (Week 1)
+
+**Goal:** Current Lit-specific code extracted behind `FrameworkAdapter` interface. Zero behavioral change. All existing tests pass.
+
+| Track | Work | Parallelizable? |
+|---|---|---|
+| **0-A: Define adapter interface** | Create `packages/framework/src/adapter/types.ts` with `FrameworkAdapter` interface. Create `packages/framework/src/adapter/resolve.ts` that reads `litro.config.ts` and returns the adapter instance. | Start first |
+| **0-B: Extract Lit adapter** | Move Lit-specific code from `ssr.ts`, `create-page-handler.ts`, `shell.ts` into `packages/framework/src/adapter/lit/`. Implement `FrameworkAdapter` interface. | After 0-A |
+| **0-C: Wire adapter into pipeline** | Update `create-page-handler.ts` to call `adapter.renderPage()`. Update `shell.ts` to call `adapter.getHeadScripts()` and `adapter.needsDSDPolyfill`. Update CLI to resolve adapter from config. | After 0-B |
+| **0-D: Add `adapter` config field** | Add optional `adapter` field to `litro.config.ts` type. Default to `'lit'`. No user-facing change. | Parallel with 0-B |
+
+**Agents can parallelize:** 0-A and 0-D are independent. 0-B and 0-C are sequential.
+
+**Exit criteria:** `pnpm test` (360 tests) + `pnpm test:e2e` (92 tests) pass. No diff in SSR output, shell HTML, or client behavior.
+
+### Phase 1: FAST adapter (Week 2)
+
+**Goal:** A Litro project scaffolded with `--adapter fast` builds, serves, and passes a framework-parameterized test suite.
+
+| Track | Work | Parallelizable? |
+|---|---|---|
+| **1-A: FAST runtime components** | Implement `LitroOutlet`, `LitroLink`, `LitroPage` as FASTElement subclasses in `packages/framework/src/adapter/fast/runtime/`. | Independent |
+| **1-B: FAST SSR adapter** | Implement `renderPage()` using `@microsoft/fast-ssr`. Handle DSD output, streaming, server-side component registration. | Independent from 1-A |
+| **1-C: FAST client entry** | Write FAST-specific `client.ts` bootstrap (no hydrate-support patch, FAST's own initialization). | Independent |
+| **1-D: create-litro `--adapter fast`** | Add FAST template variants to recipes. Wire `--adapter` flag into scaffolder. | Independent from 1-A/B/C |
+| **1-E: Test suite** | Parameterize existing unit tests to run against both Lit and FAST adapters. Add FAST-specific e2e playwright project. | After 1-A + 1-B + 1-C |
+
+**Agents can parallelize:** 1-A, 1-B, 1-C, and 1-D are fully independent. 1-E depends on all four.
+
+**Exit criteria:** `pnpm test --adapter fast` passes parameterized unit tests. FAST e2e project passes core navigation, SSR, and data-fetching tests.
+
+### Phase 2: Elena adapter (Week 3-4)
+
+**Goal:** A Litro project scaffolded with `--adapter elena` builds, serves, and passes a framework-parameterized test suite. Light DOM output validated.
+
+| Track | Work | Parallelizable? |
+|---|---|---|
+| **2-A: Elena runtime components** | Implement `LitroOutlet`, `LitroLink`, `LitroPage` using Elena mixin. Light DOM, `@scope` CSS. | Independent |
+| **2-B: Elena SSR adapter** | Implement `renderPage()` for light DOM output. No DSD wrapper. Plain HTML string serialization. Test streaming. | Independent from 2-A |
+| **2-C: Elena client entry** | Write Elena-specific `client.ts` — minimal bootstrap, progressive enhancement, no hydration patch. | Independent |
+| **2-D: create-litro `--adapter elena`** | Add Elena template variants to recipes. Elena pages use `@scope` CSS, light DOM patterns. | Independent from 2-A/B/C |
+| **2-E: Test suite** | Extend parameterized tests for Elena. DOM assertions must account for light DOM (no shadow root). Add Elena e2e playwright project. | After 2-A + 2-B + 2-C |
+| **2-F: Elena-specific validation** | Verify: no DSD polyfill emitted, `@scope` CSS scoping works in all target browsers, progressive enhancement (no-JS rendering) produces readable content, bundle size delta vs. Lit adapter. | After 2-E |
+
+**Agents can parallelize:** 2-A, 2-B, 2-C, and 2-D are fully independent. 2-E and 2-F are sequential after those.
+
+**Extra time allocated** for Elena's RC status — API may require adjustments.
+
+### Phase 3: Documentation and content (Week 4-5)
+
+**Goal:** Users can discover, understand, and adopt the adapter system through docs, blog content, and updated project files.
+
+| Track | Work | Parallelizable? |
+|---|---|---|
+| **3-A: Adapter docs pages** | New docs section `/docs/adapters/` with overview page + per-adapter guides (`/docs/adapters/lit`, `/docs/adapters/fast`, `/docs/adapters/elena`). Each guide covers: installation, project setup, writing page components in that framework, SSR behavior differences, known limitations. Add to sidebar under new "Adapters" section. | Independent |
+| **3-B: Blog post** | "Litro goes framework-agnostic" — announce post covering: motivation (web components are the standard, not any single library), what the adapter system is, how to choose between Lit/FAST/Elena, code examples showing the same page in all 3 frameworks, performance/bundle size comparison, link to HN clone demos. | Independent from 3-A |
+| **3-C: README updates** | Update root `README.md`, `packages/framework/README.md`, and `packages/create-litro/README.md` to mention adapter support. Add `--adapter` flag to CLI usage examples. Update "Quick Start" to show adapter selection. | Independent |
+| **3-D: ARCHITECTURE.md + DECISIONS.md** | Append adapter architecture to `ARCHITECTURE.md`. Log the key decisions in `DECISIONS.md`: why per-project not per-page, why no template IR, why native classes over LitroComponentDef, Elena inclusion rationale. | Independent |
+| **3-E: Introduction page update** | Update `/docs/introduction` (or equivalent getting-started page) to mention adapter support early. Add a "Choose your framework" section with a brief comparison table (Lit: mature/Shadow DOM, FAST: Microsoft/observable, Elena: lightweight/light DOM). | Parallel with 3-A |
+| **3-F: Migration guide** | New page `/docs/adapters/switching` — how to switch an existing Lit project to FAST or Elena. Step-by-step: update config, swap dependencies, rewrite page base classes, adjust styles (Shadow DOM to `@scope` for Elena). Honest about what changes and what doesn't. | After 3-A |
+| **3-G: Comparison page update** | Update existing `/compare/` pages to mention adapter flexibility. Litro's comparison vs Next.js/Nuxt/Enhance now includes "choose your component library" as a differentiator. | Independent |
+| **3-H: Prerender routes** | Add all new docs/blog pages to `prerender.routes` in `docs/nitro.config.ts`. Ensure sitemap and RSS pick them up. | After 3-A + 3-B |
+
+**Agents can parallelize:** 3-A through 3-G are all independent. 3-H depends on 3-A and 3-B being finalized.
+
+### Phase 4: HackerNews clone showcase (Week 5-6)
+
+**Goal:** Three identical HackerNews clone apps — one per adapter — demonstrating that Litro produces the same functional result regardless of framework choice. These serve as both documentation and proof of adapter equivalence.
+
+Each clone is a small but non-trivial fullstack app:
+- **Pages:** Top stories list, story detail with comments (nested), user profile, "Ask HN" / "Show HN" filtered views
+- **Data:** HN API (`https://hacker-news.firebaseio.com/v0/`) via `definePageData()` server-side fetching
+- **Features exercised:** SSR with real data, SPA navigation via `<litro-link>`, dynamic routes (`/item/[id]`, `/user/[id]`), catch-all for 404, reactive client-side state (comment collapse/expand)
+- **Styling:** Identical visual output across all 3 — same CSS custom properties, same layout. The only difference is the component implementation (Shadow DOM vs. light DOM for Elena)
+
+| Track | Work | Parallelizable? |
+|---|---|---|
+| **4-A: Lit HN clone** | `examples/hn-lit/` — Lit adapter, Shadow DOM, serves as the reference implementation. Build this first to establish the shared design (CSS custom properties, page structure, API helpers). | Start first — establishes the reference |
+| **4-B: FAST HN clone** | `examples/hn-fast/` — FAST adapter, Shadow DOM. Port from Lit reference. Should be a straightforward base class + template syntax swap since both use Shadow DOM. | After 4-A design is stable |
+| **4-C: Elena HN clone** | `examples/hn-elena/` — Elena adapter, light DOM. Port from Lit reference. Most interesting delta: `@scope` CSS instead of Shadow DOM styles, no DSD in SSR output, progressive enhancement. | After 4-A design is stable |
+| **4-D: Comparison page** | New docs page `/docs/adapters/showcase` linking all 3 clones with side-by-side code snippets highlighting the differences. Include bundle size, SSR payload size, and Lighthouse scores (SSG build of each). | After 4-A + 4-B + 4-C |
+| **4-E: Benchmark integration** | Add all 3 HN clones to `pnpm bench:cross`. Publish results to `benchmarks/results/latest.json` so the benchmarks docs page picks them up. | After 4-A + 4-B + 4-C |
+
+**Agents can parallelize:** 4-B and 4-C are independent once 4-A is stable. 4-D and 4-E are independent of each other but depend on all clones being complete.
+
+**Why HackerNews:** It's the standard benchmark app in the web framework community (every framework has one). It's complex enough to exercise real patterns (nested data, dynamic routes, client interactivity) but simple enough to build in a few days per variant. Having all three side-by-side makes Litro's adapter story immediately tangible.
+
+---
+
+## Testing strategy
+
+### Parameterized unit tests
+
+Existing framework tests in `packages/framework/` are refactored into adapter-parameterized suites:
+
+```typescript
+const adapters = ['lit', 'fast', 'elena'] as const;
+
+for (const adapterName of adapters) {
+  describe(`SSR pipeline [${adapterName}]`, () => {
+    const adapter = loadAdapter(adapterName);
+
+    it('renders page component to stream', async () => {
+      const stream = adapter.renderPage('test-page', { title: 'Hello' });
+      const html = await collectStream(stream);
+      expect(html).toContain('Hello');
+      // Shadow DOM adapters: expect <template shadowrootmode>
+      // Elena: expect plain HTML, no DSD wrapper
+      if (adapter.needsDSDPolyfill) {
+        expect(html).toContain('shadowrootmode');
+      } else {
+        expect(html).not.toContain('shadowrootmode');
+      }
+    });
+  });
+}
+```
+
+### E2e test projects
+
+Add Playwright projects for each adapter in `playwright.config.ts`:
+
+- `playground-fast` — FAST variant of playground (port 3035)
+- `playground-elena` — Elena variant of playground (port 3036)
+- Shared test specs with adapter-conditional assertions where DOM structure differs
+
+### Behavioral equivalence tests
+
+For each of the 3 internal components, verify identical behavior across adapters:
+
+| Behavior | Tested how |
+|---|---|
+| Outlet mounts router and renders page content | Navigate to route, assert content visible |
+| Link performs SPA navigation on click | Click link, assert URL changed without page reload |
+| Link falls back to `<a>` without JS | Disable JS, assert `<a>` tag present with correct href |
+| Page reads `__litro_data__` before first render | SSR page with server data, assert data visible without flash |
+| Page exposes `serverData` as reactive property | Update serverData, assert re-render |
+
+### What we do NOT test across adapters
+
+- Framework-specific rendering internals (Lit's DOM patching, FAST's observable tracking, Elena's string rendering)
+- Template syntax correctness (that's the user's code, written in native framework syntax)
+- Framework library bugs
+
+---
+
+## Migration and backward compatibility
+
+### Existing projects
+
+- `litro.config.ts` without an `adapter` field defaults to `'lit'`. No existing project breaks.
+- The `lit` adapter is extracted from current code, not rewritten. Behavioral parity is guaranteed by the existing test suite.
+- No deprecation of any current API. `LitElement`-based pages continue working unchanged.
+
+### Docs and playgrounds
+
+- `playground/`, `playground-11ty/`, `playground-starlight/` remain Lit-based (they are the Lit adapter's test fixtures)
+- New `playground-fast/` and `playground-elena/` workspaces added for adapter validation
+- `docs/` and `docs-ssr/` remain Lit-based (no reason to migrate the docs site)
+
+### Changesets
+
+Per existing convention: one changeset per package, never combine packages.
+
+- `@beatzball/litro` — major version bump (adapter interface is a new capability, but default behavior is unchanged; semver minor is sufficient if no breaking changes to existing API)
+- `@beatzball/create-litro` — minor version bump (new `--adapter` flag)
+- `@beatzball/litro-router` — no changes
+
+---
+
+## Future considerations (explicitly deferred)
+
+| Topic | Why deferred | Revisit trigger |
+|---|---|---|
+| **Per-page framework mixing** | Requires mixed hydration, framework-aware routing, SSR orchestrator — research-grade problems. Current adapter interface has `canRender(tag)` hook point if needed. | User demand, or a project that demonstrably needs Lit layout + Elena content pages |
+| **CEM integration** | Custom Elements Manifest could power IDE tooling, component catalogues, and per-page framework detection. Not needed for per-project selection. | Tooling improvements, or per-page mixing implementation |
+| **Docs site conversion** | `docs/` and `docs-ssr/` are 7,700+ LOC across 33 Lit components/pages. Converting to FAST or Elena is 2-3 weeks of effort with no user-facing benefit. The docs site remaining on Lit demonstrates the default adapter at production scale. | If dogfooding all adapters in the docs becomes a marketing priority |
+| **Additional adapters** | Stencil, Haunted, hybrids, or other web component libraries could be supported via the same interface. | Community contributions, user requests |
+| **Adapter marketplace** | Third-party adapters published as npm packages (`litro-adapter-stencil`). Requires a stable, documented adapter API. | After 1.0 of the adapter interface |
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `@microsoft/fast-ssr` beta instability | Medium | FAST adapter SSR may not work reliably | Ship FAST as client-only fallback; SSR optional |
+| Elena RC API changes before 1.0 | Medium | Elena adapter needs rework | Phase 2 timing gives buffer; adapter is thin |
+| `@scope` CSS edge cases in older browsers | Low | Elena component styles break | `@scope` is Baseline Jan 2026; polyfill exists but defeats the purpose |
+| Performance gap between adapters | Low | Users blame Litro for framework perf differences | Benchmark suite (`pnpm bench:cross`) extended to cover all 3 adapters; document expected differences |
+| Template IR pressure resurfaces | Low | Users want portable components | Address with documentation: "Litro is adapter-agnostic, not component-agnostic — your components are native [framework] code" |
+
+---
+
+## Success metrics
+
+1. A `create-litro my-app --adapter fast` project builds, serves SSR with DSD output, and navigates correctly in dev and preview mode. FAST adapter is the gate for Elena — it validates the adapter interface against a second Shadow DOM framework before tackling Elena's light DOM divergence.
+2. A `create-litro my-app --adapter elena` project builds, serves light DOM HTML (no DSD), and navigates correctly in dev and preview mode.
+3. All 3 adapters pass the parameterized test suite with no adapter-specific test skips (except DOM structure assertions).
+4. Lit adapter extraction (Phase 0) produces zero test regressions.
+5. FAST SSR output is valid DSD, streams correctly through Nitro, and hydrates without console errors. If `@microsoft/fast-ssr` beta proves unstable, FAST ships with client-only rendering and a documented SSR limitation.
+6. Bundle size overhead of the adapter abstraction is < 500 bytes gzipped vs. current Lit-only code.
+7. No user-facing API changes for existing Lit projects. `litro.config.ts` without `adapter` field works identically to pre-adapter Litro.
+8. Docs site has adapter overview, per-adapter guides, and a blog post announcing the feature. README files updated. `ARCHITECTURE.md` and `DECISIONS.md` reflect the adapter architecture.
+9. Three HackerNews clone apps (`examples/hn-lit/`, `examples/hn-fast/`, `examples/hn-elena/`) produce visually identical output, exercise SSR + SPA navigation + dynamic routes + client interactivity, and are linked from the docs showcase page.


### PR DESCRIPTION
## Summary
- Add `FrameworkAdapter` interface defining the contract between Litro's infrastructure and pluggable web component frameworks (Lit, FAST, Elena)
- Extract Lit-specific SSR code (`@lit-labs/ssr`, `lit/static-html.js`, `RenderResultReadable`) from `create-page-handler.ts` into a dedicated Lit adapter at `packages/framework/src/adapter/lit/`
- Make DSD polyfill conditional in `shell.ts` via `includeDSDPolyfill` option (defaults `true` for backward compat, `false` for future light DOM adapters)
- Add `iterableToReadable()` utility replacing Lit-specific `RenderResultReadable` with a framework-agnostic `AsyncIterable<string>` to Node.js `Readable` converter
- Add `LitroConfig` type with `adapter?: 'lit' | 'fast' | 'elena'` field and lazy adapter resolver
- Include full PRD (`prd/PRD-ADAPTER.md`) covering 5 phases: adapter extraction, FAST, Elena, docs/blog, HN clone showcase

## Packages changed
- `@beatzball/litro` — minor: framework adapter interface, new exports (`FrameworkAdapter`, `AdapterName`, `LitroConfig`)

## Test plan
- [x] All 270 framework unit tests pass (including 4 new DSD polyfill opt-out tests)
- [x] All 18 router tests pass
- [x] All 17 create-litro tests pass
- [x] All 43 docs tests pass
- [x] All 61 docs-ui tests pass
- [x] All 92 e2e tests pass (`pnpm test:e2e`)
- [x] TypeScript compilation clean (`pnpm --filter @beatzball/litro build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)