### PR TITLE
docs: Sprint 3 cleanup — test counts, package framing, Lighthouse, DSD baseline, recipe trees, deno init, execa removal

### DIFF
--- a/.changeset/cleanup-sprint-3-create.md
+++ b/.changeset/cleanup-sprint-3-create.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/create-litro": patch
+---
+
+npm metadata and scaffolder docs: rewrite the package description and keywords to mention all three adapters (Lit / FAST / Elena), and fix the README's Deno scaffold command (`deno init --npm @beatzball/litro my-app` — the older `deno create npm:…` form was removed in Deno 2.x).

--- a/.changeset/cleanup-sprint-3-framework.md
+++ b/.changeset/cleanup-sprint-3-framework.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": patch
+---
+
+npm metadata + dependency cleanup: rewrite the package description and keywords to reflect that all three adapters (Lit / FAST / Elena) are first-class, and drop the unused `execa` runtime dependency (the CLI uses `child_process.spawn` directly per `cli/index.ts:18`).

--- a/.changeset/cleanup-sprint-3-router.md
+++ b/.changeset/cleanup-sprint-3-router.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro-router": patch
+---
+
+npm metadata: rewrite the package description and keywords to reflect that the router is framework-agnostic — it works with Lit, FAST, Elena, or plain custom elements, not just Lit.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,9 +98,9 @@ Runtime:     catch-all handler imports manifest -> matches request path -> SSR -
 
 ---
 
-## 5. Critical Import Ordering Constraint for SSR Hydration (Lit/FAST only)
+## 5. Critical Import Ordering Constraint for SSR Hydration (Lit and FAST)
 
