### PR TITLE
fix: recipe and tooling hygiene follow-ups

### DIFF
--- a/.changeset/create-litro-scaffold-hygiene.md
+++ b/.changeset/create-litro-scaffold-hygiene.md
@@ -1,0 +1,22 @@
+---
+'@beatzball/create-litro': patch
+---
+
+Two fixes to what a scaffolded app ships:
+
+**Generated stubs are no longer committable.** The templates ignored
+`server/stubs/page-manifest.ts` (and the fullstack action stubs) by name, but
+the scanners also emit `litro-content.js` and `agent-*.ts`, and several of
+those embed the absolute filesystem path of the machine that built them. A new
+app would commit a local path on its first `git add`. The whole
+`server/stubs/` directory is now ignored, so a newly added scanner cannot
+silently start leaking one. `server/plugins/litro-actions.ts` is unaffected —
+it lives outside `stubs/` and stays tracked, as intended.
+
+**End-to-end tests no longer run against whatever else owns port 3000.** The
+generated `playwright.config.ts` hardcoded port 3000 with
+`reuseExistingServer`. If any unrelated app was already listening there,
+`litro dev` moved to the next free port while Playwright ran the entire suite
+against the stranger and reported confusing 404s. The config now uses port
+4321 (override with `LITRO_E2E_PORT`), passes `--port` to `litro dev`, and
+never reuses an existing server.

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -3,9 +3,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Clean URLs — try exact file, then directory index, then 404
+    # Keep redirects relative so a non-80 port or a proxy prefix survives.
+    # With absolute_redirect on (the default), the trailing-slash redirect below
+    # rewrote the Host to nginx's own server_name and dropped the port.
+    absolute_redirect off;
+
+    # Clean URLs. Serve the directory's index.html directly instead of
+    # redirecting to the trailing-slash form: one fewer round trip, and no
+    # chance of nginx rewriting host or port on the way.
     location / {
-        try_files $uri $uri/ $uri.html =404;
+        try_files $uri $uri.html $uri/index.html =404;
     }
 
     # 1-year immutable caching for content-hashed assets (/_litro/app.js uses stable name

--- a/packages/create-litro/package.json
+++ b/packages/create-litro/package.json
@@ -16,7 +16,8 @@
     "create-litro": "./dist/src/index.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && node -e \"require('fs').cpSync('recipes', 'dist/recipes', { recursive: true })\"",
+    "clean": "node -e \"const fs=require('fs');fs.rmSync('dist',{recursive:true,force:true});fs.rmSync('tsconfig.tsbuildinfo',{force:true});\"",
+    "build": "pnpm run clean && tsc -p tsconfig.json && node -e \"require('fs').cpSync('recipes', 'dist/recipes', { recursive: true })\"",
     "dev": "tsc -p tsconfig.json --watch",
     "test": "vitest run"
   },

--- a/packages/create-litro/recipes/11ty-blog/template/.gitignore
+++ b/packages/create-litro/recipes/11ty-blog/template/.gitignore
@@ -6,8 +6,11 @@ dist/
 .output/
 .nitro/
 
-# Generated (overwritten on every build by the pages plugin)
-server/stubs/page-manifest.ts
+# Generated on every build. The whole stubs directory is ignored, not named
+# files: the scanners also emit litro-content.js, action-*.ts and agent-*.ts,
+# and several of them embed absolute local paths from the machine that built
+# them. A new scanner must not silently start leaking one.
+server/stubs/
 routes.generated.ts
 
 # TypeScript build info

--- a/packages/create-litro/recipes/11ty-blog/template/playwright.config.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Deliberately not 3000. That port is commonly held by something else on a
+// developer machine, and `litro dev` will quietly move to the next free one --
+// leaving the suite pointed at a stranger's server. Override with LITRO_E2E_PORT.
+const PORT = Number(process.env.LITRO_E2E_PORT ?? 4321);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -7,14 +12,17 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm dev --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    // Never reuse. If an unrelated app is already listening here, reuse would
+    // run the whole suite against it and report confusing 404s instead of
+    // starting the app under test.
+    reuseExistingServer: false,
     timeout: 60000,
   },
 });

