### PR TITLE
feat(framework): per-page bodyScript hook (synchronous end-of-body script)

### DIFF
--- a/.changeset/body-script-hook.md
+++ b/.changeset/body-script-hook.md
@@ -1,0 +1,5 @@
+---
+"@beatzball/litro": minor
+---
+
+Add a per-page `bodyScript` hook: pages can return an optional `bodyScript` string (raw HTML, typically a synchronous `<script>`) from `definePageData()`, and the shell emits it at end-of-body immediately before the app-bundle script. This gives pages a synchronous, pre-hydration slot — symmetric with `seoHead` for `<head>` — for filling server-unknowable values (e.g. times in the user's local timezone) on first paint. Like `seoHead`/`seoTitle`, the field is stripped from the serialized `__litro_data__` client JSON. Pages that don't use it are byte-for-byte unchanged.

--- a/packages/docs-content/content/docs/core-concepts/data-fetching.md
+++ b/packages/docs-content/content/docs/core-concepts/data-fetching.md
@@ -44,6 +44,28 @@ export class BlogSlugPage extends LitroPage {
 }
 ```
 
+## Reserved Fields
+
+Three optional string fields in the `definePageData` result are extracted server-side into the HTML shell and stripped from the serialized client JSON:
+
+- **`seoTitle`** — the document `<title>`.
+- **`seoHead`** — raw HTML injected into `<head>` (meta tags, Open Graph, JSON-LD).
+- **`bodyScript`** — raw HTML emitted at end-of-body, immediately before the app-bundle `<script>`. A synchronous classic script here runs after the page's (declarative shadow DOM) content has been parsed but before the module bundle executes — a pre-hydration slot for filling values the server can't know (for example, times in the user's local timezone) on first paint.
+
+```ts
+export const pageData = definePageData(async () => ({
+  seoTitle: 'Now - My App',
+  bodyScript: `<script>(function(){
+    var el = document.querySelector('page-now');
+    if (!el || !el.shadowRoot) return;
+    var slot = el.shadowRoot.querySelector('.local-time');
+    if (slot) slot.textContent = new Date().toLocaleTimeString();
+  })();</script>`,
+}));
+```
+
+`bodyScript` runs only on full document loads — on client-side (SPA) navigations it does not re-run, so the component's own rendering must still produce the final values (the pre-paint script only makes the first paint correct sooner). All three fields are author-controlled raw HTML: Litro applies no escaping, so never build them from untrusted input.
+
 ## Error Handling
 
 Throw an H3 error to return a 404 or other error status:

--- a/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
+++ b/packages/framework/src/runtime/__tests__/create-page-handler.test.ts
@@ -258,6 +258,68 @@ describe('createPageHandler — seoTitle from pageData', () => {
 });
 
 // ---------------------------------------------------------------------------
+// bodyScript injection
+// ---------------------------------------------------------------------------
+
+describe('createPageHandler — bodyScript from pageData', () => {
+  beforeEach(() => {
+    vi.mocked(buildShell).mockClear();
+  });
+
+  const BODY_SCRIPT = '<script>window.__prePaint = true;</script>';
+
+  it('passes bodyScript string to buildShell as bodyScript option', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ bodyScript: BODY_SCRIPT })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.bodyScript).toBe(BODY_SCRIPT);
+  });
+
+  it('strips bodyScript from the serialized client JSON, keeping other fields', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: {
+        pageData: makePageData(async () => ({ bodyScript: BODY_SCRIPT, message: 'hello' })),
+      },
+    });
+
+    await callHandler(handler);
+
+    const json = lastBuildShellOpts()?.serverDataJson;
+    expect(json).toBeDefined();
+    expect(JSON.parse(json as string)).toEqual({ message: 'hello' });
+  });
+
+  it('ignores non-string bodyScript values (number, object, null)', async () => {
+    for (const badValue of [42, { js: 'x' }, null]) {
+      const handler = createPageHandler({
+        route: makeRoute(),
+        pageModule: { pageData: makePageData(async () => ({ bodyScript: badValue })) },
+      });
+
+      await callHandler(handler);
+
+      expect(lastBuildShellOpts()?.bodyScript).toBeUndefined();
+    }
+  });
+
+  it('omits bodyScript option when pageData does not return one', async () => {
+    const handler = createPageHandler({
+      route: makeRoute(),
+      pageModule: { pageData: makePageData(async () => ({ message: 'hello' })) },
+    });
+
+    await callHandler(handler);
+
+    expect(lastBuildShellOpts()?.bodyScript).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // pageData fetch failure
 // ---------------------------------------------------------------------------
 

--- a/packages/framework/src/runtime/__tests__/shell.test.ts
+++ b/packages/framework/src/runtime/__tests__/shell.test.ts
@@ -230,6 +230,40 @@ describe('buildShell — foot: app bundle', () => {
 });
 
 // ---------------------------------------------------------------------------
+// foot — bodyScript (per-page synchronous end-of-body script)
+// ---------------------------------------------------------------------------
+
+describe('buildShell — foot: bodyScript', () => {
+  const BODY_SCRIPT = '<script>window.__prePaint = true;</script>';
+
+  it('emits bodyScript in the foot when provided', () => {
+    const { foot } = buildDefault('page-home', { bodyScript: BODY_SCRIPT });
+    expect(foot).toContain(BODY_SCRIPT);
+  });
+
+  it('emits bodyScript BEFORE the app-bundle script tag', () => {
+    const { foot } = buildDefault('page-home', { bodyScript: BODY_SCRIPT });
+    const bodyScriptIdx = foot.indexOf(BODY_SCRIPT);
+    const appScriptIdx = foot.indexOf('<script type="module" src="/_litro/app.js">');
+    expect(bodyScriptIdx).toBeGreaterThan(-1);
+    expect(appScriptIdx).toBeGreaterThan(-1);
+    expect(bodyScriptIdx).toBeLessThan(appScriptIdx);
+  });
+
+  it('emits bodyScript exactly once', () => {
+    const { head, foot } = buildDefault('page-home', { bodyScript: BODY_SCRIPT });
+    expect(head).not.toContain(BODY_SCRIPT);
+    expect(foot.split(BODY_SCRIPT).length - 1).toBe(1);
+  });
+
+  it('foot is byte-for-byte unchanged when bodyScript is omitted', () => {
+    const { foot: withUndefined } = buildDefault('page-home', { bodyScript: undefined });
+    const { foot: withoutOption } = buildDefault('page-home');
+    expect(withUndefined).toBe(withoutOption);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // foot — document closing
 // ---------------------------------------------------------------------------
 

--- a/packages/framework/src/runtime/create-page-handler.ts
+++ b/packages/framework/src/runtime/create-page-handler.ts
@@ -149,6 +149,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
       let serverDataJson: string | undefined;
       let dynamicHead = '';
       let dynamicTitle: string | undefined;
+      let dynamicBodyScript = '';
       const pageDataExport = mod.pageData as PageDataFetcher<unknown> | undefined;
       if (pageDataExport?.__litroPageData === true) {
         try {
@@ -167,10 +168,14 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
           const d = data as Record<string, unknown>;
           if (typeof d.seoHead === 'string') dynamicHead = d.seoHead;
           if (typeof d.seoTitle === 'string') dynamicTitle = d.seoTitle;
-          // Strip seoHead and seoTitle before serializing to avoid the </script>
-          // injection issue described above. The client doesn't need these fields
-          // — they were only needed server-side to build the <head>.
-          const { seoHead: _h, seoTitle: _t, ...clientData } = d;
+          // Per-page synchronous end-of-body script (emitted before the app
+          // bundle) — the body-slot counterpart to seoHead.
+          if (typeof d.bodyScript === 'string') dynamicBodyScript = d.bodyScript;
+          // Strip seoHead, seoTitle and bodyScript before serializing to avoid
+          // the </script> injection issue described above. The client doesn't
+          // need these fields — they were only needed server-side to build the
+          // HTML shell.
+          const { seoHead: _h, seoTitle: _t, bodyScript: _b, ...clientData } = d;
           serverDataJson = JSON.stringify(clientData);
         } catch (dataErr) {
           // Data fetch failure is non-fatal: log a warning and render without
@@ -207,6 +212,7 @@ export function createPageHandler(options: PageHandlerOptions): EventHandler {
         contentDevPolling: isDev && process.env.LITRO_HAS_CONTENT === 'true',
         skipLinks,
         includeDSDPolyfill: adapter.needsDSDPolyfill,
+        bodyScript: dynamicBodyScript || undefined,
       });
 
       // Delegate rendering to the framework adapter. The adapter returns an

--- a/packages/framework/src/runtime/page-data.ts
+++ b/packages/framework/src/runtime/page-data.ts
@@ -56,6 +56,15 @@ export interface PageDataFetcher<T> {
  *
  * On the client, read the data with `getServerData<T>()`.
  *
+ * Reserved fields — extracted server-side into the HTML shell and stripped
+ * from the serialized client JSON:
+ *   - `seoTitle` (string): document <title>.
+ *   - `seoHead` (string): raw HTML injected into <head> (meta tags, JSON-LD).
+ *   - `bodyScript` (string): raw HTML emitted at end-of-body immediately
+ *     before the app-bundle script — a synchronous pre-hydration slot for
+ *     filling server-unknowable values (e.g. the user's local time) on first
+ *     paint. Does not run on client-side (SPA) navigations.
+ *
  * @param fetcher - An async function that receives the H3 event and returns
  *                  the data object for this page. Must return a
  *                  JSON-serializable value.

--- a/packages/framework/src/runtime/shell.ts
+++ b/packages/framework/src/runtime/shell.ts
@@ -144,6 +144,20 @@ export interface ShellOptions {
    * @default true
    */
   includeDSDPolyfill?: boolean;
+  /**
+   * Raw HTML emitted at end-of-body, immediately BEFORE the app-bundle
+   * <script type="module"> tag — typically a synchronous classic
+   * `<script>…</script>`.
+   *
+   * A synchronous script here runs after the page element and its (declarative
+   * shadow DOM) content have been parsed but before the deferred module bundle
+   * executes, giving pages a pre-hydration slot to fill server-unknowable
+   * values (e.g. times in the user's local timezone) on first paint.
+   *
+   * Author-controlled raw HTML with the same trust model as `head` — no
+   * framework escaping is applied.
+   */
+  bodyScript?: string;
 }
 
 /**
@@ -217,8 +231,13 @@ export function buildShell(
 <litro-outlet id="_litro_main" tabindex="-1" style="outline:none">
 `;
 
-  const foot = `</litro-outlet>
+  // Per-page synchronous body script. Emitted BEFORE the app-bundle script so
+  // it runs pre-hydration — after the page's DSD content is parsed, before the
+  // deferred module bundle executes.
+  const bodyScript = options?.bodyScript ?? '';
 
+  const foot = `</litro-outlet>
+${bodyScript}
   <!--
     App bundle — framework adapter bootstrap + page components.
     /_litro/ maps to dist/client/ (Vite output) via publicAssets in nitro.config.ts.


### PR DESCRIPTION
## Summary

Adds an optional `bodyScript` field to a page's `definePageData(...)` result. When present, the shell emits it as raw HTML at **end-of-body, immediately before the app-bundle `<script>`** — a synchronous, pre-hydration execution slot, symmetric with the existing `seoHead` (which injects into `<head>`).

## Motivation

Some content depends on values the server cannot know at SSR/SSG time — most notably the user's timezone / local "now". Today the options are: fill after hydration (waits for the app bundle — visible flash), or a `<head>` script (runs before the page element exists, so it can't touch the DSD content synchronously). A synchronous script at end-of-body runs *after* the page element + its shadow root are parsed but *before* the deferred module bundle — so it can fill server-unknowable values on **first paint**.

