### PR TITLE
fix: serve the live client entry in litro dev

### DIFF
--- a/.changeset/create-litro-dev-middleware.md
+++ b/.changeset/create-litro-dev-middleware.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/create-litro': patch
+---
+
+Recipe templates' `server/middleware/vite-dev.ts` now builds its dev Vite server from `litroViteDevConfig()` (and pre-warms the client entry via `warmupLitroViteServer()`), so scaffolded apps get the live-source dev entry fix for issue 97 instead of serving a stale pre-built bundle.

--- a/.changeset/dev-live-entry.md
+++ b/.changeset/dev-live-entry.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/litro': patch
+---
+
+`litro dev` now serves the live client entry (`/app.ts`) through Vite instead of a stale pre-built `dist/client/app.js` — source edits reflect in the browser without a rebuild (issue 97). The new `litroViteDevConfig()`/`warmupLitroViteServer()` helpers (`@beatzball/litro/runtime/vite-dev.js`) centralise the dev Vite config: dev `base: '/'` so module URLs stay clear of the `/_litro/` static mount, dependency pre-optimization and page warmup to prevent mid-load full reloads, and watcher ignores for `.nitro/`/`.litro/` so Nitro regenerating its types no longer forces a full browser reload. The actions Vite plugin now also stubs `@beatzball/litro/actions/server` by resolved path, which live-source dev requires to keep `node:crypto` imports out of the browser graph.

--- a/.changeset/dev-live-entry.md
+++ b/.changeset/dev-live-entry.md
@@ -3,3 +3,5 @@
 ---
 
 `litro dev` now serves the live client entry (`/app.ts`) through Vite instead of a stale pre-built `dist/client/app.js` — source edits reflect in the browser without a rebuild (issue 97). The new `litroViteDevConfig()`/`warmupLitroViteServer()` helpers (`@beatzball/litro/runtime/vite-dev.js`) centralise the dev Vite config: dev `base: '/'` so module URLs stay clear of the `/_litro/` static mount, dependency pre-optimization and page warmup to prevent mid-load full reloads, and watcher ignores for `.nitro/`/`.litro/` so Nitro regenerating its types no longer forces a full browser reload. The actions Vite plugin now also stubs `@beatzball/litro/actions/server` by resolved path, which live-source dev requires to keep `node:crypto` imports out of the browser graph.
+
+Backwards compatible for existing apps: the live entry only activates when the app's `server/middleware/vite-dev.ts` builds its Vite server from `litroViteDevConfig()` (which sets `LITRO_DEV_LIVE_ENTRY`). Apps still running a previously-scaffolded middleware keep their prior dev behavior unchanged after upgrading; update the middleware to the current template to opt in to the live entry.

--- a/.changeset/router-settled-marker.md
+++ b/.changeset/router-settled-marker.md
@@ -1,0 +1,5 @@
+---
+'@beatzball/litro-router': minor
+---
+
+The router now sets a `data-litro-settled` attribute on the outlet element once the atomic page swap completes. Until that point, the visible content on an initial load is the SSR'd shell whose event handlers are not wired — interactions can land on a dead element. The attribute is the router's observable "current page element is live" signal; consumers (including e2e tests) can poll for it (`litro-outlet[data-litro-settled]`) before interacting with the page.

