### PR TITLE
fix: dev mode client entry script path

### DIFF
--- a/.changeset/fix-dev-app-script-path.md
+++ b/.changeset/fix-dev-app-script-path.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/litro': patch
+---
+
+Fix dev mode serving stale client bundles by referencing `/_litro/app.ts` instead of the built `/_litro/app.js` when `litro dev` is running.

--- a/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
+++ b/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
@@ -8,7 +8,7 @@
  * Run with: pnpm --filter @beatzball/litro test
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before any imports of the modules under test.
@@ -468,6 +468,82 @@ describe('createPageHandler — Accept: application/json content negotiation', (
     const result = await callHandlerWithResult(handler);
 
     expect(result).toEqual(payload);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appScriptUrl — dev resolves app.ts, prod resolves app.js (issue 97)
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — appScriptUrl dev/prod resolution', () => {
+  const originalLitroDev = process.env.LITRO_DEV;
+  const originalBasePath = process.env.LITRO_BASE_PATH;
+
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+    // The preceding "Accept: application/json" describe block leaves
+    // mockRequestHeaders.current set (module-scoped, no afterEach reset
+    // there) — clear it so these tests exercise the normal HTML path.
+    mockRequestHeaders.current = {};
+  });
+
+  afterEach(() => {
+    if (originalLitroDev === undefined) delete process.env.LITRO_DEV;
+    else process.env.LITRO_DEV = originalLitroDev;
+    if (originalBasePath === undefined) delete process.env.LITRO_BASE_PATH;
+    else process.env.LITRO_BASE_PATH = originalBasePath;
+  });
+
+  it('resolves appScriptUrl to /_litro/app.ts when LITRO_DEV=true', async () => {
+    process.env.LITRO_DEV = 'true';
+    delete process.env.LITRO_BASE_PATH;
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hi' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.appScriptUrl).toBe('/_litro/app.ts');
+  });
+
+  it('resolves appScriptUrl to /_litro/app.js when LITRO_DEV is unset (production)', async () => {
+    delete process.env.LITRO_DEV;
+    delete process.env.LITRO_BASE_PATH;
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hi' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.appScriptUrl).toBe('/_litro/app.js');
+  });
+
+  it('resolves appScriptUrl to /_litro/app.js when LITRO_DEV=false', async () => {
+    process.env.LITRO_DEV = 'false';
+    delete process.env.LITRO_BASE_PATH;
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hi' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.appScriptUrl).toBe('/_litro/app.js');
+  });
+
+  it('honors LITRO_BASE_PATH together with LITRO_DEV in dev mode', async () => {
+    process.env.LITRO_DEV = 'true';
+    process.env.LITRO_BASE_PATH = '/litro';
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hi' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.appScriptUrl).toBe('/litro/_litro/app.ts');
   });
 });
 

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -183,13 +183,15 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
         }
       }
 
-      // Always reference the compiled bundle. In dev mode Vite's middleware
-      // intercepts /_litro/app.js and serves app.ts on the fly (Vite resolves
-      // .js → .ts automatically). If Vite is not intercepting, the static file
-      // handler serves the pre-built dist/client/app.js as a fallback.
+      // In dev mode, reference the unbuilt source (app.ts) directly so Vite's
+      // middleware (base: '/_litro/') unambiguously owns the request — this
+      // matches the documented contract in shell.ts and avoids the Nitro
+      // publicAssets static handler serving a stale dist/client/app.js when
+      // one exists from a prior production build (see issue 97). In
+      // production, reference the compiled bundle.
       const basePath = process.env.LITRO_BASE_PATH ?? '';
-      const appScriptUrl = `${basePath}/_litro/app.js`;
       const isDev = process.env.LITRO_DEV === 'true';
+      const appScriptUrl = `${basePath}/_litro/app.${isDev ? 'ts' : 'js'}`;
 
       // Get any framework-specific head scripts from the adapter.
       const adapterHeadScripts = adapter.getHeadScripts({ isDev, basePath });
@@ -258,9 +260,11 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       );
 
       // Build a minimal fallback shell (no server data — data fetch may have
-      // been the source of the error, or may not have run yet).
+      // been the source of the error, or may not have run yet). Same
+      // dev/prod app script resolution as the happy path above.
       const basePath = process.env.LITRO_BASE_PATH ?? '';
-      const appScriptUrl = `${basePath}/_litro/app.js`;
+      const isDevFallback = process.env.LITRO_DEV === 'true';
+      const appScriptUrl = `${basePath}/_litro/app.${isDevFallback ? 'ts' : 'js'}`;
       // Carry vary header through the fallback path too — the URL can still
       // be hit with Accept: application/json on retries.
       setResponseHeader(event, 'vary', 'Accept');


### PR DESCRIPTION
## Summary

- `create-page-handler.ts` hardcoded the app bundle script tag as `/_litro/app.js` in both the happy path and the SSR-failure fallback path, even in dev mode.
- With a prior production build present, Nitro's static `publicAssets` handler could serve the stale built `dist/client/app.js` instead of letting Vite's dev middleware serve fresh `app.ts` on the fly — the exact contract `shell.ts` already documents (dev should pass `appScriptUrl: '/_litro/app.ts'`).
- Both call sites now derive the extension from the existing `isDev` flag (`process.env.LITRO_DEV === 'true'`): `/_litro/app.ts` in dev, `/_litro/app.js` in production. No new dev-detection mechanism was introduced.

Closes #97

## Test plan

- [x] `pnpm --filter @beatzball/litro test` — 417 tests pass, including new cases asserting `appScriptUrl` resolves to `/_litro/app.ts` under `LITRO_DEV=true` and `/_litro/app.js` when unset/false, plus base-path composition.
- [x] `pnpm --filter @beatzball/litro build` — compiles cleanly.
- [x] Added one changeset (`@beatzball/litro`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)