### PR TITLE
ci: fix Node-version time-bombs in Release and Dependency Audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
+      # osv-scanner is a standalone binary that scans the checked-in
+      # pnpm-lock.yaml directly — it needs neither Node nor pnpm. A setup-node
+      # step with `cache: pnpm` but no `pnpm install` leaves the pnpm store
+      # path empty and fails at post-run cache-save on the current runners, so
+      # this job deliberately has no setup-node/pnpm steps.
+      #
       # npm retired the audit endpoint `pnpm audit` calls (HTTP 410), so audit
       # via osv-scanner instead: it scans the lockfile against the OSV database
       # with no dependency on that endpoint. Baseline/ignore rules (each with a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,11 @@ jobs:
           cache: pnpm
 
       # npm trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.
+      # Pin the 11.x line: npm@latest is now 12.x, which drops Node 20 (requires
+      # Node >= 22.22 and fails install with EBADENGINE here), whereas 11.x
+      # supports both Node 20 and OIDC trusted publishing.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest && npm --version
+        run: npm install -g npm@^11 && npm --version
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Two CI jobs began failing on `main` at commit 97e80be — both from upstream version drift on the GitHub runners, not from any merged code (both were green on the litro-agent branch that landed).

## Release — `EBADENGINE`
The `Upgrade npm for OIDC trusted publishing` step runs `npm install -g npm@latest`, which now resolves to **npm 12.x**. npm 12 requires Node `^22.22.2 || ^24.15.0 || >=26`, but the job pins Node 20, so the install fails:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Fix: pin the OIDC-capable **11.x** line (`npm@^11`). npm 11 supports both Node 20 and trusted publishing (needs >= 11.5.1) — the same posture that published prior releases.

## Dependency Audit — post-run cache-save
The osv-scanner scan **passes** ("No issues found", 12 advisories baselined via `osv-scanner.toml`). The job died in `Post Run actions/setup-node@v4`: it declares `cache: pnpm` but never runs `pnpm install`, so the pnpm store path is empty and the current (Node 24 default) runners turn the missing-path warning into a hard `##[error]`.

Fix: osv-scanner is a standalone binary that scans the checked-in `pnpm-lock.yaml` — it needs neither Node nor pnpm. Drop the vestigial `setup-node`/`pnpm` steps from the job entirely.

## Validation
- The audit job's fix is exercised by this PR's own CI run.
- The Release job only runs on push to `main` (it has no PR trigger), so its fix can't run here; the change is a one-line dependency pin verified against npm 11's engine range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)