--- a/benchmarks/apps/hn-litro-elena/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro-elena/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/benchmarks/apps/hn-litro-elena/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro-elena/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,26 +42,17 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/benchmarks/apps/hn-litro-fast/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro-fast/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/benchmarks/apps/hn-litro-fast/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro-fast/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,26 +42,17 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/benchmarks/apps/hn-litro/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/benchmarks/apps/hn-litro/server/middleware/vite-dev.ts
+++ b/benchmarks/apps/hn-litro/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,26 +42,17 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/docs-ssr/server/middleware/vite-dev.ts
+++ b/docs-ssr/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/docs-ssr/server/middleware/vite-dev.ts
+++ b/docs-ssr/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/docs-ssr/server/starlight.config.js
+++ b/docs-ssr/server/starlight.config.js
@@ -14,6 +14,7 @@ export const siteConfig = {
         { label: 'Introduction', slug: 'introduction' },
         { label: 'Getting Started', slug: 'getting-started' },
         { label: 'Configuration', slug: 'configuration' },
+        { label: 'Upgrading', slug: 'upgrading' },
       ],
     },
     {

--- a/docs/server/middleware/vite-dev.ts
+++ b/docs/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/docs/server/middleware/vite-dev.ts
+++ b/docs/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/docs/server/starlight.config.js
+++ b/docs/server/starlight.config.js
@@ -14,6 +14,7 @@ export const siteConfig = {
         { label: 'Introduction', slug: 'introduction' },
         { label: 'Getting Started', slug: 'getting-started' },
         { label: 'Configuration', slug: 'configuration' },
+        { label: 'Upgrading', slug: 'upgrading' },
       ],
     },
     {

--- a/e2e/docs-ssr/search.spec.ts
+++ b/e2e/docs-ssr/search.spec.ts
@@ -83,6 +83,8 @@ test('search page returns 200', async ({ request }) => {
 test('header contains a search pill button', async ({ page }) => {
   await page.goto('/');
   // After hydration, spaNav property is set and the pill becomes visible.
+  // Wait for the router's post-swap marker (client entry booted) first.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   // Use first() since SSR + hydration may produce two header elements briefly.
   const pill = page.locator('starlight-header').first().locator('.search-pill');
   await expect(pill).toBeVisible({ timeout: 5000 });
@@ -96,6 +98,10 @@ test('Cmd+K opens search modal', async ({ page }) => {
   await page.goto('/');
   // Wait for the modal to be appended to body by app.ts
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   const modal = page.locator('search-modal');
   await expect(modal).toHaveAttribute('open', '');
@@ -104,6 +110,10 @@ test('Cmd+K opens search modal', async ({ page }) => {
 test('Escape closes search modal', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   await expect(page.locator('search-modal')).toHaveAttribute('open', '');
   await page.keyboard.press('Escape');
@@ -113,6 +123,10 @@ test('Escape closes search modal', async ({ page }) => {
 test('header pill click opens search modal', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   const pill = page.locator('starlight-header').first().locator('.search-pill');
   await pill.click();
   await expect(page.locator('search-modal')).toHaveAttribute('open', '');
@@ -121,6 +135,10 @@ test('header pill click opens search modal', async ({ page }) => {
 test('/ shortcut opens modal when not in an input', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('/');
   await expect(page.locator('search-modal')).toHaveAttribute('open', '');
 });
@@ -132,6 +150,10 @@ test('/ shortcut opens modal when not in an input', async ({ page }) => {
 test('typing in modal shows autosuggest results', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   // Wait for the modal's shadow DOM to render and input to be available
   const input = page.locator('search-modal').locator('input[type="search"]');
@@ -145,6 +167,10 @@ test('typing in modal shows autosuggest results', async ({ page }) => {
 test('arrow keys navigate results in modal', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   const input = page.locator('search-modal').locator('input[type="search"]');
   await expect(input).toBeVisible({ timeout: 5000 });
@@ -160,6 +186,10 @@ test('arrow keys navigate results in modal', async ({ page }) => {
 test('Enter on result navigates away', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   const input = page.locator('search-modal').locator('input[type="search"]');
   await expect(input).toBeVisible({ timeout: 5000 });
@@ -181,6 +211,10 @@ test('Enter on result navigates away', async ({ page }) => {
 test('search modal has correct ARIA attributes', async ({ page }) => {
   await page.goto('/');
   await page.waitForSelector('search-modal', { state: 'attached' });
+  // Attached does not mean upgraded with keyboard/click listeners wired. The
+  // router's post-swap marker fires after the client entry has booted (all
+  // statically-imported components upgraded) — wait for it before interacting.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.keyboard.press('Meta+k');
   const dialog = page.locator('search-modal').locator('[role="dialog"]');
   await expect(dialog).toHaveAttribute('aria-modal', 'true');

--- a/e2e/docs-ssr/streaming.spec.ts
+++ b/e2e/docs-ssr/streaming.spec.ts
@@ -45,10 +45,12 @@ test('app bundle script appears in the document foot', async ({ request }) => {
   const res = await request.get('/');
   const html = await res.text();
 
-  // The app bundle <script type="module"> must be present in the HTML.
+  // The app entry <script type="module"> must be present in the HTML.
   // Hydration support (lit-element-hydrate-support.js) is the first import
   // inside app.ts and is bundled into app.js — no separate script tag needed.
-  const appIdx = html.indexOf('app.js');
+  // Dev serves the live source entry (`/app.ts`, issue 97); prod/preview
+  // serves the built bundle (`/_litro/app.js`) — accept either.
+  const appIdx = html.search(/src="[^"]*app\.(js|ts)"/);
   expect(appIdx).toBeGreaterThan(-1);
   // The script should appear after the main content (in the foot)
   const outletIdx = html.indexOf('</litro-outlet>');

--- a/e2e/playground-fast/agent.spec.ts
+++ b/e2e/playground-fast/agent.spec.ts
@@ -26,6 +26,9 @@ test.describe('agent demo — chat, data/UI separation (FAST playground, /agent)
     // router's initial resolve mounts a second (hidden) page-agent alongside
     // the SSR'd one before the atomic swap settles.
     await page.waitForSelector('page-agent:not([hidden])');
+    // Router "swap complete" marker — before it, interactions can land on the
+    // dead SSR'd shell. Same convention as the Lit playground's agent spec.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
 
     await page.fill('#chat-input', 'what is the weather in lisbon');
     await page.click('#chat-send');
@@ -52,6 +55,9 @@ test.describe('agent demo — chat, data/UI separation (FAST playground, /agent)
   }) => {
     await page.goto('/agent');
     await page.waitForSelector('page-agent:not([hidden])');
+    // Router "swap complete" marker — before it, interactions can land on the
+    // dead SSR'd shell. Same convention as the Lit playground's agent spec.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
 
     await page.fill('#chat-input', 'what is the weather in lisbon');
     await page.click('#chat-send');

--- a/e2e/playground/agent.spec.ts
+++ b/e2e/playground/agent.spec.ts
@@ -37,6 +37,13 @@ test.describe('agent demo — chat, data/UI separation (Lit playground, /agent)'
     // interacting, exactly as server-actions-forms.spec.ts and
     // server-actions-streaming.spec.ts do for page-forms.
     await page.waitForSelector('page-agent:not([hidden])');
+    // Wait for the router's authoritative "swap complete" marker before
+    // interacting. Until the initial SSR->client swap finishes, the visible
+    // element is the SSR'd shell with NO live event handlers — clicks land on
+    // it and are silently dropped. Element-count/visibility checks cannot
+    // distinguish that phase (count is 1 both before the client element mounts
+    // and after the swap), so poll the outlet attribute set post-swap.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
 
     await page.fill('#chat-input', 'what is the weather in lisbon');
     await page.click('#chat-send');
@@ -64,6 +71,13 @@ test.describe('agent demo — chat, data/UI separation (Lit playground, /agent)'
   }) => {
     await page.goto('/agent');
     await page.waitForSelector('page-agent:not([hidden])');
+    // Wait for the router's authoritative "swap complete" marker before
+    // interacting. Until the initial SSR->client swap finishes, the visible
+    // element is the SSR'd shell with NO live event handlers — clicks land on
+    // it and are silently dropped. Element-count/visibility checks cannot
+    // distinguish that phase (count is 1 both before the client element mounts
+    // and after the swap), so poll the outlet attribute set post-swap.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
 
     await page.fill('#chat-input', 'what is the weather in lisbon');
     await page.click('#chat-send');

--- a/e2e/playground/dev-live-entry.spec.ts
+++ b/e2e/playground/dev-live-entry.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression for issue #97 — `litro dev` must serve the LIVE client entry
+ * through Vite, never the stale pre-built `dist/client/app.js`.
+ *
+ * These tests run against the dev server (playwright `webServer` = `litro dev`).
+ * On the old behavior the HTML shell referenced `/_litro/app.js`, which Nitro's
+ * `publicAssets` static handler served from a pre-built bundle — so source edits
+ * to `app.ts` never reflected in the browser. Each assertion below FAILS on that
+ * old behavior.
+ */
+
+/** Marker only present in Vite's PRODUCTION bundle (the stale-bundle tell). */
+const BUILT_BUNDLE_MARKER = '__vite__mapDeps';
+
+function extractAppScriptSrc(html: string): string {
+  const match = html.match(/<script type="module" src="([^"]+)"><\/script>/);
+  if (!match) throw new Error('no module entry <script> found in shell');
+  return match[1];
+}
+
+test('dev shell references a root-relative source entry, not /_litro/app.js', async ({ request }) => {
+  const html = await (await request.get('/')).text();
+  const src = extractAppScriptSrc(html);
+  // Dev must NOT point at the /_litro/ static mount (that path serves the stale
+  // pre-built bundle). It should reference the root-relative `.ts` source entry.
+  expect(src).not.toBe('/_litro/app.js');
+  expect(src).toMatch(/\/app\.ts(\?.*)?$/);
+});
+
+test('dev client entry is served as live Vite source, not the built bundle', async ({ request }) => {
+  const html = await (await request.get('/')).text();
+  const src = extractAppScriptSrc(html);
+
+  const res = await request.get(src);
+  expect(res.status()).toBe(200);
+  const body = await res.text();
+
+  // Live, Vite-transformed source: no production-bundle marker, and imports are
+  // rewritten to Vite's dev module URLs (`/@fs/…`, `/@vite/…`, `/node_modules/…`).
+  expect(body).not.toContain(BUILT_BUNDLE_MARKER);
+  expect(body).toMatch(/\/(@fs|@vite|@id|node_modules)\//);
+});
+
+test('dev client entry transitive imports resolve (live module graph)', async ({ request }) => {
+  const html = await (await request.get('/')).text();
+  const entry = await (await request.get(extractAppScriptSrc(html))).text();
+
+  // The live entry's imports are rewritten to Vite dev module URLs. Pick the
+  // first one and confirm it resolves — proving the whole graph is served live
+  // (on the old behavior these `/_litro/`-prefixed URLs 404'd and the browser
+  // fell back to the stale built bundle).
+  const firstImport = entry.match(/\bimport\s+(?:[^'"]*from\s*)?["'](\/[^"']+)["']/);
+  expect(firstImport, 'live entry should have a rewritten module import').not.toBeNull();
+  const res = await request.get(firstImport![1]);
+  expect(res.status()).toBe(200);
+});
+
+test('page hydrates from the live entry (client navigation works)', async ({ page }) => {
+  let fullReloadCount = 0;
+  page.on('load', () => fullReloadCount++);
+
+  await page.goto('/');
+  await page.waitForSelector('litro-outlet');
+  // A working SPA navigation proves the live entry loaded, ran, and wired the
+  // router — i.e. the client bundle is real, not a 404/stale artifact.
+  await page.evaluate(() => {
+    history.pushState({}, '', '/blog');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  });
+  await page.waitForURL('**/blog');
+  await expect(page.locator('h1').first()).toContainText('Blog');
+  expect(fullReloadCount).toBe(1);
+});

--- a/e2e/playground/server-actions-externalization.spec.ts
+++ b/e2e/playground/server-actions-externalization.spec.ts
@@ -14,6 +14,9 @@ test('no server-module code reaches the browser on the actions page', async ({ p
   });
   await page.goto('/actions');
   await page.waitForSelector('page-actions:not([hidden])');
+  // Router "swap complete" marker — before it, clicks can land on the dead
+  // SSR'd shell. Same convention as server-actions.spec.ts.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.locator('#rpc-button').click();
   await expect(page.locator('#rpc-result')).toContainText('LITRO ACTIONS');
   // Await every captured body before asserting — pushing resolved strings

--- a/e2e/playground/server-actions-forms.spec.ts
+++ b/e2e/playground/server-actions-forms.spec.ts
@@ -66,6 +66,9 @@ test.describe('server actions — enhanced form posts', () => {
     // litro-router's _resolve()); wait for the atomic swap to settle before
     // interacting, matching the convention in server-actions.spec.ts.
     await page.waitForSelector('page-forms:not([hidden])');
+    // Router "swap complete" marker — before it, clicks can land on the dead
+    // SSR'd shell. Same convention as server-actions.spec.ts.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
     await page.locator('#gb-submit').click();
     await expect(page.locator('#enhanced-error')).toContainText('Name is required');
     expect(page.url()).toContain('/forms');
@@ -75,6 +78,8 @@ test.describe('server actions — enhanced form posts', () => {
   test('success surfaces via litro:action-success detail', async ({ page }) => {
     await page.goto('/forms');
     await page.waitForSelector('page-forms:not([hidden])');
+    // Router "swap complete" marker (see the validation test above).
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
     await page.fill('#gb-name', 'Enhanced');
     await page.fill('#gb-message', 'enhanced hello');
     await page.locator('#gb-submit').click();

--- a/e2e/playground/server-actions-streaming.spec.ts
+++ b/e2e/playground/server-actions-streaming.spec.ts
@@ -25,6 +25,9 @@ test.describe('server actions — streaming', () => {
     // wait for the atomic swap to settle before interacting, matching the
     // convention in server-actions.spec.ts.
     await page.waitForSelector('page-forms:not([hidden])');
+    // Router "swap complete" marker — before it, clicks can land on the dead
+    // SSR'd shell. Same convention as server-actions.spec.ts.
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
     await page.locator('#stream-button').click();
     await expect(page.locator('#stream-lines li')).toHaveCount(4);
     await expect(page.locator('#stream-lines li').first()).toContainText('3 @ 20');
@@ -34,6 +37,8 @@ test.describe('server actions — streaming', () => {
   test('mid-stream error surfaces as a LitroActionError message', async ({ page }) => {
     await page.goto('/forms');
     await page.waitForSelector('page-forms:not([hidden])');
+    // Router "swap complete" marker (see the countdown test above).
+    await page.waitForSelector('litro-outlet[data-litro-settled]');
     await page.locator('#stream-fail-button').click();
     await expect(page.locator('#stream-error')).toHaveText('stream blew up');
   });

--- a/e2e/playground/server-actions.spec.ts
+++ b/e2e/playground/server-actions.spec.ts
@@ -14,6 +14,10 @@ test('SSR page contains data fetched via in-process action call', async ({ reque
 test('button click performs typed RPC and revives Date', async ({ page }) => {
   await page.goto('/actions');
   await page.waitForSelector('page-actions:not([hidden])');
+  // Wait for the router's authoritative "swap complete" marker: until the
+  // initial SSR->client swap finishes, the visible element is the SSR'd shell
+  // whose button has no live handler, so a click lands on it and is dropped.
+  await page.waitForSelector('litro-outlet[data-litro-settled]');
   await page.locator('#rpc-button').click();
   await expect(page.locator('#rpc-result')).toContainText('LITRO ACTIONS @ 20');
   await expect(page.locator('#rpc-result')).not.toContainText('NOT-A-DATE');

--- a/packages/create-litro/recipes/11ty-blog/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/packages/create-litro/recipes/11ty-blog/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/packages/create-litro/recipes/fullstack/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/fullstack/template/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/packages/create-litro/recipes/fullstack/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/fullstack/template/server/middleware/vite-dev.ts
@@ -1,27 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            // Attach Vite HMR WebSocket to Nitro's existing HTTP server so
-            // both share a single port with no conflicts.
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/packages/create-litro/recipes/starlight/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/starlight/template/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/packages/create-litro/recipes/starlight/template/server/middleware/vite-dev.ts
+++ b/packages/create-litro/recipes/starlight/template/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/packages/docs-content/content/docs/upgrading.md
+++ b/packages/docs-content/content/docs/upgrading.md
@@ -1,0 +1,133 @@
+---
+title: Upgrading
+description: How to upgrade an existing Litro app, and the release-by-release notes for anything that needs a decision — including opting in to the live dev entry (issue 97) introduced alongside @beatzball/litro 0.12.1.
+date: 2026-07-19
+---
+
+# Upgrading
+
+Litro releases are coordinated: `@beatzball/litro`, `@beatzball/litro-router`, and `@beatzball/create-litro` version together through changesets, and a release never silently changes the behavior of an existing app. Anything that would is gated behind an opt-in, and this page documents each one.
+
+To upgrade, bump the packages and reinstall:
+
+```bash
+pnpm update @beatzball/litro @beatzball/litro-router
+```
+
+`@beatzball/create-litro` only matters when scaffolding new apps — `npm create @beatzball/litro@latest` always uses the latest.
+
+Full change lists live in each package's CHANGELOG on npm or in the repository.
+
+## litro 0.12.1 / litro-router 0.2.0
+
+### Live dev entry — the stale-bundle fix (opt-in)
+
+Previously, `litro dev` served the client from a pre-built `dist/client/app.js`. That bundle was built once (on first start) and never rebuilt, so edits to `app.ts` or shared components could stop reflecting in the browser until you deleted `dist/client/` and restarted — the classic symptom being stale pages or "hydration value mismatch" errors after changing shared code.
+
+As of `@beatzball/litro` 0.12.1, dev can serve the **live source entry** through Vite instead: the shell references `/app.ts`, every module in the client graph is transformed on demand, and edits reflect on reload with no rebuild step. Production and SSG builds are completely unchanged.
+
+**Upgrading alone changes nothing.** The live entry only activates when your app's Vite dev middleware is built from the framework's `litroViteDevConfig()` helper. Apps scaffolded before 0.12.1 run an older middleware and keep their previous dev behavior after upgrading.
+
+To opt in, replace your `server/middleware/vite-dev.ts` with the current version:
+
+```ts
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
+import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
+
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
+let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
+
+export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
+  if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
+
+  if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
+    const httpServer = (event.node.req.socket as import('node:net').Socket & {
+      server?: import('node:http').Server;
+    }).server;
+
+    viteHandlerPromise = import('vite')
+      .then(({ createServer }) =>
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
+      )
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
+  }
+
+  const viteHandler = await viteHandlerPromise;
+  return viteHandler(event);
+});
+```
+
+That file swap is the whole migration. Notes:
+
+- Keep `base: '/_litro/'` in your `vite.config.ts` — it still configures the **production** build. The helper only overrides `base` for the dev middleware server.
+- The helper also stops Vite from watching `.nitro/` and `.litro/` (Nitro regenerating its types no longer forces a full browser reload) and pre-optimizes the dependency graph of `app.ts` and every page module at startup.
+- Apps scaffolded with `@beatzball/create-litro` 0.7.1 or later include this middleware already.
+- If your shared modules read `process.env` at module top level, guard them (`globalThis.process?.env`) — the production build tree-shakes server-only code out of the client bundle, but the live dev graph executes the whole module in the browser.
+
+### `data-litro-settled` — knowing when the page is interactive
+
+`@beatzball/litro-router` 0.2.0 marks the outlet element with a `data-litro-settled` attribute once the initial SSR-to-client swap completes. Before that moment, the visible content is the server-rendered shell, whose event handlers are not wired yet.
+
+This is additive — nothing existing changes — but it closes a real gap if you run browser tests or defer interactions until the page is live:
+
+```ts
+// Playwright: wait for the page to be interactive before clicking
+await page.waitForSelector('litro-outlet[data-litro-settled]');
+```
+
+Element-count or visibility checks cannot distinguish the pre-hydration shell from the live page; the attribute can.
+
+## litro 0.12.0
+
+Adds the `@beatzball/litro/stream` subpath — the NDJSON stream wire protocol (`createStreamEncoder`, `createStreamDecoder`, `serializeValue`, `deserializeValue`) shared by Server Actions streaming and the agent layer. Purely additive; no action needed.
+
+`@beatzball/litro-agent` 0.1.0 released alongside it: the filesystem-first agent layer where `agents/<name>/` directories become durable streaming session endpoints and tools return server-rendered components. Entirely opt-in — see [Agents](/docs/agents) for setup.
+
+## litro 0.11.0
+
+Introduced Server Actions (typed RPC, no-JS forms, streaming). Opt-in, with a few one-time wiring edits for existing apps — see [Upgrading from 0.10.x or earlier](/docs/server-actions#upgrading-from-010x-or-earlier) on the Server Actions page.

--- a/packages/docs-ui/src/route-meta.ts
+++ b/packages/docs-ui/src/route-meta.ts
@@ -12,8 +12,14 @@
  *   UMAMI_SRC        — script URL (default: https://cloud.umami.is/script.js)
  *   UMAMI_DOMAINS    — data-domains allowlist (optional)
  */
-const umamiScript = process.env.UMAMI_WEBSITE_ID
-  ? `<script defer src="${process.env.UMAMI_SRC ?? 'https://cloud.umami.is/script.js'}" data-website-id="${process.env.UMAMI_WEBSITE_ID}"${process.env.UMAMI_DOMAINS ? ` data-domains="${process.env.UMAMI_DOMAINS}"` : ''}></script>`
+// `globalThis.process?.` guard: this module is shared with browser-side page
+// components. In the production client bundle the unused server-only exports
+// (and with them these env reads) are tree-shaken away, but the dev server
+// serves the module as live source where the whole body executes — a bare
+// `process` reference would throw ReferenceError and kill the client graph.
+const env = globalThis.process?.env ?? {};
+const umamiScript = env.UMAMI_WEBSITE_ID
+  ? `<script defer src="${env.UMAMI_SRC ?? 'https://cloud.umami.is/script.js'}" data-website-id="${env.UMAMI_WEBSITE_ID}"${env.UMAMI_DOMAINS ? ` data-domains="${env.UMAMI_DOMAINS}"` : ''}></script>`
   : '';
 
 export const starlightHead = [

--- a/packages/docs-ui/src/seo.ts
+++ b/packages/docs-ui/src/seo.ts
@@ -1,4 +1,6 @@
-const siteUrl = (process.env.SITE_URL ?? 'https://litro.dev').replace(/\/$/, '');
+// `globalThis.process?.` guard: shared with browser-side page components —
+// see route-meta.ts for why a bare `process` reference breaks live-source dev.
+const siteUrl = (globalThis.process?.env?.SITE_URL ?? 'https://litro.dev').replace(/\/$/, '');
 
 export interface SeoOptions {
   title: string;

--- a/packages/framework/src/cli/index.ts
+++ b/packages/framework/src/cli/index.ts
@@ -90,12 +90,16 @@ switch (command) {
     // Nitro's dev server proxies requests to a worker thread. During
     // dev:reload the worker restarts — inflight connections emit ECONNRESET
     // which Node v24+ treats as a fatal uncaught exception, crashing the
-    // server. Write a temporary guard script and preload it via --require.
+    // server. EPIPE is the same class of benign client-disconnect error on
+    // the write side (a browser aborting an in-flight module/SSR stream —
+    // routine under live-source dev, which streams far more responses) and
+    // must not kill the server either. Write a temporary guard script and
+    // preload it via --require.
     const guardDir = join(cwd, 'node_modules', '.cache');
     const guardPath = join(guardDir, 'litro-dev-guard.cjs');
     mkdirSync(guardDir, { recursive: true });
     writeFileSync(guardPath,
-      'process.on("uncaughtException",function(e){if(e&&e.code==="ECONNRESET")return;console.error(e);process.exit(1)});\n',
+      'process.on("uncaughtException",function(e){if(e&&(e.code==="ECONNRESET"||e.code==="EPIPE"))return;console.error(e);process.exit(1)});\n',
     );
     const nodeOpts = [process.env.NODE_OPTIONS, `--require "${guardPath}"`]
       .filter(Boolean).join(' ');

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -183,13 +183,18 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
         }
       }
 
-      // Always reference the compiled bundle. In dev mode Vite's middleware
-      // intercepts /_litro/app.js and serves app.ts on the fly (Vite resolves
-      // .js → .ts automatically). If Vite is not intercepting, the static file
-      // handler serves the pre-built dist/client/app.js as a fallback.
+      // Reference the client entry. In dev mode we point at the .ts SOURCE at a
+      // ROOT-relative path (`/app.ts`) so Vite's dev middleware serves it as
+      // live, transformed source — edits to app.ts reflect without a rebuild.
+      // Dev must NOT use the `/_litro/` prefix: Nitro's publicAssets handler
+      // owns `/_litro/*` and would serve the stale pre-built dist/client/app.js
+      // (issue #97). The dev Vite server runs with base '/', so it emits and
+      // serves the entry and every transitive import at root-relative paths.
+      // In production the compiled `/_litro/app.js` bundle is served by the
+      // publicAssets static handler (dist/client/app.js).
       const basePath = process.env.LITRO_BASE_PATH ?? '';
-      const appScriptUrl = `${basePath}/_litro/app.js`;
       const isDev = process.env.LITRO_DEV === 'true';
+      const appScriptUrl = isDev ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
 
       // Get any framework-specific head scripts from the adapter.
       const adapterHeadScripts = adapter.getHeadScripts({ isDev, basePath });
@@ -260,7 +265,8 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // Build a minimal fallback shell (no server data — data fetch may have
       // been the source of the error, or may not have run yet).
       const basePath = process.env.LITRO_BASE_PATH ?? '';
-      const appScriptUrl = `${basePath}/_litro/app.js`;
+      const isDev = process.env.LITRO_DEV === 'true';
+      const appScriptUrl = isDev ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
       // Carry vary header through the fallback path too — the URL can still
       // be hit with Accept: application/json on retries.
       setResponseHeader(event, 'vary', 'Accept');

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -192,9 +192,16 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // serves the entry and every transitive import at root-relative paths.
       // In production the compiled `/_litro/app.js` bundle is served by the
       // publicAssets static handler (dist/client/app.js).
+      //
+      // LITRO_DEV_LIVE_ENTRY gates the live entry on the app actually running
+      // the new litroViteDevConfig()-based middleware: an app upgraded to this
+      // framework version but still running its previously-scaffolded
+      // vite-dev middleware keeps the old (stale-bundle) behavior instead of a
+      // broken `/app.ts` graph — see litroViteDevConfig() in runtime/vite-dev.
       const basePath = process.env.LITRO_BASE_PATH ?? '';
       const isDev = process.env.LITRO_DEV === 'true';
-      const appScriptUrl = isDev ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
+      const liveEntry = isDev && process.env.LITRO_DEV_LIVE_ENTRY === '1';
+      const appScriptUrl = liveEntry ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
 
       // Get any framework-specific head scripts from the adapter.
       const adapterHeadScripts = adapter.getHeadScripts({ isDev, basePath });
@@ -266,7 +273,9 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       // been the source of the error, or may not have run yet).
       const basePath = process.env.LITRO_BASE_PATH ?? '';
       const isDev = process.env.LITRO_DEV === 'true';
-      const appScriptUrl = isDev ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
+      // Same LITRO_DEV_LIVE_ENTRY gating as the happy path above.
+      const liveEntry = isDev && process.env.LITRO_DEV_LIVE_ENTRY === '1';
+      const appScriptUrl = liveEntry ? `${basePath}/app.ts` : `${basePath}/_litro/app.js`;
       // Carry vary header through the fallback path too — the URL can still
       // be hit with Accept: application/json on retries.
       setResponseHeader(event, 'vary', 'Accept');

--- a/packages/framework/src/runtime/vite-dev.ts
+++ b/packages/framework/src/runtime/vite-dev.ts
@@ -1,0 +1,141 @@
+/**
+ * vite-dev.ts — dev-server Vite config for Litro's single-port setup
+ *
+ * Builds the Vite `InlineConfig` used by each app's `server/middleware/vite-dev.ts`
+ * when it spins up an in-process Vite dev server in `middlewareMode`. Centralising
+ * it here fixes the stale-client-bundle footgun described in issue #97.
+ *
+ * The problem
+ * ───────────
+ * A Litro app's `vite.config.ts` sets `base: '/_litro/'` so the PRODUCTION client
+ * bundle (served from `dist/client/` via Nitro's `publicAssets` mount at
+ * `/_litro/`) resolves its preload/import URLs. Vite reads that same config in
+ * dev, so it EMITS every module URL prefixed with `/_litro/`.
+ *
+ * But in dev Nitro's `publicAssets` handler owns `/_litro/*` and is consulted
+ * BEFORE the Vite dev middleware — it never yields. So a `/_litro/app.js` request
+ * (and every `/_litro/@fs/…`, `/_litro/@vite/client`, `/_litro/node_modules/…`
+ * import) is served the pre-built, and now STALE, `dist/client/app.js`. Source
+ * edits to `app.ts` / `pages/*.ts` silently stop reflecting in the browser until
+ * `dist/` is deleted — exactly the bug reported in issue #97.
+ *
+ * The fix
+ * ───────
+ * Override `base` to `'/'` for the DEV Vite server only. Vite then emits and
+ * serves the entry and all transitive imports at ROOT-relative paths (`/app.ts`,
+ * `/@fs/…`, `/@vite/client`, …), which the Vite dev middleware DOES receive
+ * (Nitro's `/_litro/` static handler never sees them). The HTML shell references
+ * `/app.ts` in dev (see create-page-handler), so the live source entry — not the
+ * stale bundle — is what the browser loads. Production is unaffected: the shell
+ * still references `/_litro/app.js` and `vite build` still uses `base: '/_litro/'`
+ * from `vite.config.ts`.
+ *
+ * This module has NO `vite` import (only a type-only import, which is erased), so
+ * it is safe to import from a Nitro server middleware without pulling Vite into
+ * the production bundle. Callers still perform the `import('vite')` + `createServer`
+ * themselves so Vite stays out of the production trace.
+ */
+
+import type { Server } from 'node:http';
+import type { InlineConfig, ViteDevServer } from 'vite';
+
+/** Litro's client entry filename (relative to the app root). */
+export const LITRO_CLIENT_ENTRY = 'app.ts';
+
+export interface LitroViteDevOptions {
+  /** Vite project root — the app directory (typically `process.cwd()`). */
+  root: string;
+  /**
+   * The HTTP server Nitro is already listening on. Passed as Vite's `hmr.server`
+   * so Vite attaches its HMR WebSocket to the existing port instead of opening a
+   * second, conflicting server. When omitted, Vite uses its default HMR setup.
+   */
+  hmrServer?: Server;
+  /**
+   * Client entry to pre-scan for dependency optimization. Defaults to
+   * {@link LITRO_CLIENT_ENTRY} (`app.ts`). See `optimizeDeps.entries` below.
+   */
+  entry?: string;
+}
+
+/**
+ * Builds the Vite `InlineConfig` for Litro's single-port dev server.
+ *
+ * @see the module docblock for why `base` is forced to `'/'` in dev (issue #97).
+ */
+export function litroViteDevConfig(options: LitroViteDevOptions): InlineConfig {
+  return {
+    // DEV base override — see module docblock. `vite.config.ts` keeps
+    // `base: '/_litro/'` for the production build; this only affects the dev
+    // middleware server so its module URLs stay clear of Nitro's `/_litro/` mount.
+    base: '/',
+    // middlewareMode: Vite does NOT bind its own HTTP server — it exposes a
+    // connect middleware stack that the Nitro server middleware mounts.
+    server: {
+      middlewareMode: true,
+      // Attach Vite's HMR WebSocket to Nitro's existing HTTP server (single port).
+      hmr: options.hmrServer ? { server: options.hmrServer } : true,
+      // Never watch Nitro/Litro server-state dirs. Nitro regenerates
+      // `.nitro/types/tsconfig.json` on every dev:reload (and whenever a second
+      // Nitro process shares the app dir, e.g. a test spawning its own server),
+      // and Vite treats any tracked-tsconfig change as "clear cache + force
+      // full-reload" — yanking the page out from under the browser mid-session.
+      // `.litro/` holds runtime state (agent session logs) that is likewise
+      // never client source. Neither dir can contain modules Vite serves.
+      watch: {
+        ignored: ['**/.nitro/**', '**/.litro/**'],
+      },
+      // Transform the client entry and every page module at server startup.
+      // Page modules are lazily (dynamically) imported by the router at
+      // navigation time; without warmup that first import is a cold, on-demand
+      // transform. In dev the router briefly keeps the SSR'd element mounted
+      // alongside the incoming one while `route.action()` (the dynamic import)
+      // resolves — a slow cold transform widens that window. Warming the page
+      // graph up front keeps those imports fast so the swap is near-instant.
+      warmup: {
+        clientFiles: [options.entry ?? LITRO_CLIENT_ENTRY, 'pages/**/*.{ts,tsx,js,jsx,mjs}'],
+      },
+    },
+    // 'custom' appType suppresses Vite's built-in SPA HTML fallback — Nitro owns
+    // all HTML responses.
+    appType: 'custom',
+    root: options.root,
+    optimizeDeps: {
+      // In middlewareMode + appType 'custom', Vite has no HTML entry to crawl,
+      // so it defers dependency optimization until the first module request —
+      // discovering new deps then triggers a full-page reload mid-hydration
+      // (which can duplicate SSR'd DOM). Scan the client entry AND every page
+      // component up front so the whole client dependency graph is pre-bundled
+      // at server startup. Page modules are lazily (dynamically) imported by the
+      // router, so without the `pages/**` glob their deps would be discovered on
+      // first navigation and force a reload. Pre-scanning keeps page loads stable.
+      entries: [options.entry ?? LITRO_CLIENT_ENTRY, 'pages/**/*.{ts,tsx,js,jsx,mjs}'],
+    },
+  };
+}
+
+/**
+ * Pre-warms the client entry so Vite finishes optimizing its dependency graph
+ * before the first page is served.
+ *
+ * `optimizeDeps.entries` alone only schedules a scan; the actual dep-bundling
+ * still races the first request. `warmupRequest` runs the entry through the
+ * full transform pipeline — which awaits the dep optimizer — so by the time this
+ * resolves the optimized deps are ready and no mid-load full-reload (that can
+ * duplicate SSR'd DOM during hydration) is emitted to the first client.
+ *
+ * Best-effort: warmup failures never block the dev server from serving.
+ *
+ * @param server - The Vite dev server created from {@link litroViteDevConfig}.
+ * @param entry  - Root-relative entry URL to warm (default `/app.ts`).
+ */
+export async function warmupLitroViteServer(
+  server: ViteDevServer,
+  entry: string = `/${LITRO_CLIENT_ENTRY}`,
+): Promise<void> {
+  try {
+    await server.warmupRequest(entry);
+  } catch {
+    // Ignore — warmup is a startup optimization, not a correctness requirement.
+  }
+}

--- a/packages/framework/src/runtime/vite-dev.ts
+++ b/packages/framework/src/runtime/vite-dev.ts
@@ -64,6 +64,18 @@ export interface LitroViteDevOptions {
  * @see the module docblock for why `base` is forced to `'/'` in dev (issue #97).
  */
 export function litroViteDevConfig(options: LitroViteDevOptions): InlineConfig {
+  // Signal to the page handler (same Nitro worker process) that the live-entry
+  // dev config is in play, so it may reference `/app.ts` instead of the built
+  // `/_litro/app.js`. Apps scaffolded before this helper existed run an older
+  // `server/middleware/vite-dev.ts` whose Vite server keeps the production
+  // `base: '/_litro/'` — under that base a root-relative `/app.ts` graph does
+  // NOT resolve (imports get rewritten to `/_litro/...` URLs that the static
+  // mount swallows). Gating on this flag keeps such apps on their previous
+  // working behavior after a framework upgrade; adopting the new middleware
+  // opts them into the live entry. The vite-dev middleware intercepts every
+  // request before the page handler and builds its Vite server from this
+  // config, so the flag is always set before the first shell is rendered.
+  process.env.LITRO_DEV_LIVE_ENTRY = '1';
   return {
     // DEV base override — see module docblock. `vite.config.ts` keeps
     // `base: '/_litro/'` for the production build; this only affects the dev

--- a/packages/framework/src/vite/actions.ts
+++ b/packages/framework/src/vite/actions.ts
@@ -81,6 +81,10 @@ function assertNoDataExports(code: string, id: string): void {
 
 export function litroActionsPlugin(): Plugin {
   let root = process.cwd();
+  // Absolute path the `@beatzball/litro/actions/server` subpath resolves to in
+  // this project (resolved lazily on first transform, then cached). Used to
+  // stub the module by path — see the transform hook below.
+  let serverSubpathId: string | null | undefined;
 
   return {
     name: 'litro:actions',
@@ -98,6 +102,28 @@ export function litroActionsPlugin(): Plugin {
     },
 
     async transform(code, id) {
+      // Stub `@beatzball/litro/actions/server` when it enters the CLIENT graph.
+      // The resolveId hook above only catches the bare specifier, which Vite
+      // resolves via its own resolver (dep optimizer / `source` export
+      // condition) before this plugin is consulted — so in dev the real module
+      // (importing node:crypto via hash.ts) would otherwise be served as live
+      // source and throw in the browser. Match it here by its resolved path,
+      // where the transform pipeline reliably runs.
+      // `this.resolve` only exists when running under a real Rollup/Vite
+      // plugin context (unit tests invoke this hook directly without one);
+      // without it we cannot map the subpath to a path, so skip the check.
+      if (serverSubpathId === undefined) {
+        if (typeof this.resolve === 'function') {
+          const resolved = await this.resolve(SERVER_SUBPATH, undefined, { skipSelf: true });
+          serverSubpathId = resolved?.id ?? null;
+        } else {
+          serverSubpathId = null;
+        }
+      }
+      if (serverSubpathId && id.split('?', 1)[0] === serverSubpathId.split('?', 1)[0]) {
+        return { code: SERVER_SUBPATH_STUB, map: null };
+      }
+
       if (!SERVER_MODULE_RE.test(id)) return null;
       // Mirror the Nitro scanner's exclusion: third-party *.server.* files in
       // node_modules are never registered server-side, so stubbing them would

--- a/packages/litro-router/src/__tests__/index.test.ts
+++ b/packages/litro-router/src/__tests__/index.test.ts
@@ -224,6 +224,28 @@ describe('LitroRouter — setRoutes and resolve', () => {
     expect(outlet.firstElementChild?.tagName.toLowerCase()).toBe('rr-fresh');
   });
 
+  it('marks the outlet data-litro-settled only after the atomic swap completes', async () => {
+    // Until the swap, the visible content on an initial load is the SSR'd
+    // shell whose event handlers are not wired — the attribute is the
+    // router's observable "current page element is live" signal, polled by
+    // consumers (including e2e tests) before interacting with the page.
+    history.replaceState(null, '', '/');
+    const ssrShell = document.createElement('span');
+    outlet.appendChild(ssrShell);
+    if (!customElements.get('rr-settle')) {
+      customElements.define('rr-settle', class extends HTMLElement {});
+    }
+    expect(outlet.hasAttribute('data-litro-settled')).toBe(false);
+    router.setRoutes([{ path: '/', component: 'rr-settle' }]);
+    // Synchronously after setRoutes the swap is still pending (updateComplete
+    // + rAF have not run) — the marker must not be set yet.
+    expect(outlet.hasAttribute('data-litro-settled')).toBe(false);
+    await new Promise(r => setTimeout(r, 50));
+    expect(outlet.hasAttribute('data-litro-settled')).toBe(true);
+    // And it is set by the same pass that removed the stale SSR content.
+    expect(outlet.querySelector('span')).toBeNull();
+  });
+
   it('runs action() before mounting the component', async () => {
     history.replaceState(null, '', '/');
     const order: string[] = [];

--- a/packages/litro-router/src/index.ts
+++ b/packages/litro-router/src/index.ts
@@ -271,6 +271,16 @@ export class LitroRouter {
       }
       el.removeAttribute('hidden');
 
+      // Mark the outlet once the swap has completed. Until this point the
+      // visible content on an initial load is the SSR'd shell, whose event
+      // handlers are not wired (this router swaps in a client-rendered element
+      // rather than hydrating events onto the SSR DOM) — so interactions can
+      // land on a dead element. The attribute is the router's observable
+      // "current page element is live" signal: it lives on the persistent
+      // outlet (not the page element), so consumers — including e2e tests —
+      // can poll for it without racing a one-shot event.
+      this.outlet.setAttribute('data-litro-settled', '');
+
       // Focus the outlet so keyboard users start at the top of the new page.
       this.outlet.focus({ preventScroll: true });
 

--- a/playground-11ty/server/middleware/vite-dev.ts
+++ b/playground-11ty/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-11ty/server/middleware/vite-dev.ts
+++ b/playground-11ty/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground-elena/server/middleware/vite-dev.ts
+++ b/playground-elena/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-elena/server/middleware/vite-dev.ts
+++ b/playground-elena/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,26 +42,17 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground-fast/server/middleware/vite-dev.ts
+++ b/playground-fast/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-fast/server/middleware/vite-dev.ts
+++ b/playground-fast/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,26 +42,17 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground-starlight-elena/server/middleware/vite-dev.ts
+++ b/playground-starlight-elena/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-starlight-elena/server/middleware/vite-dev.ts
+++ b/playground-starlight-elena/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground-starlight-fast/server/middleware/vite-dev.ts
+++ b/playground-starlight-fast/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-starlight-fast/server/middleware/vite-dev.ts
+++ b/playground-starlight-fast/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground-starlight/server/middleware/vite-dev.ts
+++ b/playground-starlight/server/middleware/vite-dev.ts
@@ -24,7 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
-import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -54,7 +54,14 @@ export default defineEventHandler(async (event) => {
         // from the app directory.
         createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;

--- a/playground-starlight/server/middleware/vite-dev.ts
+++ b/playground-starlight/server/middleware/vite-dev.ts
@@ -1,25 +1,58 @@
+/**
+ * Vite dev middleware
+ *
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
+ *
+ * Why server middleware instead of devHandlers:
+ *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
+ *   the DevServer constructor, before build:before ever fires. Pushing to
+ *   devHandlers from any config hook is too late. Server middleware files
+ *   (server/middleware/) are bundled into the worker and registered in h3App
+ *   BEFORE the router, giving Vite first access to every request.
+ *
+ * Bundle size:
+ *   Nitro's Rollup replaces process.dev with false in production builds.
+ *   DCE then eliminates the entire handler body — including the dynamic
+ *   import('vite') call — so vite is NOT copied to the production output.
+ */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig } from '@beatzball/litro/runtime/vite-dev.js';
 
+// Singleton: initialise once on the first dev request, then reuse.
+// A Promise is cached so concurrent first requests queue on the same
+// initialisation rather than racing to create multiple Vite servers.
 let viteHandlerPromise: Promise<ReturnType<typeof fromNodeMiddleware>> | null = null;
 
 export default defineEventHandler(async (event) => {
+  // process.dev is a Rollup-defined constant: true in dev, false in prod.
+  // In production, Rollup constant-folds this to `if (true) return;` and
+  // DCE removes everything below — including import('vite') — so vite is
+  // never included in the production bundle.
+  // At runtime in dev, NITRO_DEV_WORKER_ID is a belt-and-suspenders guard.
   if (!process.dev || !process.env.NITRO_DEV_WORKER_ID) return;
 
   if (!viteHandlerPromise) {
+    // Extract Nitro's underlying HTTP server from the first request's socket.
+    // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          appType: 'custom',
-          root: process.cwd(),
-        }),
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
       .then((server) => fromNodeMiddleware(server.middlewares));
   }

--- a/playground/server/middleware/vite-dev.ts
+++ b/playground/server/middleware/vite-dev.ts
@@ -1,18 +1,22 @@
 /**
  * Vite dev middleware
  *
- * Intercepts ALL requests before Nitro's route handlers so that Vite can
- * serve JS/TS modules (including /_litro/app.ts and page chunks) with the correct
- * MIME type. Vite calls next() for requests it does not own (HTML pages,
- * API routes), which Nitro's router then handles normally.
+ * Spins up an in-process Vite dev server (middlewareMode) and hands it every
+ * request so Vite can serve the live client entry and JS/TS module graph with
+ * the correct MIME type. Vite calls next() for requests it does not own (HTML
+ * pages, API routes), which Nitro's router then handles normally.
+ *
+ * The Vite config comes from litroViteDevConfig() in @beatzball/litro, which
+ * forces `base: '/'` in dev so module URLs stay clear of Nitro's `/_litro/`
+ * static mount (that mount would otherwise serve a stale pre-built bundle —
+ * issue #97). See that helper's docblock for the full rationale.
  *
  * Why server middleware instead of devHandlers:
  *   Nitro's DevServer.createApp() reads nitro.options.devHandlers ONCE in
  *   the DevServer constructor, before build:before ever fires. Pushing to
  *   devHandlers from any config hook is too late. Server middleware files
  *   (server/middleware/) are bundled into the worker and registered in h3App
- *   BEFORE the router (createNitroApp() calls h3App.use(middleware) then
- *   h3App.use(router.handler)), giving Vite first access to every request.
+ *   BEFORE the router, giving Vite first access to every request.
  *
  * Bundle size:
  *   Nitro's Rollup replaces process.dev with false in production builds.
@@ -20,6 +24,7 @@
  *   import('vite') call — so vite is NOT copied to the production output.
  */
 import { defineEventHandler, fromNodeMiddleware } from 'h3';
+import { litroViteDevConfig, warmupLitroViteServer } from '@beatzball/litro/runtime/vite-dev.js';
 
 // Singleton: initialise once on the first dev request, then reuse.
 // A Promise is cached so concurrent first requests queue on the same
@@ -37,28 +42,26 @@ export default defineEventHandler(async (event) => {
   if (!viteHandlerPromise) {
     // Extract Nitro's underlying HTTP server from the first request's socket.
     // Passing it as hmr.server tells Vite to attach its WebSocket upgrade
-    // handler to the *existing* server (port 3030) instead of opening a new
-    // standalone WebSocket server that would conflict with Nitro's port.
+    // handler to the *existing* server instead of opening a new standalone
+    // WebSocket server that would conflict with Nitro's port.
     const httpServer = (event.node.req.socket as import('node:net').Socket & {
       server?: import('node:http').Server;
     }).server;
 
     viteHandlerPromise = import('vite')
       .then(({ createServer }) =>
-        createServer({
-          // middlewareMode: Vite does NOT bind its own HTTP server.
-          server: {
-            middlewareMode: true,
-            hmr: httpServer ? { server: httpServer } : true,
-          },
-          // 'custom' appType: suppress Vite's SPA HTML fallback.
-          appType: 'custom',
-          // process.cwd() is the project root because Nitro is always
-          // started from the playground directory.
-          root: process.cwd(),
-        })
+        // process.cwd() is the project root because Nitro is always started
+        // from the app directory.
+        createServer(litroViteDevConfig({ root: process.cwd(), hmrServer: httpServer })),
       )
-      .then((server) => fromNodeMiddleware(server.middlewares));
+      .then(async (server) => {
+        // Pre-warm the client entry so Vite finishes optimizing its dependency
+        // graph before the first page is served. Without this, dep discovery
+        // happens mid-load and triggers a full-page reload that can duplicate
+        // the SSR'd DOM during hydration.
+        await warmupLitroViteServer(server);
+        return fromNodeMiddleware(server.middlewares);
+      });
   }
 
   const viteHandler = await viteHandlerPromise;


### PR DESCRIPTION
Closes #97. Supersedes the approach in draft PR 104 (which referenced `app.ts` without making Vite own the URL — the dev-mode E2E hang that parked it is analysed in that PR's comments).

## The bug

`litro dev` served a **stale pre-built bundle**: the shell referenced `/_litro/app.js`, Nitro's `publicAssets` mount owned `/_litro/*` ahead of the Vite dev middleware, and the CLI's one-time `vite build` gave that mount a bundle that never updated. Source edits silently stopped reflecting until `dist/` was deleted.

## The fix

Dev now references the root-relative source entry (`/app.ts`), and a new central helper — `litroViteDevConfig()` in `@beatzball/litro/runtime/vite-dev.js`, adopted by every app's `server/middleware/vite-dev.ts` and the create-litro recipe templates — forces `base: '/'` for the dev Vite server so the live module graph stays clear of the static mount. Production is unchanged (`/_litro/app.js` from `dist/client/`, `vite.config.ts` keeps `base: '/_litro/'`).

## Latent issues that live-source dev surfaced (all fixed here)

1. **`actions/server` stub never fired in dev** — Vite resolves the bare specifier via the `source` export condition before the plugin's `resolveId`, so real `node:crypto` code reached the browser graph. The transform hook now stubs the module by resolved path (covered by the existing externalization e2e).
2. **Forced full reloads from Nitro's own type generation** — Vite treats any tracked-tsconfig change as "clear cache + force full-reload"; Nitro rewrites `.nitro/types/tsconfig.json` on every dev reload (and when a second Nitro process shares the app dir, as the agent-resume e2e does). The dev watcher now ignores `.nitro/` and `.litro/`.
3. **Mid-load dep-optimizer reloads** — in `middlewareMode` + `appType: 'custom'` there is no HTML entry to crawl, so optimization deferred to first request and late-discovered deps forced full reloads. `optimizeDeps.entries` + `server.warmup` pre-scan the entry and every page module at startup.
4. **`process is not defined` in docs-ui** — `route-meta.ts`/`seo.ts` read `process.env` at module top level; production tree-shaking removed the dead code, live source executed it in the browser and killed the whole docs-ssr client graph. Guarded via `globalThis.process?.`.

## litro-router: `data-litro-settled` (minor)

Investigating residual e2e flake exposed a real observability gap: after the initial load, the visible content is the SSR'd shell **whose event handlers are not wired** (this router swaps in a client-rendered element rather than hydrating events), and nothing distinguishable marked the moment the live element took over — element-count/visibility checks pass both before the client element mounts and after the swap. The router now sets `data-litro-settled` on the outlet when the atomic swap completes. E2e specs that interact with a freshly-loaded page wait for `litro-outlet[data-litro-settled]`; the same signal is available to apps (analytics, deferred interactions).

## Verification

- New regression suite `e2e/playground/dev-live-entry.spec.ts`: dev shell references the source entry; entry serves as live Vite source (not the built bundle); transitive module graph resolves; hydration and SPA navigation work from it. A sentinel-edit check (edit `app.ts`, re-fetch, see the edit with no rebuild) was verified manually during development.
- Framework unit tests 413/413; litro-router 29/29 (including a new test asserting the marker is set only after the swap).
- Playground e2e 37/37 across repeated **true-cold** runs (Vite dep cache, `.nitro`, `.litro` all wiped) — the reproduction conditions for every failure mode found along the way.
- Full 9-project e2e suite green across repeated local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)