### PR TITLE
chore(agent): polish deferred minor findings — session store + resume e2e

### DIFF
--- a/.changeset/litro-agent-minor-polish.md
+++ b/.changeset/litro-agent-minor-polish.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/litro-agent': patch
+---
+
+Session store hygiene: `fileSessionStore` no longer pays a `mkdir` syscall on every single `append()` call (cached once per store instance, with retry-on-failure preserved), and its internal per-session promise-chain registry now drops an entry once it settles and nothing has chained onto it since, instead of retaining one for every distinct session id for the lifetime of the process.

--- a/e2e/playground/agent-resume.spec.ts
+++ b/e2e/playground/agent-resume.spec.ts
@@ -34,7 +34,13 @@ const cliEntry = path.join(repoRoot, 'packages/framework/dist/cli/index.js');
 
 const PORT = 3052;
 const BASE = `http://localhost:${PORT}`;
-const SESSION = 'e2e-resume';
+// Unique per run, same rationale as e2e/playground/agent.spec.ts's `session`:
+// `beforeAll` wipes `.litro/` before starting the server, but that hook does
+// NOT re-run on a Playwright retry of this test -- a fixed id would let a
+// retry's POST land in the same session file as the killed first attempt,
+// replaying a longer (duplicated) event sequence and breaking the exact
+// `toEqual(['message', 'text-delta'])` assertion below.
+const SESSION = `e2e-resume-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 
 let proc: ChildProcess | undefined;
 let stdoutBuf = '';

--- a/packages/litro-agent/src/sessions/file.mkdir.test.ts
+++ b/packages/litro-agent/src/sessions/file.mkdir.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'pathe';
+
+const mkdirCalls = { count: 0 };
+const failNext = { mkdir: false };
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    mkdir: async (...args: Parameters<typeof actual.mkdir>) => {
+      mkdirCalls.count++;
+      if (failNext.mkdir) {
+        failNext.mkdir = false;
+        throw new Error('EACCES: simulated');
+      }
+      return actual.mkdir(...args);
+    },
+  };
+});
+
+// Import after the mock so fileSessionStore picks up the mocked mkdir.
+const { fileSessionStore } = await import('./file.js');
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'litro-agent-store-mkdir-'));
+  mkdirCalls.count = 0;
+  failNext.mkdir = false;
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('fileSessionStore directory-creation hygiene', () => {
+  it('calls mkdir once across many appends to the same and different sessions', async () => {
+    const store = fileSessionStore({ dir });
+    await store.append('s1', { ts: 1, kind: 'message', payload: 'a' });
+    await store.append('s1', { ts: 2, kind: 'message', payload: 'b' });
+    await store.append('s2', { ts: 3, kind: 'message', payload: 'c' });
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) => store.append('s3', { ts: i, kind: 'text-delta', payload: i })),
+    );
+
+    expect(mkdirCalls.count).toBe(1);
+  });
+
+  it('retries mkdir on the next append after a failure (no permanently-cached rejection)', async () => {
+    const store = fileSessionStore({ dir });
+
+    failNext.mkdir = true;
+    await expect(store.append('s1', { ts: 1, kind: 'message', payload: 'a' })).rejects.toThrow(/EACCES/);
+    expect(mkdirCalls.count).toBe(1);
+
+    const ev = await store.append('s1', { ts: 2, kind: 'message', payload: 'b' });
+    expect(ev.seq).toBe(1);
+    expect(mkdirCalls.count).toBe(2);
+  });
+});

--- a/packages/litro-agent/src/sessions/file.ts
+++ b/packages/litro-agent/src/sessions/file.ts
@@ -17,6 +17,25 @@ export function fileSessionStore(opts?: { dir?: string }): SessionStore {
   // Per-session sequence counters
   const seqs = new Map<string, number>();
 
+  // The session directory only needs to exist once; `mkdir(recursive:
+  // true)` is idempotent but still a syscall, and append() used to pay it on
+  // EVERY call. Cache the in-flight/settled promise so concurrent and
+  // subsequent appends share one `mkdir`. On failure the cached promise is
+  // cleared so the next append retries (matches the prior per-call
+  // behavior, which always got a fresh attempt).
+  let dirReady: Promise<void> | undefined;
+  function ensureDir(): Promise<void> {
+    if (!dirReady) {
+      dirReady = mkdir(dir, { recursive: true })
+        .then(() => undefined)
+        .catch((err: unknown) => {
+          dirReady = undefined;
+          throw err;
+        });
+    }
+    return dirReady;
+  }
+
   async function initSeqIfNeeded(sessionId: string): Promise<void> {
     if (seqs.has(sessionId)) return;
 
@@ -62,7 +81,7 @@ export function fileSessionStore(opts?: { dir?: string }): SessionStore {
 
       const newChain = currentChain.catch(() => {}).then(async () => {
         // Create directory if needed
-        await mkdir(dir, { recursive: true });
+        await ensureDir();
 
         // Initialize seq on first touch
         await initSeqIfNeeded(sessionId);
@@ -91,8 +110,24 @@ export function fileSessionStore(opts?: { dir?: string }): SessionStore {
       chains.set(sessionId, newChain);
 
       // Wait for the chain to complete and return the event
-      await newChain;
-      return resultEvent!;
+      try {
+        await newChain;
+        return resultEvent!;
+      } finally {
+        // Registry hygiene: once this link settles (success or rejection),
+        // drop it from the map if it's still the current entry for this
+        // session -- i.e. nothing chained onto it while it was running. If a
+        // concurrent append already replaced the map entry with a newer
+        // link, leave it alone; that later link owns cleanup when IT
+        // settles. This keeps `chains` from growing forever across the
+        // lifetime of a long-running process as distinct session ids come
+        // and go, while never racing: the get/delete pair below is
+        // synchronous, so nothing can interleave between the check and the
+        // delete.
+        if (chains.get(sessionId) === newChain) {
+          chains.delete(sessionId);
+        }
+      }
     },
 
     async *read(sessionId: string, fromSeq = 0): AsyncIterable<SessionEvent> {


### PR DESCRIPTION
## Summary

Small polish pass over the Minor findings deferred at litro-agent v0's merge (the detailed ledger no longer exists, so each of the four named areas was re-reviewed from scratch against current `main`). Two areas had a genuine, low-risk defect worth fixing; two were re-reviewed and found to already be correct or not worth the behavior-change risk — see "Deferred / needs review" below.

## Fixed

- **Session store** (`packages/litro-agent/src/sessions/file.ts`)
  - `mkdir(dir, { recursive: true })` was called on **every single `append()`** — one syscall per session event, forever. It's now created once per store instance via a cached `ensureDir()` promise. On failure the cache is cleared so the next append still retries (same retry behavior as before, just without repaying the syscall on the happy path).
  - The per-session promise-chain map (`chains`) never removed an entry once a session touched it, so a long-running process accumulates one Map entry per distinct session id forever. `append()` now deletes its own chain link from the map once it settles, but only if nothing chained onto it in the meantime (a synchronous reference-equality check against the map's current value — no interleaving is possible in the single-threaded window between the check and the delete, so concurrent appends to the same session are unaffected; the sibling `seqs` cache is intentionally left untouched since it exists specifically to avoid re-reading the log file).
  - Added `packages/litro-agent/src/sessions/file.mkdir.test.ts`: asserts `mkdir` is called exactly once across many appends (same and different sessions), and that a failed `mkdir` is retried on the next append rather than being permanently cached.

- **E2E** (`e2e/playground/agent-resume.spec.ts`)
  - `SESSION` was a fixed literal (`'e2e-resume'`). `beforeAll` wipes `.litro/` before starting the server, but that hook does not re-run on a Playwright retry of the single test in this file — a retry after a failure would POST into the same session file as the killed first attempt, producing a longer/duplicated replayed event sequence and breaking the exact `toEqual(['message', 'text-delta'])` assertion. Switched to a per-run unique id, matching the pattern (and its documented rationale) already used in `e2e/playground/agent.spec.ts`.
  - Test-only change — no changeset needed for this part.

## Deferred / needs review

- **Providers** (`openai-compatible.ts`, `anthropic.ts`) — both use a truthy check (`if (delta?.content)` / `if (delta?.type === 'text_delta' && delta.text)`) before yielding a `text-delta` event, which silently drops a delta whose `content`/`text` field is the empty string. Traced this all the way through `runtime/loop.ts`: every `text-delta` event triggers `accumulatedText += ev.text` (a no-op for `''`) AND a session-store `append()` plus an NDJSON write to the client. Dropping an empty-string delta is therefore functionally invisible to the accumulated text, and "fixing" the truthy check to also forward `''` deltas would only add extra store I/O and wire traffic for zero behavioral benefit — the opposite direction from the mkdir fix above. A genuine whitespace-only delta (e.g. a single space `" "`) is a truthy string and already passes through untouched; the buffered-line reader (`readLines`) already correctly withholds a line until a full line arrives, so a network chunk that happens to be pure whitespace mid-line is never mishandled either. No concrete defect found; changing the truthy check would be a pure behavior change with no test currently expecting it, so left as-is.

- **Runtime handler** (`runtime/handler.ts`) — re-read `broadcast()` and `closeTails()` closely. Both already iterate a `[...subs]` snapshot, `try`/`catch` each subscriber's callback individually, and unsubscribe only the failing one (`broadcast`) or unconditionally continue to the next subscriber after the try/catch (`closeTails`) — i.e. one subscriber's thrown `onEvent`/`onClose` cannot prevent the others in the same broadcast key from being notified/closed. This already matches the "an error in one subscriber's cleanup shouldn't drop others" requirement; no defect found, no change made.

## Test plan

- [x] `pnpm --filter @beatzball/litro build` (router → framework → litro-agent, in dependency order)
- [x] `pnpm --filter @beatzball/litro-agent build` — green
- [x] `pnpm --filter @beatzball/litro-agent test` — 97/97 passing (95 pre-existing + 2 new in `file.mkdir.test.ts`)
- [ ] Full Playwright e2e not run in this pass (only the resume spec's session-id literal changed; behavior of the spec itself is otherwise identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)