### PR TITLE
fix(content): fail loudly on duplicate content slugs

### DIFF
--- a/.changeset/content-slug-collision-error.md
+++ b/.changeset/content-slug-collision-error.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/litro': patch
+---
+
+Content layer: duplicate slugs now fail the build with an error naming the colliding files. Slugs are derived from the filename (or the parent directory for `index.md`), so `docs/setup.md` and `blog/setup.md` collide — previously the slug-keyed index silently kept only one of them, dropping the other from every listing and lookup.

--- a/packages/docs-content/content/docs/content-layer.md
+++ b/packages/docs-content/content/docs/content-layer.md
@@ -53,6 +53,8 @@ interface GetPostsOptions {
 
 Returns a single post by its **slug** (the filename without the `.md` extension; nested files use just the file's own slug, not the full path). Returns `null` if not found.
 
+Because the slug is the post's identity, it must be unique across the whole content directory — `docs/setup.md` and `blog/setup.md` would collide. The content index fails the build with an error naming the colliding files rather than silently keeping only one of them; rename a file to resolve it (`index.md` files take their parent directory's name as the slug, so they participate in the same rule).
+
 ```ts
 const post = await getPost('hello-world');
 ```

--- a/packages/framework/src/content/index.test.ts
+++ b/packages/framework/src/content/index.test.ts
@@ -4,10 +4,12 @@
  * Run with: pnpm --filter litro test
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ContentIndex } from './index.js';
-import { resolve } from 'pathe';
+import { resolve, join } from 'pathe';
 import { fileURLToPath } from 'node:url';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const FIXTURES_DIR = resolve(__dirname, '__fixtures__/blog');
@@ -183,5 +185,55 @@ describe('ContentIndex', () => {
     // Now exclude drafts at query time
     const publishedOnly = await draftIndex.getPosts({ includeDrafts: false });
     expect(publishedOnly.every(p => !p.draft)).toBe(true);
+  });
+});
+
+describe('duplicate slug detection', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'litro-content-collision-'));
+    await mkdir(join(dir, 'docs'), { recursive: true });
+    await mkdir(join(dir, 'blog'), { recursive: true });
+    await writeFile(
+      join(dir, 'docs', 'intro.md'),
+      '---\ntitle: Docs Intro\ndate: 2026-01-01\n---\nDocs body\n',
+    );
+    await writeFile(
+      join(dir, 'blog', 'intro.md'),
+      '---\ntitle: Blog Intro\ndate: 2026-02-01\n---\nBlog body\n',
+    );
+    await writeFile(
+      join(dir, 'blog', 'unique-post.md'),
+      '---\ntitle: Unique\ndate: 2026-03-01\n---\nBody\n',
+    );
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('build() fails loudly on cross-directory basename collisions, naming both files', async () => {
+    const idx = new ContentIndex(dir);
+    await expect(idx.build()).rejects.toThrow(
+      /duplicate content slug[\s\S]*"intro"[\s\S]*blog\/intro\.md[\s\S]*docs\/intro\.md/i,
+    );
+  });
+
+  it('index/parent-directory slugs collide too (docs/foo/index.md vs blog/foo.md)', async () => {
+    const dir2 = await mkdtemp(join(tmpdir(), 'litro-content-collision-'));
+    await mkdir(join(dir2, 'docs', 'foo'), { recursive: true });
+    await mkdir(join(dir2, 'blog'), { recursive: true });
+    await writeFile(
+      join(dir2, 'docs', 'foo', 'index.md'),
+      '---\ntitle: Foo Section\ndate: 2026-01-01\n---\nBody\n',
+    );
+    await writeFile(
+      join(dir2, 'blog', 'foo.md'),
+      '---\ntitle: Foo Post\ndate: 2026-02-01\n---\nBody\n',
+    );
+    const idx = new ContentIndex(dir2);
+    await expect(idx.build()).rejects.toThrow(/duplicate content slug[\s\S]*"foo"/i);
+    await rm(dir2, { recursive: true, force: true });
   });
 });

--- a/packages/framework/src/content/index.ts
+++ b/packages/framework/src/content/index.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'pathe';
+import { dirname, join, relative } from 'pathe';
 import fg from 'fast-glob';
 import { parseMarkdownFile } from './parser.js';
 import type { Post, GetPostsOptions } from './types.js';
@@ -98,6 +98,32 @@ export class ContentIndex {
         return parseMarkdownFile(file, this.contentDir, directoryData);
       }),
     );
+
+    // Slugs are the public identity (getPost(slug), posts map key), so
+    // colliding basenames MUST fail loudly: the map would otherwise keep
+    // only one entry and silently drop the rest from every listing.
+    // parsedPosts[i] corresponds to files[i] (Promise.all preserves order).
+    const filesBySlug = new Map<string, string[]>();
+    parsedPosts.forEach((post, i) => {
+      const rel = relative(this.contentDir, files[i]);
+      const existing = filesBySlug.get(post.slug);
+      if (existing) existing.push(rel);
+      else filesBySlug.set(post.slug, [rel]);
+    });
+    const collisions = Array.from(filesBySlug.entries()).filter(
+      ([, sources]) => sources.length > 1,
+    );
+    if (collisions.length > 0) {
+      const details = collisions
+        .map(([slug, sources]) => `  "${slug}": ${sources.sort().join(', ')}`)
+        .join('\n');
+      throw new Error(
+        `[litro:content] Duplicate content slug${collisions.length === 1 ? '' : 's'} in ${this.contentDir}.\n` +
+          `Slugs are derived from the filename (or the parent directory for index.md), ` +
+          `so they must be unique across the whole content directory:\n${details}\n` +
+          `Rename the colliding files to give each a unique slug.`,
+      );
+    }
 
     // Sort by date descending — always index ALL posts (including drafts).
     // Draft filtering is deferred to getPosts() so callers can opt in per-query.


### PR DESCRIPTION
## Summary

Follow-up to PR 93. `ContentIndex` keys posts by bare filename slug, so colliding basenames across collections silently overwrote each other — the losing file vanished from every listing and `getPost()` lookup with no signal. That is how the Server Actions announcement post disappeared from the live blog while the site otherwise deployed cleanly.

`build()` now detects duplicate slugs after parsing and throws an error naming each colliding slug and its source files (covering the `index.md` parent-directory slug convention too), instead of silently dropping content. Docs: uniqueness rule added to the content-layer guide's `getPost` section. Changeset: patch for `@beatzball/litro`.

Swept every content directory in the repo — no existing collisions, so nothing breaks on upgrade; a site that does have one is already silently broken today and now gets an actionable error.

### Verification
- TDD: two new tests (cross-directory basename collision; index.md-vs-file collision) failed before the change, pass after
- Framework suite 411/411, build clean, docs tests 61 + 43 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)