### PR TITLE
docs: include Nuxt in HN benchmark blog post title

### DIFF
--- a/packages/docs-content/content/blog/five-hn-clones-benchmark.md
+++ b/packages/docs-content/content/blog/five-hn-clones-benchmark.md
@@ -1,5 +1,5 @@
 ---
-title: "Web Components vs Next.js: A Real-App Benchmark"
+title: "Web Components vs Next.js and Nuxt: A Real-App Benchmark"
 description: "We built the same Hacker News clone five times — Lit, FAST Element, Elena, Next.js 14, and Nuxt 3 — fed them through the same benchmark pipeline, and published the results. What we learned about web components, hydration-data cost, and the tradeoffs nobody advertises."
 date: 2026-04-20
 tags:
@@ -9,7 +9,7 @@ tags:
   - ssg
 ---
 
-# Web Components vs Next.js: A Real-App Benchmark
+# Web Components vs Next.js and Nuxt: A Real-App Benchmark
 
 We built the same Hacker News clone five times — once each with Litro's three framework adapters (Lit, FAST Element, Elena), once with Next.js 14, and once with Nuxt 3 — and fed all five through the same benchmark pipeline. Same routes, same fixture data, same CSS, all statically generated.
 


### PR DESCRIPTION
## Summary
- The HN benchmark blog post compares web components against **both** Next.js 14 and Nuxt 3, but its title only named Next.js. Updates the frontmatter `title` and the H1 from "Web Components vs Next.js: A Real-App Benchmark" to "Web Components vs Next.js and Nuxt: A Real-App Benchmark" so it reflects the actual matchup.

## Packages changed
- None — docs-content only (`@beatzball/litro-docs-content` is in the changesets ignore list).

## Test plan
- [x] Blog index and post route render the new title (`pnpm --filter @beatzball/litro-docs-ssr dev`, visit `/blog` and `/blog/five-hn-clones-benchmark`)
- [x] No other references to the old title anywhere in the repo (verified: grep returned the single updated file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)