**Validated downstream:** forallti.me shipped this exact change as a `pnpm patch` (`/sleepy-time/now` renders local sleep-cycle wake times correctly on first paint even with `/_litro/app.js` blocked entirely, proven by e2e and verified live in production). This PR is the upstream version; the built `dist/runtime/{shell,create-page-handler}.js` output matches the validated patch byte-for-byte in the changed regions.

## Changes

- `src/runtime/shell.ts` — `ShellOptions.bodyScript?: string`; `buildShell()` emits it in the foot immediately before the app-bundle script. Empty/absent → foot is byte-for-byte unchanged.
- `src/runtime/create-page-handler.ts` — extracts a string `bodyScript` from the pageData result, strips it from the serialized `__litro_data__` client JSON (mirroring `seoHead`/`seoTitle`, avoiding the `</script>` injection issue), and passes it to `buildShell`.
- `src/runtime/page-data.ts` — documents the reserved fields (`seoTitle`, `seoHead`, `bodyScript`) on `definePageData`.
- `docs/core-concepts/data-fetching.md` — new "Reserved Fields" section (these were previously undocumented) with a `bodyScript` example, the SPA-navigation caveat, and the trust model (raw HTML, no framework escaping — never build from untrusted input).
- Changeset: `@beatzball/litro` **minor**.

## Tests

- `shell.test.ts` (+4): emitted in foot; emitted **before** the app-bundle script; emitted exactly once (not in head); foot byte-for-byte unchanged when omitted.
- `create-page-handler.test.ts` (+4): passed to `buildShell` as the `bodyScript` option; stripped from the serialized client JSON (other fields kept); non-string values ignored; option omitted when absent.
- Framework suite: **421/421** passing; `tsc` build clean.

## Notes

- **Streaming:** part of `shell.foot`, written after the SSR stream — no streaming changes.
- **SPA navigation:** the script runs only on full document loads; the component's own rendering must still produce the final values (the docs call this out).
- **No conflict with #107:** touches different hunks of `create-page-handler.ts` (data extraction + `buildShell` options vs. `appScriptUrl` computation); either can merge first.
- Once released, forallti.me bumps the litro dep and drops its local `patches/@beatzball__litro.patch` — the page-level usage stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)