### PR TITLE
fix: drop the published "source" export condition (blank page on Vite 8)

### DIFF
--- a/.changeset/create-litro-drop-source-condition.md
+++ b/.changeset/create-litro-drop-source-condition.md
@@ -1,0 +1,12 @@
+---
+'@beatzball/create-litro': patch
+---
+
+Scaffolded apps no longer list `'source'` in `resolve.conditions`. An installed
+package's TypeScript is never transpiled by Vite, so resolving to source emitted
+raw decorators and produced a client bundle no browser could parse — a blank
+page from a build that reported success. Templates now consume the packages'
+compiled output.
+
+Affected the `fullstack`, `11ty-blog`, and `starlight` recipes on the `lit` and
+`fast` adapters, on Vite 8. The `elena` adapter was unaffected.

--- a/.changeset/litro-agent-drop-source-condition.md
+++ b/.changeset/litro-agent-drop-source-condition.md
@@ -1,0 +1,8 @@
+---
+'@beatzball/litro-agent': patch
+---
+
+Remove the `source` export condition so consumers always resolve the compiled
+output. Publishing `source` pointed installed apps at TypeScript that Vite does
+not transpile inside `node_modules`, which produced an unparseable client
+bundle on Vite 8. No API change.

--- a/.changeset/litro-drop-source-condition.md
+++ b/.changeset/litro-drop-source-condition.md
@@ -1,0 +1,26 @@
+---
+'@beatzball/litro': patch
+---
+
+Remove the `source` export condition. It pointed consumers at the package's
+TypeScript source, and Vite does not transpile TypeScript that lives inside
+`node_modules` — so an installed app got Lit's `@customElement` decorators
+emitted as raw syntax:
+
+```js
+(@at(`litro-outlet`) class extends rt { ... })
+```
+
+No browser can parse that. The client bundle died with `Invalid or unexpected
+token`, nothing hydrated, and the page rendered blank — while the build still
+exited 0 and the prerendered HTML was still correct.
+
+This affected any app whose `vite.config.ts` listed `'source'` in
+`resolve.conditions` (which every `create-litro` template did) **on Vite 8**.
+Vite 5 was unaffected, so apps only broke on upgrading. Four of the six recipe
+variants were affected: Lit and FAST apps broke on `@customElement` / `@attr`;
+Elena apps use no decorators and were fine.
+
+Existing apps need no code change — upgrading is enough. Leaving `'source'` in
+`resolve.conditions` is now harmless, because the condition no longer matches
+and resolution falls through to the compiled output.

--- a/.changeset/litro-router-drop-source-condition.md
+++ b/.changeset/litro-router-drop-source-condition.md
@@ -1,0 +1,8 @@
+---
+'@beatzball/litro-router': patch
+---
+
+Remove the `source` export condition so consumers always resolve the compiled
+output. Publishing `source` pointed installed apps at TypeScript that Vite does
+not transpile inside `node_modules`, which produced an unparseable client
+bundle on Vite 8. No API change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,38 @@ jobs:
       - name: Build litro-agent
         run: pnpm --filter litro-agent build
 
+  # Builds every recipe the way a real user gets it: packed tarballs installed
+  # into a fresh scaffold, NOT the workspace symlink every other job uses.
+  #
+  # This exists because a scaffolded app was blank for weeks while every job
+  # here stayed green. Vite 8 does not transpile TypeScript inside node_modules,
+  # so resolving the package to its src/ emitted raw decorators the browser
+  # cannot parse -- while the build still exited 0 and the prerendered HTML was
+  # still perfect. Parsing the emitted bundle is the check that catches it.
+  scaffolded-apps:
+    name: Scaffolded Apps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build litro-router
+        run: pnpm --filter litro-router build
+      - name: Build framework
+        run: pnpm --filter litro build
+      - name: Build litro-agent
+        run: pnpm --filter litro-agent build
+      - name: Build create-litro
+        run: pnpm --filter create-litro build
+      - name: Scaffold every recipe from packed tarballs and parse each bundle
+        run: node scripts/verify-scaffolded-apps.mjs
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/benchmarks/apps/hn-litro-elena/vite.config.ts
+++ b/benchmarks/apps/hn-litro-elena/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
+import { litroSourceAlias } from '../../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/benchmarks/apps/hn-litro-fast/vite.config.ts
+++ b/benchmarks/apps/hn-litro-fast/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
+import { litroSourceAlias } from '../../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/benchmarks/apps/hn-litro/vite.config.ts
+++ b/benchmarks/apps/hn-litro/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
+import { litroSourceAlias } from '../../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/benchmarks/apps/litro/vite.config.ts
+++ b/benchmarks/apps/litro/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
+import { litroSourceAlias } from '../../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/docs-ssr/vite.config.ts
+++ b/docs-ssr/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 // Browser stub for docs/src/packages.ts — reads CHANGELOG.md / package.json
 // at SSG build time (server-side only). In the browser, data arrives via serverData.
