### PR TITLE
chore: --host CLI flag, stale export cleanup, Elena 1.0.0

### DIFF
--- a/.changeset/cli-host-flag-elena-stable.md
+++ b/.changeset/cli-host-flag-elena-stable.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": patch
+---
+
+Add --host flag to dev and preview CLI commands; update @elenajs/core peer dep to stable 1.0.0

--- a/.changeset/elena-template-stable.md
+++ b/.changeset/elena-template-stable.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/create-litro": patch
+---
+
+Update Elena template dependencies to @elenajs/core 1.0.0 and @elenajs/ssr 1.0.0-alpha.10

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ cd playground
 litro dev
 ```
 
-The dev server starts on `http://localhost:3030` serving both Vite (JS modules, HMR) and Nitro (API routes, HTML shell) on a single port. Use `litro dev --port <n>` to change the port.
+The dev server starts on `http://localhost:3030` serving both Vite (JS modules, HMR) and Nitro (API routes, HTML shell) on a single port. Use `litro dev --port <n>` to change the port, and `litro dev --host` to expose the server to the network (listen on `0.0.0.0`).
 
 ---
 

--- a/packages/create-litro/recipes/fullstack/template-elena/package.json
+++ b/packages/create-litro/recipes/fullstack/template-elena/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@beatzball/litro": "latest",
-    "@elenajs/core": "^1.0.0-rc.13",
-    "@elenajs/ssr": "^1.0.0-alpha.9",
+    "@elenajs/core": "^1.0.0",
+    "@elenajs/ssr": "^1.0.0-alpha.10",
     "h3": "^1.13.0"
   },
   "devDependencies": {

--- a/packages/create-litro/recipes/starlight/template-elena/package.json
+++ b/packages/create-litro/recipes/starlight/template-elena/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@beatzball/litro": "latest",
-    "@elenajs/core": "1.0.0-rc.13",
-    "@elenajs/ssr": "1.0.0-alpha.9",
+    "@elenajs/core": "1.0.0",
+    "@elenajs/ssr": "1.0.0-alpha.10",
     "highlight.js": "^11.10.0",
     "h3": "^1.13.0"
   },

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -183,8 +183,8 @@
     "vite": "^5.4.11"
   },
   "devDependencies": {
-    "@elenajs/core": "1.0.0-rc.13",
-    "@elenajs/ssr": "1.0.0-alpha.9",
+    "@elenajs/core": "1.0.0",
+    "@elenajs/ssr": "1.0.0-alpha.10",
     "@microsoft/fast-element": "^2.10.3",
     "@microsoft/fast-ssr": "1.0.0-beta.39",
     "jsdom": "^25.0.0",
@@ -211,7 +211,7 @@
   "peerDependencies": {
     "@microsoft/fast-element": "^2.0.0",
     "@microsoft/fast-ssr": "^1.0.0-beta.1",
-    "@elenajs/core": "^1.0.0-rc.1",
+    "@elenajs/core": "^1.0.0",
     "@elenajs/ssr": "^1.0.0-alpha.1",
     "typescript": "^5.x"
   },

--- a/packages/framework/src/cli/index.ts
+++ b/packages/framework/src/cli/index.ts
@@ -80,6 +80,7 @@ switch (command) {
 
     const { port: rawPort, explicit } = parsePortArg(args);
     const port = await resolvePort(rawPort, explicit);
+    const host = args.includes('--host');
 
     // Nitro's dev server proxies requests to a worker thread. During
     // dev:reload the worker restarts — inflight connections emit ECONNRESET
@@ -93,7 +94,9 @@ switch (command) {
     );
     const nodeOpts = [process.env.NODE_OPTIONS, `--require "${guardPath}"`]
       .filter(Boolean).join(' ');
-    run('nitro', ['dev', '--port', String(port)], {
+    const nitroArgs = ['dev', '--port', String(port)];
+    if (host) nitroArgs.push('--host');
+    run('nitro', nitroArgs, {
       LITRO_MODE: 'server',
       LITRO_DEV: 'true',
       PORT: String(port),
@@ -162,6 +165,7 @@ switch (command) {
   case 'preview': {
     const { port: rawPort, explicit } = parsePortArg(args);
     const port = await resolvePort(rawPort, explicit);
+    const host = args.includes('--host');
 
     // SSG build: serve dist/static/ with a built-in static file server.
     const staticDir = join(cwd, 'dist', 'static');
@@ -206,8 +210,10 @@ switch (command) {
         res.writeHead(200, { 'content-type': mime });
         createReadStream(filePath).pipe(res);
       });
-      server.listen(port, () => {
-        console.log(`[litro] Previewing static build at http://localhost:${port}`);
+      const hostname = host ? '0.0.0.0' : undefined;
+      server.listen(port, hostname, () => {
+        const addr = host ? `http://0.0.0.0:${port}` : `http://localhost:${port}`;
+        console.log(`[litro] Previewing static build at ${addr}`);
       });
       break;
     }
@@ -224,7 +230,10 @@ switch (command) {
       );
       process.exit(1);
     }
-    run('node', [entry], { PORT: String(port) });
+    run('node', [entry], {
+      PORT: String(port),
+      ...(host && { HOST: '0.0.0.0' }),
+    });
     break;
   }
 
@@ -235,9 +244,11 @@ litro — Lit-first fullstack framework
 Commands:
   litro dev              Start development server (default port: 3000)
   litro dev --port 8080  Start on a custom port
+  litro dev --host       Expose to network (listen on 0.0.0.0)
   litro build            Build for production (--mode static|server, default: server)
   litro generate         Build static site (alias for litro build --mode static)
   litro preview          Preview production build
+  litro preview --host   Expose preview server to network
     `);
     process.exit(0);
 }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -26,8 +26,6 @@
  *   PageDataFetcher   — shape of the definePageData return value
  */
 
-export const version = '0.0.1';
-
 // Client-safe exports — these are the only exports that should appear in the
 // browser bundle. Server-only modules (createPageHandler, renderToStream,
 // ssgPlugin, presets) must NOT be re-exported here: they pull in Node.js-only

--- a/playground-elena/package.json
+++ b/playground-elena/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@beatzball/litro": "workspace:*",
-    "@elenajs/core": "1.0.0-rc.13",
-    "@elenajs/ssr": "1.0.0-alpha.9",
+    "@elenajs/core": "1.0.0",
+    "@elenajs/ssr": "1.0.0-alpha.10",
     "h3": "^1.15.6"
   },
   "devDependencies": {

--- a/playground-starlight-elena/package.json
+++ b/playground-starlight-elena/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@beatzball/litro": "workspace:*",
-    "@elenajs/core": "1.0.0-rc.13",
-    "@elenajs/ssr": "1.0.0-alpha.9",
+    "@elenajs/core": "1.0.0",
+    "@elenajs/ssr": "1.0.0-alpha.10",
     "highlight.js": "^11.10.0",
     "h3": "^1.13.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,11 +331,11 @@ importers:
         version: 5.4.21(@types/node@22.19.13)(terser@5.46.0)
     devDependencies:
       '@elenajs/core':
-        specifier: 1.0.0-rc.13
-        version: 1.0.0-rc.13
+        specifier: 1.0.0
+        version: 1.0.0
       '@elenajs/ssr':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9(@elenajs/core@1.0.0-rc.13)
+        specifier: 1.0.0-alpha.10
+        version: 1.0.0-alpha.10(@elenajs/core@1.0.0)
       '@microsoft/fast-element':
         specifier: ^2.10.3
         version: 2.10.3
@@ -426,11 +426,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/framework
       '@elenajs/core':
-        specifier: 1.0.0-rc.13
-        version: 1.0.0-rc.13
+        specifier: 1.0.0
+        version: 1.0.0
       '@elenajs/ssr':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9(@elenajs/core@1.0.0-rc.13)
+        specifier: 1.0.0-alpha.10
+        version: 1.0.0-alpha.10(@elenajs/core@1.0.0)
       h3:
         specifier: ^1.15.6
         version: 1.15.9
@@ -510,11 +510,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/framework
       '@elenajs/core':
-        specifier: 1.0.0-rc.13
-        version: 1.0.0-rc.13
+        specifier: 1.0.0
+        version: 1.0.0
       '@elenajs/ssr':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9(@elenajs/core@1.0.0-rc.13)
+        specifier: 1.0.0-alpha.10
+        version: 1.0.0-alpha.10(@elenajs/core@1.0.0)
       h3:
         specifier: ^1.13.0
         version: 1.15.9
@@ -693,11 +693,11 @@ packages:
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
 
-  '@elenajs/core@1.0.0-rc.13':
-    resolution: {integrity: sha512-Y6jIWahk0EnDfTHaYuAGb4/S9r6jrhFt229QT+y1xcOmP5jFN0IU4xGYcdjcSQ5aSaT3QC0uZBj3AQO0UhCZEQ==}
+  '@elenajs/core@1.0.0':
+    resolution: {integrity: sha512-YOlSv7qpvVVrzlVYoyx7s1c8cBML0b5Q8WhxXaNeO3Awd2iNcf9HcJKDWuOi9KT53F7L8K9uQNLCzyb7EVxlpw==}
 
-  '@elenajs/ssr@1.0.0-alpha.9':
-    resolution: {integrity: sha512-2KEdj4WAn6I1SzwmzGxD+7iBMn8tspgMzGNQYvd6012QC0QBSsIFLjdfdCFwQM7NTja7TwmETh9Qa8BTAV/zzg==}
+  '@elenajs/ssr@1.0.0-alpha.10':
+    resolution: {integrity: sha512-6gz0tnjE+yn5r9QeFjx7ujZPSQYbZb2q7a7J32Af3P7fbXkth9tS6BvlKRmthHz6XL2+GpNGLurhHDdMjEJ+iQ==}
     peerDependencies:
       '@elenajs/core': '>=1.0.0-rc.1'
 
@@ -4798,11 +4798,11 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
-  '@elenajs/core@1.0.0-rc.13': {}
+  '@elenajs/core@1.0.0': {}
 
-  '@elenajs/ssr@1.0.0-alpha.9(@elenajs/core@1.0.0-rc.13)':
+  '@elenajs/ssr@1.0.0-alpha.10(@elenajs/core@1.0.0)':
     dependencies:
-      '@elenajs/core': 1.0.0-rc.13
+      '@elenajs/core': 1.0.0
       htmlparser2: 12.0.0
 
   '@esbuild/aix-ppc64@0.21.5':


### PR DESCRIPTION
## Summary
- Add `--host` flag to `litro dev` and `litro preview` CLI commands — binds to `0.0.0.0` for network access
- Remove dead `export const version = '0.0.1'` from framework entry (unused, stale since 0.8.0)
- Update `@elenajs/core` from RC (`1.0.0-rc.13`) to stable `1.0.0` across all workspaces and templates
- Update `@elenajs/ssr` from `1.0.0-alpha.9` to `1.0.0-alpha.10` across all workspaces and templates
- Update `@elenajs/core` peer dep range from `^1.0.0-rc.1` to `^1.0.0`

## Packages changed
- `@beatzball/litro` — patch: --host flag, remove stale version export, Elena peer dep update
- `@beatzball/create-litro` — patch: Elena template version bumps

## Test plan
- [x] Framework unit tests pass (295/295) — `pnpm --filter @beatzball/litro test`
- [x] Router unit tests pass (18/18) — `pnpm --filter @beatzball/litro-router test`
- [x] Create-litro tests pass (17/17) — `pnpm --filter @beatzball/create-litro test`
- [x] Elena e2e tests pass (30/30) — `pnpm test:e2e -- --project elena`
- [x] Clean rebuild validated (`pnpm run clean` + full re-setup + all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)