--- a/packages/create-litro/recipes/fullstack/template/.gitignore
+++ b/packages/create-litro/recipes/fullstack/template/.gitignore
@@ -6,11 +6,12 @@ dist/
 .output/
 .nitro/
 
-# Generated (overwritten on every build by the pages plugin)
-server/stubs/page-manifest.ts
+# Generated on every build. The whole stubs directory is ignored, not named
+# files: the scanners also emit litro-content.js, action-*.ts and agent-*.ts,
+# and several of them embed absolute local paths from the machine that built
+# them. A new scanner must not silently start leaking one.
+server/stubs/
 routes.generated.ts
-server/stubs/action-manifest.ts
-server/stubs/action-handler.ts
 
 # TypeScript build info
 *.tsbuildinfo

--- a/packages/create-litro/recipes/fullstack/template/playwright.config.ts
+++ b/packages/create-litro/recipes/fullstack/template/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Deliberately not 3000. That port is commonly held by something else on a
+// developer machine, and `litro dev` will quietly move to the next free one --
+// leaving the suite pointed at a stranger's server. Override with LITRO_E2E_PORT.
+const PORT = Number(process.env.LITRO_E2E_PORT ?? 4321);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -7,14 +12,17 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm dev --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    // Never reuse. If an unrelated app is already listening here, reuse would
+    // run the whole suite against it and report confusing 404s instead of
+    // starting the app under test.
+    reuseExistingServer: false,
     timeout: 60000,
   },
 });

--- a/packages/create-litro/recipes/starlight/template/.gitignore
+++ b/packages/create-litro/recipes/starlight/template/.gitignore
@@ -6,8 +6,11 @@ dist/
 .output/
 .nitro/
 
-# Generated (overwritten on every build by the pages plugin)
-server/stubs/page-manifest.ts
+# Generated on every build. The whole stubs directory is ignored, not named
+# files: the scanners also emit litro-content.js, action-*.ts and agent-*.ts,
+# and several of them embed absolute local paths from the machine that built
+# them. A new scanner must not silently start leaking one.
+server/stubs/
 routes.generated.ts
 
 # TypeScript build info

--- a/packages/create-litro/recipes/starlight/template/playwright.config.ts
+++ b/packages/create-litro/recipes/starlight/template/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Deliberately not 3000. That port is commonly held by something else on a
+// developer machine, and `litro dev` will quietly move to the next free one --
+// leaving the suite pointed at a stranger's server. Override with LITRO_E2E_PORT.
+const PORT = Number(process.env.LITRO_E2E_PORT ?? 4321);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -7,14 +12,17 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm dev --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    // Never reuse. If an unrelated app is already listening here, reuse would
+    // run the whole suite against it and report confusing 404s instead of
+    // starting the app under test.
+    reuseExistingServer: false,
     timeout: 60000,
   },
 });