@@ -28,6 +29,8 @@ export default defineConfig({
   plugins: [litroContentPlugin(), packagesStubPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 // Browser stub for docs/src/packages.ts — reads CHANGELOG.md / package.json
 // at SSG build time (server-side only). In the browser, data arrives via serverData.
@@ -28,6 +29,8 @@ export default defineConfig({
   plugins: [litroContentPlugin(), packagesStubPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'module', 'import', 'default'],
   },
   test: {

--- a/packages/create-litro/recipes/11ty-blog/template/vite.config.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [litroContentPlugin()],
   base: '/_litro/',
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   build: {
     outDir: 'dist/client',

--- a/packages/create-litro/recipes/fullstack/template-elena/vite.config.ts
+++ b/packages/create-litro/recipes/fullstack/template-elena/vite.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   base: '/_litro/',
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   // Elena does not use legacy decorators — no special esbuild config needed.
   build: {

--- a/packages/create-litro/recipes/fullstack/template/vite.config.ts
+++ b/packages/create-litro/recipes/fullstack/template/vite.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
   base: '/_litro/',
   plugins: [litroActionsPlugin()],
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   build: {
     outDir: 'dist/client',

--- a/packages/create-litro/recipes/starlight/template-elena/vite.config.ts
+++ b/packages/create-litro/recipes/starlight/template-elena/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [litroContentPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   // Elena does not use legacy decorators — no special esbuild config needed.
   build: {

--- a/packages/create-litro/recipes/starlight/template-fast/vite.config.ts
+++ b/packages/create-litro/recipes/starlight/template-fast/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [litroContentPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   esbuild: {
     tsconfigRaw: {

--- a/packages/create-litro/recipes/starlight/template/vite.config.ts
+++ b/packages/create-litro/recipes/starlight/template/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [litroContentPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
-    conditions: ['source', 'browser', 'module', 'import', 'default'],
+    // NOTE: no 'source' condition. An installed package's TypeScript is
+    // never transpiled by Vite (it lives under node_modules), so resolving
+    // to source would emit raw decorators and break the client bundle.
+    // Always consume the package's compiled output.
+    conditions: ['browser', 'module', 'import', 'default'],
   },
   build: {
     outDir: 'dist/client',

--- a/packages/docs-ui/vitest.config.ts
+++ b/packages/docs-ui/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { litroSourceAlias } from '../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'module', 'import', 'default'],
   },
   test: {

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -17,147 +17,118 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./cli": {
-      "source": "./src/cli/index.ts",
       "types": "./dist/cli/index.d.ts",
       "import": "./dist/cli/index.js"
     },
     "./vite": {
-      "source": "./src/vite/index.ts",
       "types": "./dist/vite/index.d.ts",
       "import": "./dist/vite/index.js"
     },
     "./runtime": {
-      "source": "./src/runtime/index.ts",
       "types": "./dist/runtime/index.d.ts",
       "import": "./dist/runtime/index.js"
     },
     "./runtime/*.js": {
-      "source": "./src/runtime/*.ts",
       "types": "./dist/runtime/*.d.ts",
       "import": "./dist/runtime/*.js"
     },
     "./actions": {
-      "source": "./src/actions/index.ts",
       "types": "./dist/actions/index.d.ts",
       "import": "./dist/actions/index.js"
     },
     "./actions/client": {
-      "source": "./src/actions/client.ts",
       "types": "./dist/actions/client.d.ts",
       "import": "./dist/actions/client.js"
     },
     "./actions/handler": {
-      "source": "./src/actions/handler.ts",
       "types": "./dist/actions/handler.d.ts",
       "import": "./dist/actions/handler.js"
     },
     "./actions/server": {
-      "source": "./src/actions/server.ts",
       "types": "./dist/actions/server.d.ts",
       "import": "./dist/actions/server.js"
     },
     "./actions/form-client": {
-      "source": "./src/actions/form-client.ts",
       "types": "./dist/actions/form-client.d.ts",
       "import": "./dist/actions/form-client.js"
     },
     "./stream": {
-      "source": "./src/stream.ts",
       "types": "./dist/stream.d.ts",
       "import": "./dist/stream.js"
     },
     "./plugins": {
-      "source": "./src/plugins/pages.ts",
       "types": "./dist/plugins/pages.d.ts",
       "import": "./dist/plugins/pages.js"
     },
     "./plugins/ssg": {
-      "source": "./src/plugins/ssg.ts",
       "types": "./dist/plugins/ssg.d.ts",
       "import": "./dist/plugins/ssg.js"
     },
     "./plugins/og": {
-      "source": "./src/plugins/og.ts",
       "types": "./dist/plugins/og.d.ts",
       "import": "./dist/plugins/og.js"
     },
     "./plugins/actions": {
-      "source": "./src/plugins/actions.ts",
       "types": "./dist/plugins/actions.d.ts",
       "import": "./dist/plugins/actions.js"
     },
     "./config": {
-      "source": "./src/config/presets.ts",
       "types": "./dist/config/presets.d.ts",
       "import": "./dist/config/presets.js"
     },
     "./types": {
-      "source": "./src/types/route.ts",
       "types": "./dist/types/route.d.ts",
       "import": "./dist/types/route.js"
     },
     "./content": {
-      "source": "./src/content/index.ts",
       "types": "./dist/content/index.d.ts",
       "import": "./dist/content/index.js"
     },
     "./content/plugin": {
-      "source": "./src/content/plugin.ts",
       "types": "./dist/content/plugin.d.ts",
       "import": "./dist/content/plugin.js"
     },
     "./adapter": {
-      "source": "./src/adapter/index.ts",
       "types": "./dist/adapter/index.d.ts",
       "import": "./dist/adapter/index.js"
     },
     "./adapter/lit": {
-      "source": "./src/adapter/lit/index.ts",
       "types": "./dist/adapter/lit/index.d.ts",
       "import": "./dist/adapter/lit/index.js"
     },
     "./adapter/fast": {
-      "source": "./src/adapter/fast/index.ts",
       "types": "./dist/adapter/fast/index.d.ts",
       "import": "./dist/adapter/fast/index.js"
     },
     "./adapter/fast/runtime": {
-      "source": "./src/adapter/fast/runtime/client.ts",
       "types": "./dist/adapter/fast/runtime/client.d.ts",
       "import": "./dist/adapter/fast/runtime/client.js"
     },
     "./adapter/fast/ssr-init": {
-      "source": "./src/adapter/fast/ssr-init.ts",
       "types": "./dist/adapter/fast/ssr-init.d.ts",
       "import": "./dist/adapter/fast/ssr-init.js"
     },
     "./adapter/fast/page": {
-      "source": "./src/adapter/fast/runtime/LitroPage.ts",
       "types": "./dist/adapter/fast/runtime/LitroPage.d.ts",
       "import": "./dist/adapter/fast/runtime/LitroPage.js"
     },
     "./adapter/elena": {
-      "source": "./src/adapter/elena/index.ts",
       "types": "./dist/adapter/elena/index.d.ts",
       "import": "./dist/adapter/elena/index.js"
     },
     "./adapter/elena/ssr-shim": {
-      "source": "./src/adapter/elena/ssr-shim.ts",
       "import": "./dist/adapter/elena/ssr-shim.js"
     },
     "./adapter/elena/runtime": {
-      "source": "./src/adapter/elena/runtime/client.ts",
       "types": "./dist/adapter/elena/runtime/client.d.ts",
       "import": "./dist/adapter/elena/runtime/client.js"
     },
     "./adapter/elena/page": {
-      "source": "./src/adapter/elena/runtime/LitroPage.ts",
       "types": "./dist/adapter/elena/runtime/LitroPage.d.ts",
       "import": "./dist/adapter/elena/runtime/LitroPage.js"
     },

--- a/packages/framework/vitest.config.ts
+++ b/packages/framework/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { litroSourceAlias } from '../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     // Resolve the 'source' export condition in workspace packages so Vitest
     // uses TypeScript source files directly (e.g. litro-router/src/index.ts)
     // without requiring a prior build step. Mirrors playground/vite.config.ts.

--- a/packages/litro-agent/package.json
+++ b/packages/litro-agent/package.json
@@ -26,57 +26,46 @@
   ],
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./ui": {
-      "source": "./src/ui/index.ts",
       "types": "./dist/ui/index.d.ts",
       "import": "./dist/ui/index.js"
     },
     "./telemetry": {
-      "source": "./src/telemetry/otel.ts",
       "types": "./dist/telemetry/otel.d.ts",
       "import": "./dist/telemetry/otel.js"
     },
     "./providers/openai-compatible": {
-      "source": "./src/providers/openai-compatible.ts",
       "types": "./dist/providers/openai-compatible.d.ts",
       "import": "./dist/providers/openai-compatible.js"
     },
     "./providers/anthropic": {
-      "source": "./src/providers/anthropic.ts",
       "types": "./dist/providers/anthropic.d.ts",
       "import": "./dist/providers/anthropic.js"
     },
     "./providers/scripted": {
-      "source": "./src/providers/scripted.ts",
       "types": "./dist/providers/scripted.d.ts",
       "import": "./dist/providers/scripted.js"
     },
     "./sessions/file": {
-      "source": "./src/sessions/file.ts",
       "types": "./dist/sessions/file.d.ts",
       "import": "./dist/sessions/file.js"
     },
     "./sessions/sqlite": {
-      "source": "./src/sessions/sqlite.ts",
       "types": "./dist/sessions/sqlite.d.ts",
       "import": "./dist/sessions/sqlite.js"
     },
     "./handler": {
-      "source": "./src/runtime/handler.ts",
       "types": "./dist/runtime/handler.d.ts",
       "import": "./dist/runtime/handler.js"
     },
     "./plugin": {
-      "source": "./src/plugin.ts",
       "types": "./dist/plugin.d.ts",
       "import": "./dist/plugin.js"
     },
     "./client": {
-      "source": "./src/client.ts",
       "types": "./dist/client.d.ts",
       "import": "./dist/client.js"
     }

--- a/packages/litro-agent/vitest.config.ts
+++ b/packages/litro-agent/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config';
+import { litroSourceAlias } from '../../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'module', 'import', 'default'],
   },
   test: {

--- a/packages/litro-router/package.json
+++ b/packages/litro-router/package.json
@@ -30,7 +30,6 @@
   ],
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }

--- a/playground-11ty/vite.config.ts
+++ b/playground-11ty/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroContentPlugin()],
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/playground-elena/vite.config.ts
+++ b/playground-elena/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
 import { litroActionsPlugin } from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroActionsPlugin()],
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   // Elena does not use legacy decorators — no special esbuild config needed.

--- a/playground-fast/vite.config.ts
+++ b/playground-fast/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from 'vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   // FAST Element 2.x uses legacy TypeScript decorators (@attr, @observable).

--- a/playground-starlight-elena/vite.config.ts
+++ b/playground-starlight-elena/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroContentPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   // Elena does not use legacy decorators — no special esbuild config needed.

--- a/playground-starlight-fast/vite.config.ts
+++ b/playground-starlight-fast/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroContentPlugin()],
   base: process.env.LITRO_BASE_PATH ? `${process.env.LITRO_BASE_PATH}/_litro/` : '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   esbuild: {

--- a/playground-starlight/vite.config.ts
+++ b/playground-starlight/vite.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite';
 import litroContentPlugin from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroContentPlugin()],
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     conditions: ['source', 'browser', 'module', 'import', 'default'],
   },
   build: {

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import { litroActionsPlugin } from '@beatzball/litro/vite';
+import { litroSourceAlias } from '../scripts/litro-source-alias.mjs';
 
 export default defineConfig({
   plugins: [litroActionsPlugin()],
@@ -12,6 +13,8 @@ export default defineConfig({
   // comes from the browser receiving HTML for the preload request.
   base: '/_litro/',
   resolve: {
+    // Workspace-only: read the Litro packages from src/ (see scripts/litro-source-alias.mjs).
+    alias: litroSourceAlias(),
     // Resolve 'source' condition in workspace packages so Vite uses
     // TypeScript source files directly (no pre-compilation needed in dev)
     conditions: ['source', 'browser', 'module', 'import', 'default'],

--- a/scripts/check-doc-refs.mjs
+++ b/scripts/check-doc-refs.mjs
@@ -11,8 +11,9 @@
  *
  *   2. PACKAGE IMPORTS — a named import from one of our own published packages
  *      (`import { defineConfig } from '@beatzball/litro'`) must correspond to a
- *      real export. Export names are read from the package's `source` entry in
- *      its exports map, following `export * from './x.js'` re-exports.
+ *      real export. Export names are read from the TypeScript source behind
+ *      each exports-map entry (derived from its `import` target), following
+ *      `export * from './x.js'` re-exports.
  *
  * Anything genuinely intentional goes in scripts/doc-refs-allow.txt.
  *
@@ -23,6 +24,7 @@
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { deriveSourceTarget } from './litro-source-alias.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -109,8 +111,11 @@ for (const pkgDir of OUR_PACKAGES) {
   const exportsMap = pkg.exports ?? {};
   for (const [subpath, cond] of Object.entries(exportsMap)) {
     if (typeof cond !== 'object' || cond === null) continue;
-    const src = cond.source;
-    if (typeof src !== 'string') continue;
+    // Derived from the "import" target, not a "source" condition: publishing
+    // a "source" condition pointed installed apps at TypeScript that Vite
+    // never transpiles, so it was removed from the packages.
+    const src = deriveSourceTarget(cond.import);
+    if (src === null) continue;
     const specifier = subpath === '.' ? pkg.name : `${pkg.name}/${subpath.slice(2)}`;
     if (subpath.includes('*')) {
       // e.g. "./runtime/*.js" -> "./src/runtime/*.ts": one entry per real file

--- a/scripts/litro-source-alias.d.mts
+++ b/scripts/litro-source-alias.d.mts
@@ -1,0 +1,12 @@
+/** Alias entry consumed by Vite's `resolve.alias`. */
+export interface LitroSourceAliasEntry {
+  find: RegExp;
+  replacement: string;
+}
+
+/**
+ * Workspace-only aliases mapping the published Litro packages to their
+ * TypeScript source. Derived from each package's own `exports` map.
+ */
+export declare function litroSourceAlias(): LitroSourceAliasEntry[];
+export default litroSourceAlias;

--- a/scripts/litro-source-alias.mjs
+++ b/scripts/litro-source-alias.mjs
@@ -1,0 +1,133 @@
+/**
+ * Workspace-only alias: resolve the published Litro packages to their
+ * TypeScript source instead of their compiled `dist/`.
+ *
+ * WHY THIS EXISTS
+ *
+ * The packages used to advertise a `"source"` export condition, and every app
+ * in this repo listed `'source'` first in `resolve.conditions`. That gave the
+ * monorepo a nice loop — edit `packages/framework/src`, see it immediately —
+ * but the same condition shipped to users through the recipe templates, where
+ * it silently produced a broken client bundle:
+ *
+ *   - In this workspace, `node_modules/@beatzball/litro` is a symlink whose
+ *     real path is `packages/framework/src/*.ts` — OUTSIDE any node_modules.
+ *     Vite transpiles it and finds `packages/framework/tsconfig.json`, so
+ *     `experimentalDecorators` applies and Lit's `@customElement` compiles.
+ *
+ *   - In an installed app the real path is INSIDE node_modules. Vite skips
+ *     TypeScript transformation there entirely, so no tsconfig is consulted
+ *     and the decorators pass through as raw syntax:
+ *
+ *         (@at(`litro-outlet`) class extends rt { ... })
+ *
+ *     No browser can parse that. `app.js` dies with "Invalid or unexpected
+ *     token", nothing hydrates, and the FOUC rule blanks the page — while the
+ *     build still exits 0 and the SSR HTML still looks perfect.
+ *
+ * So `"source"` is gone from the published packages, and the monorepo gets the
+ * same convenience through this explicit alias instead. An alias is local to
+ * this repo by construction: it cannot leak into anyone's app.
+ *
+ * HOW IT STAYS CORRECT
+ *
+ * The alias list is DERIVED from each package's own `exports` map at config
+ * load time — every `import` target `./dist/x.js` maps to `./src/x.ts`. Add or
+ * rename an export and the alias follows automatically. Nothing to keep in
+ * sync by hand.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Directory of this file: <repo>/scripts */
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Published package name -> its directory under packages/ */
+/** @type {Record<string, string>} */
+const PACKAGES = {
+  '@beatzball/litro': 'framework',
+  '@beatzball/litro-router': 'litro-router',
+  '@beatzball/litro-agent': 'litro-agent',
+};
+
+/** @typedef {{ find: RegExp, replacement: string }} AliasEntry */
+
+/** @param {string} s @returns {string} */
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the alias entries. Exported for the unit test; apps call
+ * `litroSourceAlias()`.
+ */
+/**
+ * Map a package `exports` "import" target to its TypeScript source.
+ *
+ *   ./dist/runtime/LitroOutlet.js  ->  ./src/runtime/LitroOutlet.ts
+ *
+ * Returns null when the target is not a compiled `dist/` entry. This is the
+ * single definition of the dist->src rule; `scripts/check-doc-refs.mjs` uses
+ * it too, so the two cannot drift.
+ *
+ * @param {unknown} importTarget
+ * @returns {string | null}
+ */
+export function deriveSourceTarget(importTarget) {
+  if (typeof importTarget !== 'string') return null;
+  const src = importTarget.replace(/^\.\/dist\//, './src/').replace(/\.js$/, '.ts');
+  return src === importTarget ? null : src;
+}
+
+/** @returns {AliasEntry[]} */
+export function litroSourceAlias() {
+  /** @type {AliasEntry[]} */
+  const entries = [];
+
+  for (const [pkgName, dir] of Object.entries(PACKAGES)) {
+    const pkgRoot = resolve(HERE, '..', 'packages', dir);
+    const manifest = JSON.parse(
+      readFileSync(join(pkgRoot, 'package.json'), 'utf-8'),
+    );
+
+    for (const [subpath, conditions] of Object.entries(manifest.exports ?? {})) {
+      if (typeof conditions !== 'object' || conditions === null) continue;
+      const importTarget = conditions.import;
+      if (typeof importTarget !== 'string') continue;
+
+      const sourceTarget = deriveSourceTarget(importTarget);
+      if (sourceTarget === null) continue; // not a compiled dist/ entry
+
+      const specifier =
+        subpath === '.' ? pkgName : `${pkgName}/${subpath.replace(/^\.\//, '')}`;
+      const absolute = join(pkgRoot, sourceTarget);
+
+      // Anchored regexes, never bare strings: a string `find` matches by
+      // prefix, so '@beatzball/litro' would swallow '@beatzball/litro/runtime'.
+      if (specifier.includes('*')) {
+        entries.push({
+          find: new RegExp(`^${escapeRegExp(specifier).replace('\\*', '(.*)')}$`),
+          replacement: absolute.replace('*', '$1'),
+        });
+      } else {
+        entries.push({
+          find: new RegExp(`^${escapeRegExp(specifier)}$`),
+          replacement: absolute,
+        });
+      }
+    }
+  }
+
+  if (entries.length === 0) {
+    throw new Error(
+      '[litro-source-alias] Derived zero aliases. The packages/*/package.json ' +
+        'exports maps changed shape — fix this helper rather than shipping a ' +
+        'silently empty alias list.',
+    );
+  }
+
+  return entries;
+}
+
+export default litroSourceAlias;

--- a/scripts/verify-scaffolded-apps.mjs
+++ b/scripts/verify-scaffolded-apps.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * verify-scaffolded-apps.mjs — build every recipe the way a real user gets it.
+ *
+ * WHY THIS EXISTS
+ *
+ * Every e2e project in this repo runs against a workspace playground, where
+ * `node_modules/@beatzball/litro` is a symlink into `packages/framework`. That
+ * is the one path where everything works. An app created with `create-litro`
+ * resolves the same package from a real `node_modules` install, and that path
+ * had never been executed by a test.
+ *
+ * It was broken for months in four of six recipe variants: Vite does not
+ * transpile TypeScript that lives inside node_modules, so resolving the
+ * package to its `src/` emitted raw decorators —
+ *
+ *     (@at(`litro-outlet`) class extends rt { ... })
+ *
+ * — which no browser can parse. The build still exited 0, the prerendered HTML
+ * was still perfect, and the only symptom was a blank white page in a browser.
+ * Nothing in CI could see it.
+ *
+ * So this script packs the real tarballs, scaffolds each recipe against them,
+ * builds, and then PARSES the emitted client bundle. A bundle that does not
+ * parse is a dead site, no matter what the build said.
+ *
+ * Usage:
+ *   node scripts/verify-scaffolded-apps.mjs            # all variants
+ *   node scripts/verify-scaffolded-apps.mjs --keep     # keep the temp dir
+ *   node scripts/verify-scaffolded-apps.mjs --only starlight:lit
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Recipe + adapter pairs create-litro can produce. */
+const VARIANTS = [
+  { recipe: 'fullstack', adapter: 'lit' },
+  { recipe: 'fullstack', adapter: 'elena' },
+  { recipe: '11ty-blog', adapter: 'lit' },
+  { recipe: 'starlight', adapter: 'lit' },
+  { recipe: 'starlight', adapter: 'fast' },
+  { recipe: 'starlight', adapter: 'elena' },
+];
+
+/** Workspace packages an app installs from the registry. */
+const PACKED = [
+  { name: '@beatzball/litro', dir: 'packages/framework' },
+  { name: '@beatzball/litro-router', dir: 'packages/litro-router' },
+  { name: '@beatzball/litro-agent', dir: 'packages/litro-agent' },
+];
+
+const args = process.argv.slice(2);
+const keep = args.includes('--keep');
+const onlyIdx = args.indexOf('--only');
+const only = onlyIdx !== -1 ? args[onlyIdx + 1] : null;
+
+function run(cmd, cmdArgs, cwd, label) {
+  try {
+    execFileSync(cmd, cmdArgs, { cwd, stdio: 'pipe', encoding: 'utf-8' });
+    return { ok: true };
+  } catch (err) {
+    const out = `${err.stdout ?? ''}${err.stderr ?? ''}`.trim();
+    return { ok: false, error: `${label} failed:\n${out.slice(-3000)}` };
+  }
+}
+
+const work = mkdtempSync(join(tmpdir(), 'litro-verify-'));
+console.log(`[verify] workspace: ${work}\n`);
+
+// ---------------------------------------------------------------------------
+// 1. Pack the real tarballs. This is what npm would publish.
+// ---------------------------------------------------------------------------
+const tarballs = {};
+for (const { name, dir } of PACKED) {
+  const pkgDir = join(REPO, dir);
+  const out = execFileSync('pnpm', ['pack', '--pack-destination', work], {
+    cwd: pkgDir,
+    encoding: 'utf-8',
+  });
+  const tgz = out.trim().split('\n').pop().trim();
+  if (!existsSync(tgz)) throw new Error(`[verify] pnpm pack gave no tarball for ${name}: ${out}`);
+  tarballs[name] = tgz;
+  console.log(`[verify] packed ${name}`);
+}
+console.log('');
+
+// ---------------------------------------------------------------------------
+// 2. Scaffold, install against the tarballs, build, PARSE the bundle.
+// ---------------------------------------------------------------------------
+const results = [];
+
+for (const { recipe, adapter } of VARIANTS) {
+  const id = `${recipe}:${adapter}`;
+  if (only && only !== id) continue;
+
+  const name = `app-${recipe}-${adapter}`;
+  const dir = join(work, name);
+
+  let step = run(
+    'node',
+    [join(REPO, 'packages/create-litro/dist/src/index.js'), name,
+     '--recipe', recipe, '--mode', 'ssg', '--adapter', adapter],
+    work, 'scaffold',
+  );
+  if (!step.ok) { results.push({ id, status: 'SCAFFOLD-FAIL', detail: step.error }); continue; }
+
+  // Force every Litro package to the packed tarball, transitive deps included.
+  const manifestPath = join(dir, 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  manifest.pnpm ??= {};
+  manifest.pnpm.overrides ??= {};
+  for (const [pkgName, tgz] of Object.entries(tarballs)) {
+    manifest.pnpm.overrides[pkgName] = `file:${tgz}`;
+    if (manifest.dependencies?.[pkgName]) manifest.dependencies[pkgName] = `file:${tgz}`;
+  }
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+
+  step = run('pnpm', ['install', '--ignore-workspace'], dir, 'install');
+  if (!step.ok) { results.push({ id, status: 'INSTALL-FAIL', detail: step.error }); continue; }
+
+  step = run('pnpm', ['build'], dir, 'build');
+  if (!step.ok) { results.push({ id, status: 'BUILD-FAIL', detail: step.error }); continue; }
+
+  const bundle = join(dir, 'dist/client/app.js');
+  if (!existsSync(bundle)) {
+    results.push({ id, status: 'NO-BUNDLE', detail: `expected ${bundle}` });
+    continue;
+  }
+
+  // The whole point: a build can exit 0 and still emit unparseable JavaScript.
+  const asModule = join(work, `${name}.check.mjs`);
+  writeFileSync(asModule, readFileSync(bundle, 'utf-8'));
+  step = run(process.execPath, ['--check', asModule], work, 'bundle parse');
+  if (!step.ok) {
+    results.push({
+      id,
+      status: 'BUNDLE-UNPARSEABLE',
+      detail:
+        'The build succeeded but the client bundle is not valid JavaScript, so ' +
+        'the site is blank in a browser.\n' + step.error,
+    });
+    continue;
+  }
+
+  results.push({ id, status: 'OK' });
+}
+
+// ---------------------------------------------------------------------------
+// 3. Report.
+// ---------------------------------------------------------------------------
+console.log('');
+console.log('  VARIANT                 RESULT');
+console.log('  ----------------------- ------------------');
+for (const r of results) console.log(`  ${r.id.padEnd(23)} ${r.status}`);
+console.log('');
+
+const failures = results.filter((r) => r.status !== 'OK');
+for (const f of failures) {
+  console.error(`\n=== ${f.id} — ${f.status} ===\n${f.detail}\n`);
+}
+
+if (!keep) rmSync(work, { recursive: true, force: true });
+else console.log(`[verify] kept ${work}`);
+
+if (failures.length > 0) {
+  console.error(`[verify] ${failures.length} of ${results.length} variants FAILED`);
+  process.exit(1);
+}
+console.log(`[verify] all ${results.length} variants OK`);


### PR DESCRIPTION
## The bug

An app created with `create-litro` renders a **blank white page** on Vite 8,
while every CI job here stays green.

The packages advertise a `source` export condition pointing at `./src/*.ts`,
and every recipe template lists `'source'` first in `resolve.conditions`.

- **In this workspace** `node_modules/@beatzball/litro` is a symlink whose real
  path is `packages/framework/src/*.ts` — **outside** any `node_modules`. Vite
  transpiles it, finds `packages/framework/tsconfig.json`, and
  `experimentalDecorators` applies. Everything works.
- **In an installed app** the real path is **inside** `node_modules`. Vite
  skips TypeScript transformation there entirely — no tsconfig is consulted at
  all — and the decorators reach the bundle as raw syntax:

```js
(@at(`litro-outlet`) class extends rt { ... }), @at(`litro-link`) class extends rt {
```

No browser can parse that. `app.js` dies with `Invalid or unexpected token`,
nothing hydrates, and the FOUC rule (`:not(:defined) { visibility: hidden }`)
blanks the page — while the build exits 0 and the prerendered HTML is perfect.

**Vite 8 only.** Vite 5 (esbuild) is unaffected; Vite 8 (Rolldown/Oxc) is not.
Vite 8 landed in the templates on 2026-07-02, so apps break on *upgrading*
rather than on install.

Verified by scaffolding every recipe fresh from the npm registry:

| Scaffolded app | Build exit | Bundle parses? |
|---|---|---|
| fullstack + lit | 0 | **SyntaxError** |
| fullstack + elena | 0 | OK |
| 11ty-blog + lit | 0 | **SyntaxError** |
| starlight + lit | 0 | **SyntaxError** |
| starlight + fast | 0 | **SyntaxError** |
| starlight + elena | 0 | OK |

Lit apps break on `@customElement`, FAST apps on `@attr` class fields. Elena
uses no decorators and is unaffected.

## Why it went unnoticed

- **All 9 e2e projects run against workspace playgrounds.** Not one runs
  against a scaffolded app. The broken path had never been executed by a test.
- **The build never fails.** Exit 0, prerender log, success banner.
- **The SSR HTML is correct**, so `curl` and Lighthouse both look healthy. Only
  a browser executing the JavaScript reveals it.
- **`scaffold.test.ts` never builds** — it asserts files exist and contain
  certain strings.

## The fix

- Remove `source` from the `litro`, `litro-router` and `litro-agent` exports
  maps. **Existing apps need no code change** — leaving `'source'` in
  `resolve.conditions` is now harmless, because the condition no longer matches
  and resolution falls through to the compiled output.
- Add `scripts/litro-source-alias.mjs` so the workspace keeps its live
  source-reload loop through an explicit alias, which cannot leak into a user's
  app. The alias list is **derived from each package's own exports map**
  (`./dist/x.js` → `./src/x.ts`), so it cannot drift. Wired into the 17
  workspace vite/vitest configs.
- Drop `'source'` from the six recipe templates.
- Add `scripts/verify-scaffolded-apps.mjs` and a `scaffolded-apps` CI job:
  every recipe is scaffolded from **packed tarballs**, built, and its bundle
  parsed. A bundle that does not parse is a dead site regardless of build exit
  code.
- `check-doc-refs.mjs` now derives each entry's source path from its `import`
  target, sharing one rule with the alias helper.

## Validation

| Check | Result |
|---|---|
| 6 recipes scaffolded from packed tarballs | 3 runs, all 6 OK each time |
| Same guard with the bug reintroduced | fails exactly the 4 known-broken variants |
| App that still lists `'source'` | fixed by upgrading alone, no edit |
| Full e2e (186 tests, 9 projects) | 3 clean runs |
| Unit tests | 766 passing across 6 suites |
| 9 workspace apps + 4 benchmark apps | all build, all bundles parse |
| Live source reload | proven: edited framework source, appeared instantly, `dist` untouched |
| Vite 5 control | unaffected, hydrates fine |
| Doc-refs guard | green |

Also validated against a real downstream app (`qdoku`, copied out and upgraded
to Vite 8): **unfixed → unparseable bundle; fixed → parses, every custom
element defined, zero page errors**, with no changes to that app's own code.

## Notes for review

- `scripts/litro-source-alias.mjs` throws if it derives zero aliases, so a
  future change to the exports-map shape fails loudly instead of silently
  disabling live reload.
- Two `playground/agent.spec.ts` tests failed once under full parallel load,
  then passed at baseline, in isolation, and in three subsequent full runs.
  Pre-existing flake, unrelated to this change, but worth a look.
- Shipping a self-contained `tsconfig.json` in the tarball does **not** fix
  this — tested. Vite never looks for one under `node_modules`.
