### PR TITLE
ci: run CI and Release on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # litro-agent's tests import @beatzball/litro/stream (a framework
@@ -43,7 +43,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build litro-router
@@ -67,7 +67,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build litro-router
@@ -93,7 +93,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Build litro-router

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,14 @@ jobs:
       # OIDC trusted publishing needs no auth config at all.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
-      # npm trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.
-      # Pin the 11.x line: npm@latest is now 12.x, which drops Node 20 (requires
-      # Node >= 22.22 and fails install with EBADENGINE here), whereas 11.x
-      # supports both Node 20 and OIDC trusted publishing.
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1; the npm bundled with
+      # Node 24 can lag that. Pin the 11.x line explicitly to guarantee an
+      # OIDC-capable npm without tracking npm@latest (12.x), which couples the
+      # pipeline to specific Node minors — keeping this decoupled from the
+      # runtime pin above.
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@^11 && npm --version
 


### PR DESCRIPTION
Follow-up to #98. That PR fixed the two immediate CI failures on the current Node 20 runtime; this one moves the whole workflow onto **Node 24**, which is overdue.

## Why
- **Node 20 reached end-of-life in April 2026.** GitHub is already force-running the workflow actions (checkout, setup-node, pnpm/action-setup) on Node 24 and emitting a deprecation warning on every job.
- Node 24 is the current **Active-LTS** even release — 22 is fine too but sits awkwardly close to npm 12's `^22.22.2` engine floor; 26 isn't LTS until Oct 2026.

## Changes
- Bump all **5** `node-version` pins `20 → 24` (4 in `ci.yml`, 1 in `release.yml`).
- Release keeps the explicit `npm@^11` upgrade: OIDC trusted publishing needs npm >= 11.5.1, Node 24's bundled npm can lag that, and pinning 11.x avoids `npm@latest` (12.x) coupling the pipeline to specific Node minors. Comment refreshed to reflect the Node 24 context.

## Not changed (deliberately)
- Root `engines.node` stays `^20.19.0 || >=22.12.0` — packages remain installable on Node 20.19+. CI runs newer while the published surface stays non-breaking. **Formally dropping the Node 20 support arm is a separate product decision**, not bundled here.

## Validation
This PR's own CI is the verification: the full toolchain (Vite 8, vitest, Playwright, Nitro build, `@lit-labs/ssr` / `@microsoft/fast-ssr` / Elena SSR) runs green on Node 24 before merge. The Release job has no PR trigger, so its Node 24 run is exercised on the next push to `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)