### PR TITLE
docs: surface @beatzball/litro-agent across the docs site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A fullstack web framework for [web components](https://developer.mozilla.org/en-
 - **Content layer** — `litro:content` virtual module for Markdown blogs with 11ty-compatible frontmatter
 - **Recipe-based scaffolding** — `fullstack`, `11ty-blog`, and `starlight` recipes via `npm create @beatzball/litro`
 - **API routes** — plain `server/api/` files, H3 handlers, no framework overhead
+- **AI agents** — `agents/<name>/` directories become durable, streaming, resumable agent endpoints whose tools return server-rendered components (`@beatzball/litro-agent`)
 - **One port in dev** — Vite and Nitro share a single HTTP port, no proxy
 - **Any deployment target** — Node.js, Cloudflare Workers, Vercel Edge, static — via Nitro adapters
 
@@ -54,6 +55,7 @@ litro/
     framework/        ← npm package: @beatzball/litro
     litro-router/     ← npm package: @beatzball/litro-router (standalone, zero-dependency)
     create-litro/     ← npm create @beatzball/litro (scaffolding)
+    litro-agent/      ← npm package: @beatzball/litro-agent (filesystem-first agent layer)
   playground/         ← fullstack recipe test app (Lit)
   playground-fast/    ← fullstack test app (FAST Element)
   playground-elena/   ← fullstack test app (Elena)

--- a/docs-ssr/pages/index.ts
+++ b/docs-ssr/pages/index.ts
@@ -91,6 +91,12 @@ export const pageData = definePageData(async (_event) => {
         description:
           "Markdown content with 11ty-compatible frontmatter and data cascade.",
       },
+      {
+        icon: "🤖",
+        title: "AI Agents",
+        description:
+          "Filesystem-first agent endpoints whose tools return server-rendered UI — the model sees data, users see components. Durable and resumable.",
+      },
     ],
     seoHead,
   } satisfies SplashData;

--- a/docs-ssr/server/starlight.config.js
+++ b/docs-ssr/server/starlight.config.js
@@ -30,6 +30,7 @@ export const siteConfig = {
       items: [
         { label: 'API Routes', slug: 'api-routes' },
         { label: 'Server Actions', slug: 'server-actions' },
+        { label: 'Agents', slug: 'agents' },
         { label: 'Content Layer', slug: 'content-layer' },
         { label: 'Static Generation', slug: 'ssg' },
         { label: 'OG Images', slug: 'og-images' },

--- a/docs/pages/index.ts
+++ b/docs/pages/index.ts
@@ -91,6 +91,12 @@ export const pageData = definePageData(async (_event) => {
         description:
           "Markdown content with 11ty-compatible frontmatter and data cascade.",
       },
+      {
+        icon: "🤖",
+        title: "AI Agents",
+        description:
+          "Filesystem-first agent endpoints whose tools return server-rendered UI — the model sees data, users see components. Durable and resumable.",
+      },
     ],
     seoHead,
   } satisfies SplashData;


### PR DESCRIPTION
Now that `@beatzball/litro-agent@0.1.0` is published, this wires it into the docs "front doors." The **Agents guide** content already ships in the shared `docs-content` package and is in the main docs sidebar (added in the v0 release) — this fills the remaining gaps.

## Changes
- **README** — add an "AI agents" feature bullet and list `packages/litro-agent` in the monorepo structure.
- **Homepages** (`docs/pages/index.ts` + `docs-ssr/pages/index.ts`) — add an "AI Agents" feature card (neither homepage surfaced it before).
- **docs-ssr sidebar** (`starlight.config.js`) — add the **Agents** guide entry. The main docs site got this in the litro-agent v0 release; docs-ssr was missing it, so this is the **parity fix** — its `docs/[...slug].ts` already renders `/docs/agents` from shared content; it just wasn't in the nav.

## Scope notes
- No changeset: only docs packages (which are changesets-ignored) and the repo README are touched — no published package changes.
- Homepage feature cards use an emoji icon to match the four existing emoji-iconed cards in the same array.
- Server Actions is *also* absent from both homepages (older gap) — left out to keep this PR scoped to litro-agent; happy to add it in a follow-up.

## Validation
CI's **Build docs-ssr** and **Build** jobs render both sites; changes are data-only additions matching the existing feature-card and sidebar shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)