--- a/packages/create-litro/src/scaffold.test.ts
+++ b/packages/create-litro/src/scaffold.test.ts
@@ -117,8 +117,14 @@ describe('scaffold', () => {
       expect(pkg.imports['#litro/action-manifest']).toBe('./server/stubs/action-manifest.ts');
 
       const gitignore = await readFile(join(targetDir, '.gitignore'), 'utf-8');
-      expect(gitignore).toContain('server/stubs/action-manifest.ts');
-      expect(gitignore).toContain('server/stubs/action-handler.ts');
+      // The whole stubs directory is ignored rather than individually named
+      // files. The scanners also emit litro-content.js and agent-*.ts, and
+      // several stubs embed absolute paths from the machine that built them,
+      // so naming files let a newly added scanner silently start leaking one.
+      expect(gitignore).toMatch(/^server\/stubs\/$/m);
+      // ...but the committed runtime plugin lives OUTSIDE stubs and must stay
+      // tracked, so the directory rule must not have swallowed it.
+      expect(gitignore).not.toContain('server/plugins');
 
       expect(existsSync(join(targetDir, 'actions/demo.server.ts'))).toBe(true);
 

--- a/packages/create-litro/vitest.config.ts
+++ b/packages/create-litro/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/recipes/**/template/**',
+      // tsc emits the specs to dist/ too; without this every test runs twice,
+      // and the compiled copy can be stale relative to the source.
+      '**/dist/**',
     ],
   },
 });


### PR DESCRIPTION
Four unrelated fixes, all found while building a docs site on top of a
scaffolded app. Each is small and independently verified.

## 1. A scaffolded app could commit an absolute local path

The templates ignored generated stubs **by name** —
`server/stubs/page-manifest.ts`, plus the fullstack action stubs. But the
scanners also emit `litro-content.js` and `agent-*.ts`, and several of those
embed the filesystem path of the machine that built them. None of those were
ignored, so a new app would commit a local path on its first `git add`.

Now the whole `server/stubs/` directory is ignored, so a newly added scanner
cannot silently start leaking one. `server/plugins/litro-actions.ts` is
unaffected — it lives outside `stubs/` and stays tracked, as intended. The
scaffold test now asserts the directory rule *and* that it did not swallow the
committed runtime plugin.

**Verified:** scaffolded an app, built it, `git add -A` — both generated stubs
present on disk, neither staged.

## 2. A scaffolded app's e2e suite could test an unrelated server

The generated `playwright.config.ts` hardcoded port 3000 with
`reuseExistingServer: !CI`. When something else already held 3000, `litro dev`
moved to the next free port while Playwright ran the **entire suite against the
stranger** and reported confusing 404s. This is not hypothetical — it happened
on a machine where Obsidian owned 3000.

Now: port 4321 (override with `LITRO_E2E_PORT`), `--port` passed through to
`litro dev`, and never reuse an existing server.

**Verified:** ran a scaffolded app's suite with another process still holding
3000 — 3/3 pass. Before the fix, that exact situation produced 3 failures.

## 3. `create-litro`'s build left stale output behind

`tsc` emits to `dist/src`, but an older layout emitted `dist/index.js` — and
that file survived every rebuild. Running it scaffolds an **ancient template**.

Added a clean step that removes `dist` **and** `tsconfig.tsbuildinfo`. The
tsbuildinfo matters: this is a composite project, so deleting only the
directory makes `tsc` a no-op and emits nothing.

**Verified:** planted a fake `dist/index.js`, rebuilt — it is gone, the real
`dist/src/index.js` is present, and `dist/recipes` is copied.

## 4. The docs nginx config dropped the port on redirect

`try_files $uri $uri/ ...` sent `/docs/x` to `/docs/x/`, and with
`absolute_redirect` on (the default) that 301 rewrote the host and lost any
non-80 port:

```
OLD  /docs/getting-started -> 301 -> http://localhost/docs/getting-started/   (port 8131 gone)
NEW  /docs/getting-started -> 200                                             (no redirect)
```

Now serves the directory's `index.html` directly, with `absolute_redirect off`.

**Verified** against the real built docs site in an nginx container: **all 82
pages return 200, zero redirects issued.** Cache-control headers and the 404
path are unchanged. Six `/docs/<section>` paths return 404 under both configs —
those directories genuinely contain no `index.html`, only sub-pages, so neither
config could ever serve them; the new one just says so a hop earlier.

## Also

`vitest` was running `create-litro`'s specs **twice** — once from source and
once from the copy `tsc` emits into `dist/`, which could be stale. `dist` is
now excluded.

## Validation

Unit 748 passing across 6 suites · e2e 186/186 · doc-refs green ·
scaffolded-apps guard 6/6 · 82-page nginx sweep green.

## The flaky test: investigated, not fixed

Two `playground/agent.spec.ts` tests failed once during a full parallel run
(`#chat-log` empty after 5s). I could not reproduce it:

- **8/8 pass** running that spec in isolation.
- **4 clean full-suite runs**, one of them with 6 CPU spinners loading the
  machine.

The test already waits for `litro-outlet[data-litro-settled]` before clicking,
so a longer timeout could easily *hide* a genuine dropped-click race rather
than fix anything. Rather than guess, I left it alone and filed it separately.
