### PR TITLE
docs: add the litro-agent package page and document v0.1

### DIFF
--- a/docs-ssr/server/starlight.config.js
+++ b/docs-ssr/server/starlight.config.js
@@ -69,6 +69,7 @@ export const siteConfig = {
         { label: '@beatzball/litro',        slug: 'packages/litro' },
         { label: '@beatzball/litro-router', slug: 'packages/litro-router' },
         { label: '@beatzball/create-litro', slug: 'packages/create-litro' },
+        { label: '@beatzball/litro-agent',  slug: 'packages/litro-agent' },
       ],
     },
     {

--- a/docs/server/starlight.config.js
+++ b/docs/server/starlight.config.js
@@ -69,6 +69,7 @@ export const siteConfig = {
         { label: '@beatzball/litro',        slug: 'packages/litro' },
         { label: '@beatzball/litro-router', slug: 'packages/litro-router' },
         { label: '@beatzball/create-litro', slug: 'packages/create-litro' },
+        { label: '@beatzball/litro-agent',  slug: 'packages/litro-agent' },
       ],
     },
     {

--- a/packages/docs-content/content/docs/agents.md
+++ b/packages/docs-content/content/docs/agents.md
@@ -75,7 +75,7 @@ The `ui()` renderer is selected by the `LITRO_ADAPTER` environment variable — 
 
 ### agents/_config.ts (optional)
 
-Runtime config is optional. The default session store is the JSONL file store, so an app that wants the default writes no config file at all. To configure it explicitly (or swap in a custom `SessionStore`):
+Runtime config is optional and takes two keys: `sessions` (see [Sessions and durability](#sessions-and-durability)) and `telemetry` (see [Telemetry](#telemetry)). The default session store is the JSONL file store and telemetry is off, so an app that wants the defaults writes no config file at all. To configure the store explicitly (or swap in a custom `SessionStore`):
 
 ```ts
 import { defineAgentConfig } from '@beatzball/litro-agent';
@@ -285,7 +285,77 @@ A session is an append-only JSONL log at `.litro/sessions/<id>.jsonl`, one `Sess
 - **Turns survive client disconnect.** A POST client that drops mid-turn does not abort the turn — the runtime keeps appending to the store and running to completion. The persisted log stays complete.
 - **Reconnect from a seq.** A fresh GET (or the client's `resume`) replays the stored log from `?from=<seq>` and, if a turn is still in flight, live-tails it until `turn-end`.
 
-The per-session turn lock is **in-process** — one Node process. A concurrent POST for the same agent/session returns 409. This is the documented v0 limitation: multi-instance deployments need a store-level lease, which lands with the alternate session stores (see [Limitations](#limitations)).
+A concurrent POST for the same agent/session returns 409. **How far that guarantee reaches depends on the store you pick:**
+
+- **`fileSessionStore` (the default)** — the turn lock is in-process, one Node process. Two instances behind a load balancer would each pass their own local check and run concurrent turns on one session.
+- **`sqliteSessionStore`** — adds a store-level lease, so the lock holds across instances. See [Multi-instance sessions](#multi-instance-sessions).
+
+### Multi-instance sessions
+
+`sqliteSessionStore` is an alternative to the default JSONL store, built for deployments running more than one instance against shared storage.
+
+```ts
+// agents/_config.ts
+import { defineAgentConfig } from '@beatzball/litro-agent';
+import { sqliteSessionStore } from '@beatzball/litro-agent/sessions/sqlite';
+
+export default defineAgentConfig({
+  sessions: sqliteSessionStore({ path: '.litro/sessions.db' }),
+});
+```
+
+It creates its parent directory if it does not exist, so the path above works on a fresh clone even though `.litro/` is gitignored.
+
+**Requires Node 22.5+**, since `node:sqlite` does not exist before that. It lives behind its own subpath and is never in the package's default import graph, so Node 20 users are unaffected and keep the JSONL store. Node prints an `ExperimentalWarning` for `node:sqlite`; that is Node's notice, not this package's.
+
+What it gives you over the default:
+
+- **Crash-safe sequence numbers.** `seq` is computed as `MAX(seq)+1` inside the same transaction as the insert, so there is no in-memory counter to lose on restart and no way for two writers to mint the same seq.
+- **A cross-instance turn lease**, renewed on a heartbeat for the life of a turn and released in a `finally`.
+- **A live tail that still works across instances.** A GET reconnecting while the turn runs on a *different* instance cannot reach that instance's in-process broadcast, so it polls the store until the turn ends.
+
+**A lost lease does not abort the turn.** If an instance stalls past the lease TTL and another takes the lease over, the first stops renewing but runs its turn to completion. Aborting mid-turn would break the append-before-wire rule above, which is what makes the persisted log trustworthy in the first place.
+
+One deliberate trade: `node:sqlite`'s `DatabaseSync` is synchronous, so each append briefly blocks the event loop — the same call the JSONL store makes with an fsync per append. An async driver is a later addition.
+
+## Telemetry
+
+Agent turns can emit OpenTelemetry spans following the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). **Telemetry is off unless you supply a tracer**, and when it is off every hook short-circuits to a shared no-op — no allocation, no attribute building.
+
+```ts
+// agents/_config.ts
+import * as otel from '@opentelemetry/api';
+import { defineAgentConfig } from '@beatzball/litro-agent';
+import { otelTracer } from '@beatzball/litro-agent/telemetry';
+
+export default defineAgentConfig({
+  telemetry: { tracer: otelTracer(otel) },
+});
+```
+
+**Your app brings OpenTelemetry; this package does not depend on it.** You pass the `@opentelemetry/api` namespace in rather than the package importing it. That guarantees the runtime uses the same api singleton your SDK registered against — a duplicated copy is the classic reason spans silently vanish — and it means no peer dependency to resolve and no dynamic import in a server bundle. Any object matching the exported `AgentTracer` interface works, so a custom tracer needs no OpenTelemetry at all.
+
+Three spans per turn:
+
+| Span | When | Notable attributes |
+|---|---|---|
+| `invoke_agent <agent>` | once per turn | `gen_ai.agent.name`, `gen_ai.conversation.id` (the session id), `litro.agent.turn.rounds`, summed token usage |
+| `chat <model>` | once per provider round | `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens` / `output_tokens`, `litro.agent.round` |
+| `execute_tool <tool>` | once per tool call | `gen_ai.tool.name`, `gen_ai.tool.call.id`, `litro.agent.tool.ui` |
+
+Tool spans are parented to the **turn**, not to the chat round that dispatched them — a tool run is a sibling of the model call, not a child of it.
+
+### Content capture
+
+Prompt and completion text is **not** recorded by default, per the semantic conventions' opt-in stance on content capture:
+
+```ts
+telemetry: { tracer: otelTracer(otel), captureContent: true, maxContentLength: 8192 }
+```
+
+**Even with capture on, a UI tool's rendered `html` is never recorded** — only its `data`. That is the same rule that keeps html out of the model's view, applied to traces: the html is stripped at the top level, when nested, and in the tool result fed back into the next round's captured messages.
+
+Errors carry the semantic-convention `error.type` and a message, never a stack.
 
 ## Client
 
@@ -325,15 +395,13 @@ Any gate failure returns 403. Beyond the gates:
 
 ## Limitations
 
-v0 is the RFC's vertical slice. The following are specified but deferred (in priority order, mirroring the design spec):
+The following are specified but deferred (in priority order, mirroring the design spec). OpenTelemetry spans and the `node:sqlite` store were on this list and shipped in 0.2.0 — see [Telemetry](#telemetry) and [Multi-instance sessions](#multi-instance-sessions).
 
-1. **OpenTelemetry** spans (GenAI semantic conventions), configured via `agents/_config.ts`.
-2. **Alternate session stores** (`node:sqlite`, Node 22.5+) — and with them the store-level lease that lifts the single-process turn-lock limitation.
-3. **Skills.** The sharing contract is fully specified (a skill is a standard Agent Skill folder; three scope levels — global `skills/`, shared `agents/_shared/skills/`, local `agents/<name>/skills/` — resolved by skill name with local-first precedence; `defineAgentPreset` bundles; npm/registry distribution; a CEM-backed design-system skillset). v0 ships only the reserved `skills`/`extends` config keys and the `_`-prefix scanner exclusion so the hierarchy lands without a breaking change.
-4. **MCP client** (`agents/<name>/mcp/`).
-5. **Standard-Schema → JSON-Schema conversion depth.** v0 hands providers a permissive object schema and leans on the tool `description` for the contract; deeper conversion is a v0.1 work item.
-6. **Elena `UIResult` renderer** (light-DOM, no hydration).
-7. **Subagents, additional surfaces, scheduled runs, and eval suites.**
-8. **`create-litro` template wiring** — until then, wire agents by hand per [Setup](#setup).
+1. **Skills.** The sharing contract is fully specified (a skill is a standard Agent Skill folder; three scope levels — global `skills/`, shared `agents/_shared/skills/`, local `agents/<name>/skills/` — resolved by skill name with local-first precedence; `defineAgentPreset` bundles; npm/registry distribution; a CEM-backed design-system skillset). v0 ships only the reserved `skills`/`extends` config keys and the `_`-prefix scanner exclusion so the hierarchy lands without a breaking change.
+2. **MCP client** (`agents/<name>/mcp/`).
+3. **Standard-Schema → JSON-Schema conversion depth.** v0 hands providers a permissive object schema and leans on the tool `description` for the contract; deeper conversion is a v0.1 work item.
+4. **Elena `UIResult` renderer** (light-DOM, no hydration).
+5. **Subagents, additional surfaces, scheduled runs, and eval suites.**
+6. **`create-litro` template wiring** — until then, wire agents by hand per [Setup](#setup).
 
 `ui()` throws for any adapter other than `lit` or `fast` in v0.

--- a/packages/docs-ui/src/packages.ts
+++ b/packages/docs-ui/src/packages.ts
@@ -22,6 +22,7 @@ const PACKAGES = [
   { slug: 'litro',        dir: 'framework',    name: '@beatzball/litro' },
   { slug: 'litro-router', dir: 'litro-router', name: '@beatzball/litro-router' },
   { slug: 'create-litro', dir: 'create-litro', name: '@beatzball/create-litro' },
+  { slug: 'litro-agent',  dir: 'litro-agent',  name: '@beatzball/litro-agent' },
 ] as const;
 
 export const ALL_PACKAGE_SLUGS = PACKAGES.map(p => p.slug);

--- a/packages/litro-agent/README.md
+++ b/packages/litro-agent/README.md
@@ -1,0 +1,166 @@
+# litro-agent
+
+Filesystem-first AI agents for [Litro](https://github.com/beatzball/litro), with tools that can return server-rendered components.
+
+- **A directory is an agent** — `agents/<name>/agent.ts` becomes a durable endpoint; files in `tools/` become its tools
+- **Durable by construction** — every event is written to the session log *before* it reaches the HTTP stream, so turns survive a client disconnect and a reconnect can replay from any point
+- **Tools can return UI** — a tool returns both `data` for the model and server-rendered `html` for the page. The model never sees the html
+- **Streaming** — turns stream as NDJSON `SessionEvent`s over a single endpoint
+- **No SDK dependency** — providers are thin adapters this package owns; OpenTelemetry, when used, is passed in by your app rather than depended on
+
+Requires `@beatzball/litro`. Agents are wired into the Litro server by a Nitro plugin, so this package is not usable standalone.
+
+---
+
+## Installation
+
+```bash
+npm install @beatzball/litro-agent
+# or
+pnpm add @beatzball/litro-agent
+```
+
+Wiring an app takes a few edits to `nitro.config.ts`, `package.json`, and `.gitignore`. The [Agents guide](https://litro.dev/docs/agents) walks through them; `create-litro` template wiring is not in yet.
+
+---
+
+## Directory convention
+
+```
+agents/
+  _config.ts            <- optional runtime config (sessions, telemetry)
+  demo/
+    agent.ts            <- default export: defineAgent({ ... })
+    instructions.md     <- system prompt
+    tools/
+      get-weather.ts    <- filename is the tool name
+```
+
+Each agent becomes one endpoint:
+
+```
+POST /__litro/agent/<agent>/<session>    run a turn, stream the events
+GET  /__litro/agent/<agent>/<session>    replay from ?from=<seq>, then live-tail
+```
+
+---
+
+## Defining an agent
+
+```ts
+// agents/demo/agent.ts
+import { defineAgent } from '@beatzball/litro-agent';
+import { anthropic } from '@beatzball/litro-agent/providers/anthropic';
+
+export default defineAgent({
+  model: anthropic({ model: 'claude-sonnet-5' }),
+  instructions: './instructions.md',
+});
+```
+
+Tools declare an input schema using any [Standard Schema](https://standardschema.dev) validator. The schema is required — it is what the model is handed and what the input is validated against before `execute` runs.
+
+```ts
+// agents/demo/tools/get-weather.ts
+import { defineTool } from '@beatzball/litro-agent';
+
+export default defineTool({
+  description: 'Look up the current weather for a city',
+  input: citySchema,
+  async execute({ city }) {
+    return { city, tempC: 21, summary: 'sunny' };
+  },
+});
+```
+
+---
+
+## UI tools
+
+A tool can return a rendered component instead of plain data. `ui()` server-renders it and returns both halves:
+
+```ts
+import { defineTool } from '@beatzball/litro-agent';
+import { ui } from '@beatzball/litro-agent/ui';
+import { html } from 'lit';
+import { WeatherCard } from '../../../components/weather-card.js';
+
+void WeatherCard; // named import + void: bare side-effect imports get tree-shaken
+
+export default defineTool({
+  description: 'Show the weather as a card',
+  input: citySchema,
+  async execute({ city }) {
+    const tempC = 21;
+    const summary = 'sunny';
+    return ui(html`<weather-card .city=${city} .tempC=${tempC}></weather-card>`, {
+      data: { city, tempC, summary },
+    });
+  },
+});
+```
+
+**The model observes `data`; the `html` streams to the page and is never shown to the model.** That separation is enforced in the runtime — for direct returns, generator returns, and nested results alike — and it holds in traces too.
+
+The renderer follows `LITRO_ADAPTER`: Lit (Declarative Shadow DOM via `@lit-labs/ssr`) or FAST. The component must be registered server-side. Elena is not supported yet.
+
+---
+
+## Providers
+
+| Import | Use |
+|---|---|
+| `@beatzball/litro-agent/providers/anthropic` | Anthropic models |
+| `@beatzball/litro-agent/providers/openai-compatible` | OpenAI, or any compatible endpoint — Ollama, LM Studio, vLLM |
+| `@beatzball/litro-agent/providers/scripted` | Deterministic canned responses for tests and demos |
+
+API keys are read from the environment only. `openaiCompatible` takes an optional `system` name so a local endpoint is not mislabelled as OpenAI in telemetry.
+
+---
+
+## Sessions
+
+A session is an append-only log. The default store writes JSONL under `.litro/sessions/`; `.litro/` holds conversation data and must be gitignored.
+
+`sqliteSessionStore` (from `@beatzball/litro-agent/sessions/sqlite`) is the alternative for deployments running more than one instance against shared storage. It adds crash-safe sequence numbers and a cross-instance turn lease. It requires **Node 22.5+**, which is why it sits behind its own subpath — Node 20 users are unaffected and keep the JSONL store.
+
+---
+
+## Telemetry
+
+Agent turns can emit OpenTelemetry spans following the GenAI semantic conventions: `invoke_agent` per turn, `chat` per provider round, `execute_tool` per tool call.
+
+**Off unless you supply a tracer**, and your app brings OpenTelemetry rather than this package depending on it:
+
+```ts
+// agents/_config.ts
+import * as otel from '@opentelemetry/api';
+import { defineAgentConfig } from '@beatzball/litro-agent';
+import { otelTracer } from '@beatzball/litro-agent/telemetry';
+
+export default defineAgentConfig({
+  telemetry: { tracer: otelTracer(otel) },
+});
+```
+
+Prompt and completion content is not recorded by default. Even with capture enabled, a UI tool's rendered html is never recorded — only its `data`.
+
+---
+
+## Client
+
+`@beatzball/litro-agent/client` is browser-safe — it imports the isomorphic wire protocol and type-only shapes, never H3 or a Node built-in.
+
+```ts
+import { agentSession, hydrateUIResult } from '@beatzball/litro-agent/client';
+```
+
+---
+
+## Documentation
+
+Full guide, security model, and the deferred-feature list: **[litro.dev/docs/agents](https://litro.dev/docs/agents)**
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Two related gaps, fixed together because both touch the agents guide.

## 1. A package page for `@beatzball/litro-agent`

The docs site generates `/docs/packages/<slug>` from each published package's README and CHANGELOG. litro-agent was never added when it shipped in July — the registry listed three packages, and litro-agent had no README to render.

- **New `packages/litro-agent/README.md`** — agent directory convention, the two endpoints, defining an agent and a tool, UI tools, providers, sessions, telemetry, and the browser-safe client entry.
- **Registered the slug** in `packages/docs-ui/src/packages.ts`. Both docs sites read that one list, so the page appears on each.
- **Sidebar entry in BOTH** `docs/` and `docs-ssr/` starlight configs. Adding it to only one is how the two sites drifted before.

Every code example was checked against source rather than written from memory. That caught two errors in my first draft:

| Draft had | Reality |
|---|---|
| `defineAgent({ provider: ... })` | the key is `model`, and `instructions` is required |
| `ui(template, data)` | second argument is an options object, `{ data }` |

Both would have been copy-paste traps on the package's front page.

## 2. Documenting what shipped in v0.1 (PR 111)

The guide still described v0, which stops being true when 0.2.0 publishes.

**Corrected a claim that becomes wrong on release.** The guide said the per-session turn lock is in-process and called it "the documented v0 limitation". That is now conditional on the store: `fileSessionStore` keeps single-process behaviour, `sqliteSessionStore` holds the lock across instances.

**New "Multi-instance sessions" section** — the store snippet, the Node 22.5+ requirement and why it sits behind its own subpath, what the lease does and does not guarantee, the store-poll tail for a GET reconnecting to a turn owned by another instance, and the rule that a lost lease stops the heartbeat but never aborts a turn. Aborting would break the append-before-wire ordering the section above it depends on.

**New "Telemetry" section** — the config snippet, why the app passes `@opentelemetry/api` in rather than the package depending on it, a table of the three spans and their attributes, the note that tool spans parent to the turn rather than to the chat round, and content capture: off by default, and a UI tool's rendered html never recorded even when it is on.

**Limitations list** — OpenTelemetry and alternate session stores were items 1 and 2 and are now shipped, so they are removed, the rest renumbered, and the intro points at the two new sections.

**`agents/_config.ts` section** now names both config keys instead of only `sessions`.

## Verification

- `node scripts/check-doc-refs.mjs` — clean across 55 files. It validates the new README's package imports against the real exports, which is exactly the class of error the first draft contained.
- Docs unit suites green: docs-ui 61, docs 43.
- **SSG site builds** and prerenders **4** package paths instead of 3, including `/docs/packages/litro-agent`.
- **SSR site builds**; a running server returns 200 on `/docs/packages/litro-agent` and `/docs/agents`, with the README content present in the HTML.
- Confirmed the stale "documented v0 limitation" sentence no longer appears in the rendered agents page.

## No changeset

A package README is docs, and it ships with whatever version publishes next. The page reads the version at build time, so it will show 0.2.0 once the pending release PR lands.
