### PR TITLE
fix: URLPattern fallback for iOS 18 + Elena docs import fix

### DIFF
--- a/.changeset/fix-urlpattern-ios18-fallback.md
+++ b/.changeset/fix-urlpattern-ios18-fallback.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro-router": patch
+---
+
+Add built-in URLPattern fallback for browsers that lack the native API (Safari < 18.2 / iOS < 18.2), fixing white-screen rendering on those devices.

--- a/packages/docs-content/content/docs/migrate/from-react-to-elena.md
+++ b/packages/docs-content/content/docs/migrate/from-react-to-elena.md
@@ -38,9 +38,9 @@ function Greeting({ name }: { name: string }) {
 **ElenaJS:**
 
 ```ts
-import { html, Component } from '@elenajs/core';
+import { html, Elena } from '@elenajs/core';
 
-class Greeting extends Component(HTMLElement) {
+class Greeting extends Elena(HTMLElement) {
   static tagName = 'my-greeting';
   static props = ['name'];
 
@@ -78,9 +78,9 @@ function Counter() {
 **ElenaJS:**
 
 ```ts
-import { html, Component } from '@elenajs/core';
+import { html, Elena } from '@elenajs/core';
 
-class Counter extends Component(HTMLElement) {
+class Counter extends Elena(HTMLElement) {
   static tagName = 'my-counter';
   static props = ['count'];
 
@@ -113,7 +113,7 @@ function Avatar({ src, alt, size = 40 }: AvatarProps) {
 **ElenaJS:**
 
 ```ts
-class Avatar extends Component(HTMLElement) {
+class Avatar extends Elena(HTMLElement) {
   static tagName = 'my-avatar';
   static props = ['src', 'alt', 'size'];
 
@@ -152,9 +152,9 @@ function Card({ children, title }) {
 **ElenaJS:**
 
 ```ts
-import { html, unsafeHTML, Component } from '@elenajs/core';
+import { html, unsafeHTML, Elena } from '@elenajs/core';
 
-class Card extends Component(HTMLElement) {
+class Card extends Elena(HTMLElement) {
   static tagName = 'my-card';
   static props = ['title'];
 

--- a/packages/litro-router/README.md
+++ b/packages/litro-router/README.md
@@ -14,7 +14,7 @@ This package is also built into the [@beatzball/litro](https://github.com/beatzb
 
 ## Browser requirements
 
-`URLPattern` is [Baseline Newly Available](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern#browser_compatibility) as of September 2025 (Chrome 95+, Edge 95+, Firefox 119+, Safari 16.4+). For older browsers a polyfill is available: [`urlpattern-polyfill`](https://github.com/nicolo-ribaudo/urlpattern-polyfill).
+`URLPattern` is [Baseline Newly Available](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern#browser_compatibility) as of September 2025 (Chrome 95+, Edge 95+, Firefox 119+, Safari 18.2+). A built-in fallback activates automatically for browsers that lack the native API (e.g. Safari 16.4–18.1 / iOS < 18.2), so no external polyfill is needed.
 
 ---
 

--- a/packages/litro-router/package.json
+++ b/packages/litro-router/package.json
@@ -39,10 +39,9 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "dependencies": {},
   "devDependencies": {
+    "jsdom": "^25.0.0",
     "typescript": "^5.7.3",
-    "vitest": "^2.1.8",
-    "jsdom": "^25.0.0"
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/litro-router/src/__tests__/index.test.ts
+++ b/packages/litro-router/src/__tests__/index.test.ts
@@ -9,6 +9,16 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
+// URLPattern type — mirrors the declare in index.ts so tests can use it.
+// ---------------------------------------------------------------------------
+interface URLPatternInit { pathname?: string }
+interface URLPatternResult { pathname: { groups: Record<string, string | undefined> } }
+declare class URLPattern {
+  constructor(init?: URLPatternInit);
+  exec(input?: URLPatternInit): URLPatternResult | null;
+}
+
+// ---------------------------------------------------------------------------
 // jsdom environment stubs — must run before the router module loads
 // ---------------------------------------------------------------------------
 
@@ -151,7 +161,7 @@ describe('LitroRouter.go()', () => {
 
 describe('LitroRouter — setRoutes and resolve', () => {
   let outlet: HTMLDivElement;
-  let router: LitroRouter;
+  let router: InstanceType<typeof LitroRouter>;
 
   beforeEach(() => {
     outlet = document.createElement('div');
@@ -290,9 +300,10 @@ describe('LitroRouter — setRoutes and resolve', () => {
 
 describe('URLPattern fallback (LitroURLPattern)', () => {
   it('installs on globalThis when native URLPattern is absent', () => {
-    expect(typeof globalThis.URLPattern).toBe('function');
+    const g = globalThis as Record<string, unknown>;
+    expect(typeof g.URLPattern).toBe('function');
     // The fallback class is named LitroURLPattern internally
-    expect(globalThis.URLPattern.name).toBe('LitroURLPattern');
+    expect((g.URLPattern as { name: string }).name).toBe('LitroURLPattern');
   });
 
   it('matches static paths exactly', () => {

--- a/packages/litro-router/src/__tests__/index.test.ts
+++ b/packages/litro-router/src/__tests__/index.test.ts
@@ -7,62 +7,27 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { LitroRouter, h3ToURLPattern } from '../index.js';
 
 // ---------------------------------------------------------------------------
-// URLPattern polyfill
-//
-// URLPattern is browser-native (Baseline Sep 2025); jsdom does not include it
-// and Node.js does not expose it as a global. We provide a minimal but correct
-// implementation that covers the three pattern shapes Litro uses:
-//   /                       — exact root
-//   /blog/:slug             — named parameter
-//   /:all*                  — catch-all (produced by h3ToURLPattern)
+// jsdom environment stubs — must run before the router module loads
 // ---------------------------------------------------------------------------
-beforeAll(() => {
-  // jsdom doesn't implement scrollTo or CSS.escape — provide no-op stubs.
-  if (typeof window.scrollTo !== 'function' || (window.scrollTo as unknown) === undefined) {
-    window.scrollTo = (() => {}) as typeof window.scrollTo;
-  }
-  if (typeof CSS === 'undefined' || typeof CSS.escape !== 'function') {
-    (globalThis as Record<string, unknown>).CSS = {
-      escape: (s: string) => s.replace(/([^\w-])/g, '\\$1'),
-    };
-  }
 
-  if (typeof (globalThis as Record<string, unknown>).URLPattern !== 'undefined') return;
-
-  (globalThis as Record<string, unknown>).URLPattern = class MinimalURLPattern {
-    private regex: RegExp;
-    private paramNames: string[] = [];
-
-    constructor(init: { pathname?: string } = {}) {
-      const pattern = init.pathname ?? '*';
-      const names: string[] = [];
-      const src = pattern
-        // catch-all :name*  →  captures the rest of the path
-        .replace(/:([^/?*]+)\*/g, (_, n) => { names.push(n); return '(.*)'; })
-        // optional :param?
-        .replace(/:([^/?*]+)\?/g, (_, n) => { names.push(n); return '([^/]*)'; })
-        // required :param
-        .replace(/:([^/?*]+)/g, (_, n) => { names.push(n); return '([^/]+)'; });
-      this.paramNames = names;
-      this.regex = new RegExp('^' + src + '$');
-    }
-
-    exec(input: { pathname?: string } = {}): {
-      pathname: { groups: Record<string, string | undefined> };
-    } | null {
-      const match = this.regex.exec(input.pathname ?? '');
-      if (!match) return null;
-      const groups: Record<string, string | undefined> = {};
-      this.paramNames.forEach((n, i) => {
-        groups[n] = match[i + 1] || undefined;
-      });
-      return { pathname: { groups } };
-    }
+// jsdom doesn't implement scrollTo or CSS.escape — provide no-op stubs.
+if (typeof window.scrollTo !== 'function' || (window.scrollTo as unknown) === undefined) {
+  window.scrollTo = (() => {}) as typeof window.scrollTo;
+}
+if (typeof CSS === 'undefined' || typeof CSS.escape !== 'function') {
+  (globalThis as Record<string, unknown>).CSS = {
+    escape: (s: string) => s.replace(/([^\w-])/g, '\\$1'),
   };
-});
+}
+
+// Ensure the native URLPattern is NOT available so the router's built-in
+// fallback activates. This simulates Safari < 18.2 / iOS < 18.2.
+delete (globalThis as Record<string, unknown>).URLPattern;
+
+// Import AFTER deleting globalThis.URLPattern so the fallback installs.
+const { LitroRouter, h3ToURLPattern } = await import('../index.js');
 
 // ---------------------------------------------------------------------------
 // h3ToURLPattern — catch-all syntax conversion
@@ -312,6 +277,80 @@ describe('LitroRouter — setRoutes and resolve', () => {
     LitroRouter.go('/nav-target');
     await new Promise(r => setTimeout(r, 50));
     expect(outlet.firstElementChild?.tagName.toLowerCase()).toBe('rr-nav');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URLPattern fallback (LitroURLPattern)
+//
+// The router installs a minimal URLPattern fallback on globalThis when the
+// native API is missing (Safari < 18.2 / iOS < 18.2). These tests verify
+// the fallback is active and handles all Litro route patterns correctly.
+// ---------------------------------------------------------------------------
+
+describe('URLPattern fallback (LitroURLPattern)', () => {
+  it('installs on globalThis when native URLPattern is absent', () => {
+    expect(typeof globalThis.URLPattern).toBe('function');
+    // The fallback class is named LitroURLPattern internally
+    expect(globalThis.URLPattern.name).toBe('LitroURLPattern');
+  });
+
+  it('matches static paths exactly', () => {
+    const p = new URLPattern({ pathname: '/' });
+    expect(p.exec({ pathname: '/' })).not.toBeNull();
+    expect(p.exec({ pathname: '/other' })).toBeNull();
+  });
+
+  it('matches multi-segment static paths', () => {
+    const p = new URLPattern({ pathname: '/blog/post' });
+    expect(p.exec({ pathname: '/blog/post' })).not.toBeNull();
+    expect(p.exec({ pathname: '/blog' })).toBeNull();
+  });
+
+  it('extracts named parameters', () => {
+    const p = new URLPattern({ pathname: '/blog/:slug' });
+    const result = p.exec({ pathname: '/blog/hello-world' });
+    expect(result).not.toBeNull();
+    expect(result!.pathname.groups.slug).toBe('hello-world');
+  });
+
+  it('named params do not match across slashes', () => {
+    const p = new URLPattern({ pathname: '/blog/:slug' });
+    expect(p.exec({ pathname: '/blog/a/b' })).toBeNull();
+  });
+
+  it('extracts multiple named parameters', () => {
+    const p = new URLPattern({ pathname: '/docs/:section/:page' });
+    const result = p.exec({ pathname: '/docs/guide/intro' });
+    expect(result).not.toBeNull();
+    expect(result!.pathname.groups.section).toBe('guide');
+    expect(result!.pathname.groups.page).toBe('intro');
+  });
+
+  it('handles optional parameters', () => {
+    const p = new URLPattern({ pathname: '/docs/:section?' });
+    expect(p.exec({ pathname: '/docs/' })).not.toBeNull();
+    expect(p.exec({ pathname: '/docs/guide' })).not.toBeNull();
+  });
+
+  it('handles catch-all patterns', () => {
+    const p = new URLPattern({ pathname: '/:all*' });
+    const result = p.exec({ pathname: '/some/deep/path' });
+    expect(result).not.toBeNull();
+    expect(result!.pathname.groups.all).toBe('some/deep/path');
+  });
+
+  it('handles prefixed catch-all patterns', () => {
+    const p = new URLPattern({ pathname: '/files/:rest*' });
+    const result = p.exec({ pathname: '/files/docs/readme.md' });
+    expect(result).not.toBeNull();
+    expect(result!.pathname.groups.rest).toBe('docs/readme.md');
+  });
+
+  it('catch-all matches root path', () => {
+    const p = new URLPattern({ pathname: '/:all*' });
+    const result = p.exec({ pathname: '/' });
+    expect(result).not.toBeNull();
   });
 });
 

--- a/packages/litro-router/src/index.ts
+++ b/packages/litro-router/src/index.ts
@@ -24,10 +24,19 @@
  */
 
 // ---------------------------------------------------------------------------
-// URLPattern ambient types
+// URLPattern types and fallback
+//
 // URLPattern (https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) is
-// Baseline Newly Available (Sep 2025) but not yet in TypeScript's DOM lib.
-// Declare the minimal subset we use so tsc compiles without lib changes.
+// Baseline Newly Available (Sep 2025) but missing in Safari < 18.2 / iOS < 18.2.
+// When the native API is absent we install a minimal fallback that covers the
+// three pattern shapes Litro generates:
+//   /                  — static paths
+//   /blog/:slug        — named parameters
+//   /docs/:section?    — optional parameters
+//   /:all*             — catch-all (produced by h3ToURLPattern)
+//
+// The fallback is intentionally NOT a full spec-compliant polyfill — it only
+// handles pathname matching with the subset of syntax above.
 // ---------------------------------------------------------------------------
 
 interface URLPatternInit {
@@ -45,6 +54,44 @@ interface URLPatternResult {
 declare class URLPattern {
   constructor(init?: URLPatternInit);
   exec(input?: URLPatternInit): URLPatternResult | null;
+}
+
+/**
+ * Minimal URLPattern fallback for browsers that lack the native API
+ * (Safari < 18.2, iOS < 18.2). Installed on globalThis only when the native
+ * constructor is absent — zero overhead on modern browsers.
+ */
+if (typeof globalThis.URLPattern === 'undefined') {
+  class LitroURLPattern {
+    private _re: RegExp;
+    private _names: string[] = [];
+
+    constructor(init: URLPatternInit = {}) {
+      const pattern = init.pathname ?? '*';
+      const names: string[] = [];
+      const src = pattern
+        // catch-all :name*  →  captures the rest of the path
+        .replace(/:([^/?*]+)\*/g, (_, n: string) => { names.push(n); return '(.*)'; })
+        // optional :param?
+        .replace(/:([^/?*]+)\?/g, (_, n: string) => { names.push(n); return '([^/]*)'; })
+        // required :param
+        .replace(/:([^/?*]+)/g, (_, n: string) => { names.push(n); return '([^/]+)'; });
+      this._names = names;
+      this._re = new RegExp('^' + src + '$');
+    }
+
+    exec(input: URLPatternInit = {}): URLPatternResult | null {
+      const match = this._re.exec(input.pathname ?? '');
+      if (!match) return null;
+      const groups: Record<string, string | undefined> = {};
+      this._names.forEach((n, i) => {
+        groups[n] = match[i + 1] || undefined;
+      });
+      return { pathname: { groups } };
+    }
+  }
+
+  (globalThis as Record<string, unknown>).URLPattern = LitroURLPattern;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/litro-router/src/index.ts
+++ b/packages/litro-router/src/index.ts
@@ -61,7 +61,7 @@ declare class URLPattern {
  * (Safari < 18.2, iOS < 18.2). Installed on globalThis only when the native
  * constructor is absent — zero overhead on modern browsers.
  */
-if (typeof globalThis.URLPattern === 'undefined') {
+if (typeof (globalThis as Record<string, unknown>).URLPattern === 'undefined') {
   class LitroURLPattern {
     private _re: RegExp;
     private _names: string[] = [];


### PR DESCRIPTION
## Summary
- Add a built-in URLPattern fallback to `@beatzball/litro-router` for browsers lacking the native API (Safari < 18.2 / iOS < 18.2). The missing API caused the router to crash, preventing custom element definitions, and the FOUC prevention CSS (`visibility: hidden` on `:not(:defined)`) hid the entire page — white screen.
- Fix Elena migration guide (`from-react-to-elena.md`) to use `Elena` mixin instead of incorrect `Component` import, per feedback from the Elena maintainer.
- Update litro-router README browser requirements to document the built-in fallback.

## Packages changed
- `@beatzball/litro-router` — patch: built-in URLPattern fallback for iOS 18.0-18.1

## Before/After
| Before | After |
| - | - |
| <img width="1008" height="1065" alt="Screenshot: Broken URLPattern across two simulated iOS Devices" src="https://github.com/user-attachments/assets/8e24673b-c9b3-4536-a531-0ccd231470ca" /> | <img width="1008" height="1065" alt="Screenshot: Fixed URLPattern across two simulated iOS Devices" src="https://github.com/user-attachments/assets/92129131-868a-499b-affb-78a824ee5a99" /> |

## Test plan
- [x] Existing litro-router unit tests pass (28/28) — now running against the fallback
- [x] Framework unit tests pass (295/295)
- [x] Manual verification on iOS 18.0/18.1 Safari (or Safari Technology Preview with URLPattern disabled)
- [x] Verify docs site renders correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)