-The hydration support module must be the first import in `app.ts` and the first `<script type="module">` in the HTML `<head>`. This does not apply to Elena (light DOM, no hydration).
+The hydration support module must be the first import in `app.ts` and the first `<script type="module">` in the HTML `<head>`. The example below shows the Lit form (`@lit-labs/ssr-client/lit-element-hydrate-support.js`); the FAST adapter uses the analogous `@microsoft/fast-element/install-element-hydration` import with the same first-import requirement. This does not apply to Elena (light DOM, no hydration).
 
 ```typescript
 // app.ts -- CORRECT
@@ -114,7 +114,7 @@ import '@lit-labs/ssr-client/lit-element-hydrate-support.js'; // TOO LATE
 
 ---
 
-## 6. Externals Inlining for Edge Adapters (Lit/FAST only)
+## 6. Externals Inlining for Edge Adapters (Lit and FAST — handled by the framework)
 
 ```typescript
 externals: {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Litro is a greenfield fullstack web framework being built in this repo. It combi
 
 - **Web Components** — framework-agnostic via adapter system: Lit (default), FAST Element, Elena
 - **Nitro** — server engine (same server that powers Nuxt), handles routing, API, SSR, deployment adapters
-- **SSR** — Lit/FAST use `@lit-labs/ssr` (Declarative Shadow DOM, streaming); Elena uses light DOM SSR (no DSD, no hydration)
+- **SSR** — Lit uses `@lit-labs/ssr`, FAST uses `@microsoft/fast-ssr` (both Declarative Shadow DOM, streaming); Elena uses light DOM SSR (no DSD, no hydration)
 - **`LitroRouter`** — built-in client-side router (URLPattern API), no external dependency
 - **Vite** — client bundle build and HMR
 - **pnpm workspaces** — monorepo tooling
@@ -26,7 +26,8 @@ Nitro Server
     ├── /api/**  →  server/api/ route files (plain H3 handlers)
     └── /**      →  Page Handler
                         ├── SSR mode: FrameworkAdapter.renderPage() → streams HTML
-                        │     ├── Lit/FAST: @lit-labs/ssr → DSD HTML → client hydrates
+                        │     ├── Lit: @lit-labs/ssr → DSD HTML → client hydrates
+                        │     ├── FAST: @microsoft/fast-ssr → DSD HTML → client hydrates
                         │     └── Elena: light DOM SSR → no hydration, progressive enhancement
                         └── Static mode: prerendered .html files served by Nitro static preset
 ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ yarn create @beatzball/litro my-app
 bun create @beatzball/litro my-app
 
 # deno
-deno create npm:@beatzball/litro@latest -- my-app
+deno init --npm @beatzball/litro my-app
 ```
 
 Follow the interactive prompts to choose a recipe, rendering mode, and framework adapter, or pass flags to skip them:
@@ -493,11 +493,11 @@ Static routes (`/`, `/about`, `/blog`) are automatically added to the prerender 
 pnpm install                                    # install all workspace deps
 pnpm --filter @beatzball/litro-router build     # compile litro-router (required once)
 pnpm --filter @beatzball/litro build            # compile framework (required once)
-pnpm --filter @beatzball/litro-router test      # run router unit tests (18 tests)
-pnpm --filter @beatzball/litro test             # run framework unit tests (228 tests)
-pnpm --filter @beatzball/create-litro test      # run scaffolding tests (17 tests)
-pnpm test:docs                                  # run docs unit tests (97 tests)
-pnpm test:e2e                                   # Playwright e2e tests (92 tests, 5 projects)
+pnpm --filter @beatzball/litro-router test      # run router unit tests
+pnpm --filter @beatzball/litro test             # run framework unit tests
+pnpm --filter @beatzball/create-litro test      # run scaffolding tests
+pnpm test:docs                                  # run docs unit tests (docs + docs-ui workspaces)
+pnpm test:e2e                                   # Playwright e2e tests across every playground + docs project
 pnpm --filter @beatzball/litro dev              # watch-compile framework
 
 # Playgrounds

--- a/packages/create-litro/README.md
+++ b/packages/create-litro/README.md
@@ -18,7 +18,7 @@ yarn create @beatzball/litro my-app
 bun create @beatzball/litro my-app
 
 # deno
-deno create npm:@beatzball/litro@latest -- my-app
+deno init --npm @beatzball/litro my-app
 ```
 
 Follow the interactive prompts to choose a recipe, rendering mode, and framework adapter, or pass flags directly to skip them:

--- a/packages/create-litro/package.json
+++ b/packages/create-litro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beatzball/create-litro",
   "version": "0.5.2",
-  "description": "Scaffold a new Litro app — fullstack SSR, Markdown blog, or docs site. Built on Lit web components and Nitro server.",
+  "description": "Scaffold a new Litro app — fullstack SSR, Markdown blog, or docs site. Pick Lit, FAST Element, or Elena via --adapter; built on web components and the Nitro server.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -24,8 +24,10 @@
     "create",
     "scaffold",
     "cli",
-    "lit",
     "web-components",
+    "lit",
+    "fast-element",
+    "elena",
     "fullstack",
     "ssr",
     "ssg",

--- a/packages/docs-content/content/blog/five-hn-clones-benchmark.md
+++ b/packages/docs-content/content/blog/five-hn-clones-benchmark.md
@@ -49,11 +49,11 @@ All runs on the same machine, same Node.js version, median of three runs. Full J
 
 | Framework     | Time   |
 |---------------|--------|
-| litro-elena   | 1523   |
-| litro-lit     | 1526   |
-| litro-fast    | 1709   |
-| nuxt          | 2465   |
-| nextjs        | 5233   |
+| litro-elena   | 1175   |
+| litro-lit     | 1352   |
+| litro-fast    | 1425   |
+| nuxt          | 2468   |
+| nextjs        | 5239   |
 
 Litro's three adapters build the same 79 story pages + 10 user pages + 3 list pages (92 total routes) in just over a second. Next.js takes nearly four times longer for the same output. Most of the gap is Next.js's RSC compilation step and the extra toolchain layers (SWC, `generateStaticParams` evaluation, static export pipeline). Nuxt sits in the middle — faster than Next.js, slower than Litro, because Nitro's prerender runs per-route but Nuxt compiles Vue SFCs and resolves auto-imports on top of it.
 

--- a/packages/docs-content/content/blog/nitro-adapters.md
+++ b/packages/docs-content/content/blog/nitro-adapters.md
@@ -90,25 +90,28 @@ Without this, you'll get a module-not-found error at runtime on Workers.
 
 ### 2. Streaming API Differences
 
-`RenderResultReadable` from `@lit-labs/ssr` is a Node.js `Readable` stream. Node.js `Readable` is not available in Cloudflare Workers.
+Litro's adapter contract is `renderPage(tag, serverData): AsyncIterable<string>`. The framework wraps that iterable with `iterableToReadable()` (`packages/framework/src/adapter/stream.ts`) — a small Node.js `Readable` adapter — and hands it to Nitro's `sendStream()`. Node `Readable` is not available in Cloudflare Workers or other edge runtimes that lack Node stream APIs.
 
-Litro's page handler uses Nitro's `sendStream()`, which accepts either a Node.js `Readable` or a standard WHATWG `ReadableStream`. For edge targets, you need to convert:
+For edge targets, wrap the same `AsyncIterable<string>` in a WHATWG `ReadableStream` instead:
 
 ```ts
-import { render } from '@lit-labs/ssr';
-import { collectResult } from '@lit-labs/ssr/lib/render-result.js';
+const ssrIterable = adapter.renderPage(tag, serverData);
 
-// Node.js targets — use RenderResultReadable directly
-import { RenderResultReadable } from '@lit-labs/ssr/lib/render-result-readable.js';
-const readable = new RenderResultReadable(renderResult);
-return sendStream(event, readable);
+// Node.js targets — the default Litro pipeline handles this via iterableToReadable
+return sendStream(event, iterableToReadable(ssrIterable));
 
-// Edge targets — convert to WHATWG ReadableStream
-const html = await collectResult(renderResult);
-return html;
+// Edge targets — wrap in WHATWG ReadableStream
+return new Response(new ReadableStream({
+  async start(controller) {
+    for await (const chunk of ssrIterable) {
+      controller.enqueue(new TextEncoder().encode(chunk));
+    }
+    controller.close();
+  },
+}));
 ```
 
-Litro's built-in page handler detects the runtime automatically. If you're writing a custom handler for an edge target, keep this difference in mind.
+Litro's built-in page handler uses the Node path. If you're writing a custom handler for an edge target, keep the runtime difference in mind.
 
 ## Vercel Deployment Example
 
@@ -129,21 +132,27 @@ The output follows Vercel's [Build Output API](https://vercel.com/docs/build-out
 NITRO_PRESET=cloudflare-workers litro build
 
 # Deploy with Wrangler
-wrangler publish dist/server/index.mjs
+wrangler deploy
 ```
 
-The `wrangler.toml` for a Litro Workers deployment:
+After the build, Nitro prints the exact output paths it generated — the Workers preset writes its entry under `dist/server/` (Litro's overridden `output.dir`). Use the path Nitro prints rather than hardcoding it, since Nitro can move files between presets and releases.
+
+A minimal `wrangler.toml` for a Litro Workers deployment:
 
 ```toml
 name = "my-litro-app"
-main = "dist/server/index.mjs"
 compatibility_date = "2025-09-01"
 
+# Fill in `main` from the path Nitro prints at the end of the build —
+# it sits under `dist/server/` but the exact filename can change between
+# Nitro releases and Cloudflare preset variants.
+main = "<path-printed-by-nitro>"
+
 [site]
-bucket = "./dist/server/public"
+bucket = "<asset-dir-printed-by-nitro>"
 ```
 
-Static assets are served by the Worker via KV bindings — Nitro generates the necessary asset manifest automatically.
+Static assets are served by the Worker via KV bindings — Nitro generates the necessary asset manifest automatically. Always copy the `main` and `bucket` values from the build output rather than hardcoding them; the layout under `dist/server/` is owned by Nitro and may evolve.
 
 ## Coolify and Self-Hosted Node.js
 

--- a/packages/docs-content/content/blog/shadow-dom-seo.md
+++ b/packages/docs-content/content/blog/shadow-dom-seo.md
@@ -51,7 +51,7 @@ A server can render:
 </my-component>
 ```
 
-The browser parses this natively — no JavaScript needed. The shadow DOM is attached before the first paint. Crawlers get real content. The approach is now Baseline (Chrome since 2021, Safari since March 2023, Firefox since October 2023), and the older attribute name `shadowroot` has been updated to `shadowrootmode`.
+The browser parses this natively — no JavaScript needed. The shadow DOM is attached before the first paint. Crawlers get real content. Declarative Shadow DOM reached web-platform Baseline in February 2024 once Firefox 123 shipped support (Chrome since 2021, Safari since March 2023, Firefox since February 2024), and the older attribute name `shadowroot` has been replaced by `shadowrootmode`.
 
 ## How `@lit-labs/ssr` Implements This
 

--- a/packages/docs-content/content/blog/streaming-ssr-dsd.md
+++ b/packages/docs-content/content/blog/streaming-ssr-dsd.md
@@ -86,14 +86,16 @@ Litro's SSR pipeline for a page request:
 2. Route handler calls definePageData.fetcher(event)
 3. Returns { post: {...} }
 4. buildShell() generates <head> + <body> HTML string
-5. renderToStream(html`<page-blog-slug .serverData=${data}>`)
-   → AsyncIterable<string>
-6. RenderResultReadable wraps the iterable as a Node.js Readable
+5. adapter.renderPage(tag, serverData)
+   → AsyncIterable<string>          ← Lit: render() from @lit-labs/ssr
+                                       FAST: @microsoft/fast-ssr templateRenderer
+                                       Elena: direct instantiate + stringify
+6. iterableToReadable() wraps the iterable as a Node.js Readable
 7. PassThrough stream: shell.head | SSR output | shell.foot
 8. sendStream(event, combined) → HTTP chunked transfer encoding
 ```
 
-The key function is `renderToStream` from `@lit-labs/ssr`. It takes a Lit `html` template and returns an `AsyncIterable<string>` — each yielded string is a chunk of HTML. The chunks include DSD templates for each Lit component in the tree.
+The adapter contract is `renderPage(tag, serverData): AsyncIterable<string>`. For Lit (the default), the adapter calls `render()` from `@lit-labs/ssr` and yields the flattened chunks of the resulting `RenderResult`; the chunks include DSD templates for each Lit component in the tree. FAST and Elena adapters produce the same `AsyncIterable<string>` shape via different mechanisms — see `packages/framework/src/adapter/{lit,fast,elena}/index.ts` for the implementations.
 
 ## The Shell Split
 
@@ -180,16 +182,16 @@ Streaming SSR directly improves two Core Web Vitals metrics:
 
 **LCP (Largest Contentful Paint):** Because the DSD template includes the actual rendered content (headings, text, images), the LCP element is in the initial HTML payload. It doesn't wait for JavaScript to render it. Googlebot sees the same content.
 
-**FID / INP (Interaction to Next Paint):** The app bundle is small (~8 kB gzipped). JavaScript parse time is minimal compared to React or Vue SSR apps.
+**FID / INP (Interaction to Next Paint):** The app bundle is small — JavaScript parse time is minimal compared to React or Vue SSR apps. See the [benchmarks](/benchmarks) for the current per-route gzipped weights across all three Litro adapters and the framework's competitors.
 
 ## Edge Adapter Note
 
-`RenderResultReadable` (from `@lit-labs/ssr/lib/render-result-readable.js`) extends Node.js's `stream.Readable`. It's not available in Cloudflare Workers or other edge runtimes that lack Node.js stream APIs.
+Litro's default stream plumbing uses `iterableToReadable()` (see `packages/framework/src/adapter/stream.ts`), which is a small wrapper around Node's `stream.Readable`. That doesn't run in Cloudflare Workers or other edge runtimes that lack Node stream APIs.
 
-For Cloudflare Workers, convert the `AsyncIterable<string>` from `renderToStream()` to a Web `ReadableStream` manually:
+For Cloudflare Workers, the adapter's `AsyncIterable<string>` output can be wrapped in a Web `ReadableStream` instead:
 
 ```ts
-const ssrIterable = renderToStream(template);
+const ssrIterable = adapter.renderPage(tag, serverData);
 
 const stream = new ReadableStream({
   async start(controller) {
@@ -201,7 +203,7 @@ const stream = new ReadableStream({
 });
 ```
 
-This is why `externals: { inline: ['@lit-labs/ssr', '@lit-labs/ssr-client'] }` is required in `nitro.config.ts` for edge targets — the SSR package must be bundled (not external) since edge runtimes don't have access to the Node.js module system.
+Litro's Lit adapter already inlines `@lit-labs/ssr` and `@lit-labs/ssr-client` for every preset (see `litAdapter.nitroConfig()` in `packages/framework/src/adapter/lit/index.ts`), and the FAST adapter handles `@microsoft/fast-ssr` similarly — so for the supported adapters you don't need to add anything in `nitro.config.ts` for edge deployment to bundle them. The Elena adapter doesn't pull in either package and ships the smallest edge footprint of the three.
 
 ## What to Read Next
 

--- a/packages/docs-content/content/blog/welcome.md
+++ b/packages/docs-content/content/blog/welcome.md
@@ -1,6 +1,6 @@
 ---
 title: Welcome to Litro
-description: Introducing Litro — a fullstack web framework built on Lit, Nitro, and Vite.
+description: Introducing Litro — a fullstack web framework for web components (Lit, FAST Element, or Elena via an adapter) on Nitro and Vite.
 date: 2026-03-12
 tags:
   - blog
@@ -11,7 +11,7 @@ tags:
 
 We're excited to introduce **Litro** — a fullstack web framework that combines the best of:
 
-- **Lit** — web components, no VDOM, no proprietary runtime
+- **Web Components** — author pages in [Lit](https://lit.dev) (default), [FAST Element](https://www.fast.design/), or [Elena](https://elenajs.com/) via Litro's adapter system; no VDOM, no proprietary runtime
 - **Nitro** — battle-tested server engine (the same one powering Nuxt)
 - **Vite** — fast HMR and modern bundling
 

--- a/packages/docs-content/content/blog/why-we-built-litro.md
+++ b/packages/docs-content/content/blog/why-we-built-litro.md
@@ -20,7 +20,7 @@ Three APIs define what's changed:
 
 **Custom Elements** — define reusable, encapsulated HTML elements with lifecycle hooks. Supported in all modern browsers since 2020 (Chrome since 2016, Safari since 2017, Firefox since 2018, Chromium Edge since 2020). Your components are standard HTML elements: they work in any framework, in vanilla HTML, in any environment that renders HTML and runs JavaScript.
 
-**Shadow DOM and Declarative Shadow DOM** — true style encapsulation without CSS Modules hacks. And with [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) (Baseline since 2023), the server can render shadow DOM directly into HTML — crawlers and browsers get the content before JavaScript runs.
+**Shadow DOM and Declarative Shadow DOM** — true style encapsulation without CSS Modules hacks. And with [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) (Baseline since Firefox 123 shipped in February 2024), the server can render shadow DOM directly into HTML — crawlers and browsers get the content before JavaScript runs.
 
 **URLPattern** — a native browser API for matching URL patterns, including named groups and wildcards. It's what `@beatzball/litro-router` is built on. No regex string parsing, no custom path-to-regexp, no external dependency.
 

--- a/packages/docs-content/content/compare/nextjs.md
+++ b/packages/docs-content/content/compare/nextjs.md
@@ -25,7 +25,7 @@ React's ecosystem today, or web platform standards for the next decade.
 <tr><td>Data fetching</td><td><code>fetch()</code> in Server Components</td><td><code>definePageData()</code></td></tr>
 <tr><td>API routes</td><td><code>app/api/route.ts</code></td><td><code>server/api/*.ts</code> (H3)</td></tr>
 <tr><td>Client routing</td><td>Next Router</td><td>LitroRouter (URLPattern)</td></tr>
-<tr><td>Hello World JS (gzipped)</td><td>~90 kB</td><td>~8 kB</td></tr>
+<tr><td>Client bundle</td><td>React runtime + RSC payloads</td><td>Web component runtime (Lit / FAST / Elena) — see <a href="/benchmarks">benchmarks</a></td></tr>
 <tr><td>Server engine</td><td>Custom</td><td>Nitro (same as Nuxt)</td></tr>
 <tr><td>Virtual DOM</td><td class="check">✓</td><td class="dash">—</td></tr>
 <tr><td>W3C standard components</td><td class="dash">—</td><td class="check">✓</td></tr>
@@ -127,7 +127,7 @@ export class BlogPost extends LitroPage {
 ## What Changes
 
 - **React → web components** — choose Lit, FAST Element, or Elena. Function components become class components; JSX becomes tagged template literals
-- **No React runtime** — the client bundle drops from ~90 kB to ~8 kB for Hello World
+- **No React runtime** — Litro ships only the chosen web-component runtime (Lit, FAST, or Elena) instead of React + RSC payloads; see the [benchmarks page](/benchmarks) for current per-route gzipped weights.
 - **Shadow DOM instead of CSS Modules** — component styles are scoped at the browser level
 - **H3 API routes** — import `defineEventHandler` from `h3` rather than using Next's Web Request/Response format
 - **Server engine** — Nitro instead of Next's custom server (more deployment targets, same Vercel support)

--- a/packages/docs-content/content/compare/nuxt.md
+++ b/packages/docs-content/content/compare/nuxt.md
@@ -34,7 +34,7 @@ Everything under the server layer — Nitro, H3, deployment presets — is share
 <tr><td>Server engine</td><td>Nitro</td><td class="same">Identical ↔</td></tr>
 <tr><td>Deployment adapters</td><td>All Nitro presets</td><td class="same">Identical ↔</td></tr>
 <tr><td>Client routing</td><td>vue-router</td><td>LitroRouter (URLPattern)</td></tr>
-<tr><td>Hello World JS (gzipped)</td><td>~60 kB</td><td>~8 kB</td></tr>
+<tr><td>Client bundle</td><td>Vue runtime + hydration payload</td><td>Web component runtime (Lit / FAST / Elena) — see <a href="/benchmarks">benchmarks</a></td></tr>
 <tr><td>Virtual DOM</td><td class="check">✓ (Vue)</td><td class="dash">—</td></tr>
 <tr><td>W3C standard components</td><td class="dash">—</td><td class="check">✓</td></tr>
 <tr><td>TypeScript</td><td class="check">✓</td><td class="check">✓</td></tr>
@@ -163,7 +163,7 @@ export default defineEventHandler(async () =&gt; {
 ## What Changes
 
 - **Vue SFCs → web components** — choose Lit, FAST Element, or Elena. `<script setup>` becomes `definePageData()`; `<template>` becomes `render()`
-- **No Vue runtime** — bundle drops from ~60 kB to ~8 kB
+- **No Vue runtime** — Litro ships only the chosen web-component runtime (Lit, FAST, or Elena) instead of Vue plus its hydration payload; the [benchmarks page](/benchmarks) has current per-route gzipped weights for both frameworks.
 - **vue-router → LitroRouter** — different API, built on URLPattern
 - **`<NuxtLink>` → `<litro-link>`** — SPA navigation; attribute is `href` not `to`
 

--- a/packages/docs-content/content/docs/adapters/overview.md
+++ b/packages/docs-content/content/docs/adapters/overview.md
@@ -107,7 +107,7 @@ Where an adapter limitation requires a workaround, it currently lives in the **a
 
 **Scope caveat:** the HN benchmark is intentionally narrow — list pages, param routes, nested comments, no forms, no streaming SSR, no user input. "No workarounds needed" is a claim about this scope, not a proof of full adapter parity under every real-world workload.
 
-**Lighthouse note:** Lighthouse cannot measure paint events inside shadow roots, so Lit and FAST SSR pages always score 0 on performance. Lighthouse scores are only meaningful for SSG output or Elena (light DOM). This is a Lighthouse limitation, not a rendering issue — the content is visible to users.
+**Lighthouse note:** Lighthouse measures Declarative Shadow DOM correctly when scoring static (SSG) output, so Lit, FAST, and Elena all return real performance scores in the HN benchmark numbers. We deliberately skip per-request SSR Lighthouse runs because the scored variable in that mode is server warm-up cost rather than the framework's render path, which makes adapter-to-adapter comparison noisy. None of the adapters score 0 because of Shadow DOM — the content is visible to users and to the scoring engine alike.
 
 ## Per-Adapter Guides
 

--- a/packages/docs-content/content/docs/recipes/11ty-blog.md
+++ b/packages/docs-content/content/docs/recipes/11ty-blog.md
@@ -24,11 +24,12 @@ my-blog/
       .11tydata.json
       first-post.md
   pages/
-    index.ts          ← blog listing
+    index.ts          ← home / blog landing
     blog/
-      [slug].ts       ← blog post
-      tags/
-        [tag].ts      ← tag listing
+      index.ts        ← blog listing
+      [slug].ts       ← individual post (dynamic, with generateRoutes())
+    tags/
+      [tag].ts        ← tag listing (sibling of `blog/`, not nested)
   public/
   app.ts
   nitro.config.ts     ← uses ssgPreset()

--- a/packages/docs-content/content/docs/recipes/fullstack.md
+++ b/packages/docs-content/content/docs/recipes/fullstack.md
@@ -20,8 +20,10 @@ pnpm create @beatzball/litro my-app
 ```
 my-app/
   pages/
-    index.ts          ← home page
-    about.ts          ← about page
+    index.ts          ← home page (with definePageData server fetch)
+    blog/
+      index.ts        ← blog listing
+      [slug].ts       ← dynamic blog post route with generateRoutes()
   server/
     api/
       hello.ts        ← GET /api/hello

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -30,7 +30,7 @@ yarn create @beatzball/litro my-app
 bun create @beatzball/litro my-app
 
 # deno
-deno create npm:@beatzball/litro@latest -- my-app
+deno init --npm @beatzball/litro my-app
 ```
 
 ```bash

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@beatzball/litro",
   "version": "0.9.1",
-  "description": "Fullstack web framework for Lit components — file-based routing, streaming SSR, SSG, and Nitro deployment adapters. A standards-based Next.js / Nuxt.js alternative.",
+  "description": "Fullstack web framework for web components — choose Lit, FAST Element, or Elena via an adapter. File-based routing, streaming SSR, SSG, and Nitro deployment adapters. A standards-based Next.js / Nuxt.js alternative.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -165,7 +165,6 @@
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
     "@resvg/resvg-js": "^2.6.0",
-    "execa": "^8.0.1",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
     "h3": "^1.15.6",
@@ -192,8 +191,10 @@
     "vitest": "^2.1.8"
   },
   "keywords": [
-    "lit",
     "web-components",
+    "lit",
+    "fast-element",
+    "elena",
     "ssr",
     "ssg",
     "static-site-generation",

--- a/packages/litro-router/package.json
+++ b/packages/litro-router/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.8",
   "type": "module",
   "types": "./dist/index.d.ts",
-  "description": "Client-side router for Lit web components. Built on the native URLPattern API. Zero dependencies. Works standalone or as part of the Litro framework.",
+  "description": "Framework-agnostic client-side router for web components — works with Lit, FAST, Elena, or plain custom elements. Built on the native URLPattern API. Zero dependencies. Works standalone or as part of the Litro framework.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -18,11 +18,13 @@
     "client-side-routing",
     "urlpattern",
     "web-components",
+    "custom-elements",
     "lit",
     "lit-element",
+    "fast-element",
+    "elena",
     "spa",
     "history-api",
-    "custom-elements",
     "zero-dependencies",
     "typescript"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,9 +383,6 @@ importers:
       '@resvg/resvg-js':
         specifier: ^2.6.0
         version: 2.6.2
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3

--- a/seo-prd/MASTER-PLAN.md
+++ b/seo-prd/MASTER-PLAN.md
@@ -6,6 +6,8 @@ Establish litro.dev as a discoverable, authoritative resource for developers sea
 SSR/SSG frameworks, Next.js / Nuxt.js alternatives, and web components tooling. All work
 targets organic search traffic from developers.
 
+> **Historical document (2026-03-18).** Most work tracked here has shipped. Several path references in this plan and its sub-PRDs (PRD-1, PRD-2, etc.) point at the pre-extraction layout — `docs/src/seo.ts` is now `packages/docs-ui/src/seo.ts`, and `docs/content/...` is now `packages/docs-content/content/...`. Treat the file references as historical pointers, not current locations.
+
 ## Current State (as of 2026-03-18)
 
 - SEO utility exists (`docs/src/seo.ts`) — meta, OG, canonical, Twitter cards

--- a/seo-prd/PRD-1-technical-seo.md
+++ b/seo-prd/PRD-1-technical-seo.md
@@ -5,6 +5,8 @@
 **Phase:** 1 (run in parallel with PRD-4 and first two blog posts)
 **Dependencies:** None — start immediately
 
+> **Historical document.** Path references — `docs/src/seo.ts`, `docs/content/...` — predate the Phase 1 extraction. The SEO utilities are now in `packages/docs-ui/src/seo.ts` and Markdown content is in `packages/docs-content/content/...`. The PRD's substance still applies; only the locations changed.
+
 ---
 
 ## Problem

--- a/seo-prd/PRD-2-comparison-pages.md
+++ b/seo-prd/PRD-2-comparison-pages.md
@@ -7,6 +7,8 @@ from day one)
 **Dependencies:** PRD-1 deployed before going live (for JSON-LD and sitemap); content
 writing can begin in parallel
 
+> **Historical document.** Path references — `docs/content/docs/migrate/...`, `docs/content/...` — predate the Phase 1 extraction. Migration guides now live under `packages/docs-content/content/docs/migrate/`. The PRD's substance still applies; only the locations changed.
+
 ---
 
 ## Problem


### PR DESCRIPTION
## Summary

Third sprint of [PRD-CLEANUP](../blob/main/prd/PRD-CLEANUP.md) — covers the three Tier 2 items (test counts, Lighthouse, Lit-only framing) plus the Tier 4 follow-ups bundled into a single pass.

## What changed

### Tier 2

- **README test counts (PRD item 8)** — README.md:496-500 listed stale counts ("18 router / 228 framework / 17 create-litro / 97 docs / 92 e2e, 5 projects" vs. actual 28 / 304 / 17 / 104 / ~153, 9 projects). Per PRD process recommendation 1, dropped the precise numbers entirely and replaced with generic descriptions so the README can't re-drift as suites grow.
- **Lighthouse "always 0" claim (PRD item 9)** — `docs/adapters/overview.md:110` retracted. The benchmark data shows real Lighthouse scores for all three adapters in SSG output (`benchmarks/results/latest.json#hnBenchmark`: Lit perf 86-100; FAST 99-100; Elena 84-100). The new copy explains why per-request SSR Lighthouse is skipped (server warm-up variance) without claiming the engine can't score the pages.
- **Package descriptions (PRD item 10)** — npm-public `description` and `keywords` for `@beatzball/litro`, `@beatzball/litro-router`, and `@beatzball/create-litro` now mention Lit / FAST / Elena instead of framing the framework as Lit-only. Welcome blog frontmatter + body updated to match.

### Tier 4 follow-ups

- **HN bench header (PRD item 13)** — `blog/five-hn-clones-benchmark.md:48` table says "Build time (median ms)" but values were means. Replaced with actual medians from `latest.json#hnBenchmark` (Elena 1175, Lit 1352, FAST 1425, Nuxt 2468, Next.js 5239).
- **Streaming-SSR pipeline (PRD item 12)** — `blog/streaming-ssr-dsd.md` and `blog/nitro-adapters.md` both described the removed `@lit-labs/ssr` `RenderResultReadable` / `renderToStream` pipeline. Rewritten to describe the current `adapter.renderPage() → AsyncIterable<string> → iterableToReadable()` flow per `packages/framework/src/adapter/stream.ts`.
- **Cloudflare Workers entrypoint (PRD item 19)** — `nitro-adapters.md` now defers to Nitro's reported output paths instead of hardcoding `dist/server/index.mjs`. The `wrangler.toml` example uses placeholder values for `main` / `bucket` with prose telling the reader to fill from the build log.
- **CLAUDE.md SSR engine attribution (PRD item 15)** — split "Lit/FAST use @lit-labs/ssr" into separate Lit (`@lit-labs/ssr`) and FAST (`@microsoft/fast-ssr`) entries; architecture diagram now shows both lines.
- **DSD baseline date (PRD item 17/18)** — `blog/shadow-dom-seo.md` and `blog/why-we-built-litro.md` corrected from "Firefox since October 2023" / "Baseline since 2023" to "Firefox 123 / February 2024".
- **Recipe doc trees (PRD item 20)** — `docs/recipes/{fullstack,11ty-blog}.md` directory trees rebuilt to match what the scaffolder actually emits in `packages/create-litro/recipes/{fullstack,11ty-blog}/template/pages/` (fullstack: `index.ts` + `blog/`; 11ty-blog: `index.ts` + `blog/{index,[slug]}.ts` + `tags/[tag].ts` as sibling of `blog/`, not nested).
- **Hello World JS gzip numbers (PRD item 21)** — `compare/{nextjs,nuxt}.md` "~8 kB / ~90 kB / ~60 kB" rows had no traceable source. Replaced with directional prose plus a link to `/benchmarks` for current per-route gzipped weights.
- **deno create syntax (PRD item 22)** — three READMEs used `deno create npm:@beatzball/litro@latest -- my-app`, but Deno 2.x removed the `deno create` subcommand entirely. Replaced with the canonical `deno init --npm @beatzball/litro my-app`. Verified against Deno 2.7.7 locally.
- **Unused execa dep (PRD item 23)** — `packages/framework/package.json:168` declared `"execa": "^8.0.1"` but no `from 'execa'` import exists anywhere in `packages/framework/src/`. Removed; lockfile regenerated.
- **seo-prd path drift (PRD item 24)** — `seo-prd/{MASTER-PLAN,PRD-1-technical-seo,PRD-2-comparison-pages}.md` reference `docs/src/seo.ts` and `docs/content/...` which moved during the Phase 1 extraction. Added "Historical document" notes pointing readers at the current locations (`packages/docs-ui/src/seo.ts`, `packages/docs-content/content/...`).

## Validation

A validation subagent reviewed every edit against the source-of-truth code (cli, presets, adapter/stream.ts, content/types.ts, parser tests, benchmarks JSON, recipe templates). It flagged:
- **One substantive overstatement** in the streaming-ssr edge-adapter paragraph (I said users still needed to add `externals: { inline: [...] }` themselves, but `litAdapter.nitroConfig()` already does this for every preset — fixed).
- **One adjacent issue** — my own wrangler.toml example hardcoded the same path the surrounding prose warns against — fixed by switching to placeholders.
- **One adjacent issue** in ARCHITECTURE.md — sections 5 + 6 labelled "Lit/FAST only" with Lit-specific examples; clarified that both adapters share the constraint with different imports.
- **One minor inconsistency** — the welcome blog frontmatter mentioned all three adapters but the body's first bullet still marketed only Lit; brought into line.

All four addressed before commit.

## Test plan

- [ ] `pnpm install` resolves without execa as a direct dep
- [ ] `pnpm --filter @beatzball/litro test` passes
- [ ] `pnpm --filter @beatzball/litro-router test` passes
- [ ] `pnpm --filter @beatzball/create-litro test` passes
- [ ] `pnpm test:docs` passes
- [ ] `pnpm bench:update-readme` is still idempotent
- [ ] Manual spot-check: `deno init --npm @beatzball/litro test-app` lands on the create-litro scaffolder

## Changesets

Three patch bumps — one per published package — covering npm-visible description/keyword changes and the framework's execa removal:
- `@beatzball/litro` patch
- `@beatzball/litro-router` patch
- `@beatzball/create-litro` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)