### PR TITLE
ci: switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required for npm trusted publishing (OIDC) — no NPM_TOKEN involved.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,14 +25,23 @@ jobs:
         with:
           version: 10
 
+      # No registry-url here: setup-node would write an .npmrc referencing
+      # ${NODE_AUTH_TOKEN}, and npm errors on undefined env vars in config.
+      # OIDC trusted publishing needs no auth config at all.
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest && npm --version
 
       - run: pnpm install --frozen-lockfile
 
+      # Publishing authenticates via OIDC trusted publishers configured on the
+      # npm packages (repo beatzball/litro, workflow release.yml) — deliberately
+      # no NPM_TOKEN/NODE_AUTH_TOKEN so npm cannot fall back to token auth.
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
@@ -41,5 +52,3 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces token-based npm publishing with OIDC trusted publishing. Token publishing has been broken since May: the original token expired silently (0.10.0 and 0.11.0 never reached npm), and every fresh granular token since — including scope-wide and all-packages read/write grants — is rejected with masked E404s at PUT time.

### Workflow changes
- `id-token: write` permission on the release job
- npm upgraded to latest on the runner (trusted publishing needs npm 11.5.1+; Node 20 ships npm 10)
- `NODE_AUTH_TOKEN`/`NPM_TOKEN` env removed, and setup-node's `registry-url` dropped (its generated .npmrc references `${NODE_AUTH_TOKEN}`, which npm hard-errors on when undefined)

### Required npm-side setup (once per package)
On npmjs.com for `@beatzball/litro`, `@beatzball/litro-router`, `@beatzball/create-litro`: Settings → Publishing access → add GitHub Actions trusted publisher with repository `beatzball/litro` and workflow filename `release.yml` (environment blank).

After merge, rerunning the failed Release run publishes litro 0.11.0, create-litro 0.7.0, and litro-router 0.1.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)