### PR TITLE
chore: release @beatzball/litro ./stream subpath as minor

### DIFF
--- a/.changeset/litro-stream-subpath.md
+++ b/.changeset/litro-stream-subpath.md
@@ -1,5 +1,5 @@
 ---
-'@beatzball/litro': patch
+'@beatzball/litro': minor
 ---
 
 Expose the NDJSON stream wire protocol (`createStreamEncoder`, `createStreamDecoder`, `serializeValue`, `deserializeValue`, `isAsyncIterable`) as a public `@beatzball/litro/stream` subpath so Server Actions and the agent layer share one protocol.


### PR DESCRIPTION
Adjusts the pending changeset bump level before the Version Packages PR (#99) is merged.

## Why
The `@beatzball/litro/stream` subpath (shipped in #96) adds a **new public export surface** — `createStreamEncoder`, `createStreamDecoder`, `serializeValue`, `deserializeValue`, `isAsyncIterable`. New backward-compatible API is a **minor** under semver; the original changeset declared it `patch`, which under-signals the new capability.

## Change
One line in `.changeset/litro-stream-subpath.md`: `patch` → `minor`.

## Effect
Once merged, the Release workflow regenerates #99 with `@beatzball/litro` at **0.12.0** instead of 0.11.2. `@beatzball/litro-agent` 0.1.0 is unaffected. This must land before #99 merges — merging #99 consumes and deletes this changeset, locking the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)