### PR TITLE
feat(cli): litro docs sync + check, and make the sidebar frontmatter real

### DIFF
--- a/.changeset/litro-docs-cli.md
+++ b/.changeset/litro-docs-cli.md
@@ -1,0 +1,27 @@
+---
+'@beatzball/litro': minor
+---
+
+Add `litro docs sync` and `litro docs check` for starlight docs sites.
+
+A starlight site has two sources of truth that can silently disagree: the
+Markdown files in the content directory, and the hand-written `sidebar` array
+in `server/starlight.config.js`. Add a page and forget the config and the page
+is live but unreachable — no link, no prev/next, and nothing says so.
+
+- **`litro docs sync`** rewrites the sidebar from your pages' frontmatter,
+  using `sidebar.order`, `sidebar.group` and `sidebar.label`.
+- **`litro docs check`** changes nothing and exits 1 on drift: a page with no
+  `title` or `description`, a body that opens with its own `# ` heading
+  (duplicating the frontmatter title), colliding slugs, a page missing from the
+  sidebar, or a sidebar link pointing at no page. Suitable as a CI step.
+
+This also makes the recipe's own documentation true. It has always claimed
+`sidebar.order` "controls sort order within the sidebar group" and that
+`sidebar.label` overrides the sidebar text — neither field was read by
+anything. Both work now, and `sidebar.group` joins them.
+
+`sync` refuses to run when the sidebar has several groups but no page declares
+one, since that would silently collapse a hand-built navigation into a single
+group. It prints the group each page currently belongs to so the structure can
+be restored by copy-paste, and takes `--force` for a deliberate flatten.

--- a/packages/create-litro/recipes/starlight/template/content/docs/guides-first-page.md
+++ b/packages/create-litro/recipes/starlight/template/content/docs/guides-first-page.md
@@ -45,8 +45,22 @@ The `slug` must match the filename (without `.md`). The page will be available a
 |---|---|---|---|
 | `title` | `string` | Yes | Page title (shown in sidebar and `<title>`) |
 | `description` | `string` | No | Short summary for SEO |
-| `sidebar.order` | `number` | No | Controls sort order within the sidebar group |
-| `sidebar.label` | `string` | No | Override the label shown in the sidebar |
+| `sidebar.order` | `number` | No | Sort order within the sidebar group. Pages without one sort last, alphabetically |
+| `sidebar.group` | `string` | No | Sidebar group this page belongs to. Defaults to `Documentation` |
+| `sidebar.label` | `string` | No | Override the label shown in the sidebar (defaults to `title`) |
+
+The `sidebar.*` fields are read by `litro docs sync`, which rewrites the
+`sidebar` array in `server/starlight.config.js` from your pages. Run it after
+adding or renaming a page:
+
+```bash
+litro docs sync    # regenerate the sidebar from your pages
+litro docs check   # verify pages and sidebar agree; exits 1 on drift
+```
+
+`litro docs check` makes a good CI step: a page that is live but missing from
+the sidebar is reachable by URL and invisible to readers, which is easy to ship
+and hard to notice.
 
 ## Markdown Features
 

--- a/packages/framework/src/cli/docs.test.ts
+++ b/packages/framework/src/cli/docs.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import {
+  existingGroups,
+  parseFrontmatter,
+  buildSidebar,
+  renderSidebar,
+  replaceSidebarBlock,
+  findProblems,
+  type DocsPage,
+} from './docs.js';
+
+function page(over: Partial<DocsPage> = {}): DocsPage {
+  return {
+    slug: 'a',
+    relPath: 'content/docs/a.md',
+    title: 'A',
+    description: 'desc',
+    label: 'A',
+    group: 'Documentation',
+    order: null,
+    ...over,
+  };
+}
+
+describe('parseFrontmatter', () => {
+  it('reads flat fields and strips quotes', () => {
+    const fm = parseFrontmatter(`---\ntitle: "Getting Started"\ndescription: 'One line.'\n---\n\n## Body`);
+    expect(fm.title).toBe('Getting Started');
+    expect(fm.description).toBe('One line.');
+  });
+
+  it('reads the nested sidebar map as dotted keys', () => {
+    const fm = parseFrontmatter(`---\ntitle: T\nsidebar:\n  order: 3\n  group: Guides\n---\n`);
+    expect(fm['sidebar.order']).toBe('3');
+    expect(fm['sidebar.group']).toBe('Guides');
+  });
+
+  it('returns nothing when there is no frontmatter', () => {
+    expect(parseFrontmatter('# Just a heading\n')).toEqual({});
+  });
+
+  it('does not treat a --- inside the body as a frontmatter fence', () => {
+    // A horizontal rule after the real block must not extend it.
+    const fm = parseFrontmatter(`---\ntitle: T\n---\n\n## Body\n\n---\n\nmore`);
+    expect(fm.title).toBe('T');
+    expect(Object.keys(fm)).toEqual(['title']);
+  });
+});
+
+describe('buildSidebar', () => {
+  it('orders pages within a group by sidebar.order', () => {
+    const groups = buildSidebar([
+      page({ slug: 'c', title: 'C', order: 3 }),
+      page({ slug: 'a', title: 'A', order: 1 }),
+      page({ slug: 'b', title: 'B', order: 2 }),
+    ]);
+    expect(groups[0].items.map((i) => i.slug)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('keeps unordered pages, sorting them last by title', () => {
+    // A page that forgets `order` must stay reachable, not vanish.
+    const groups = buildSidebar([
+      page({ slug: 'zebra', title: 'Zebra', order: null }),
+      page({ slug: 'apple', title: 'Apple', order: null }),
+      page({ slug: 'first', title: 'First', order: 1 }),
+    ]);
+    expect(groups[0].items.map((i) => i.slug)).toEqual(['first', 'apple', 'zebra']);
+  });
+
+  it('orders groups by their lowest-ordered page', () => {
+    const groups = buildSidebar([
+      page({ slug: 'g2', title: 'G2', group: 'Second', order: 10 }),
+      page({ slug: 'g1', title: 'G1', group: 'First', order: 1 }),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['First', 'Second']);
+  });
+
+  it('falls back to the slug when a title is empty', () => {
+    const groups = buildSidebar([page({ slug: 'no-title', title: '', label: '' })]);
+    expect(groups[0].items[0].label).toBe('no-title');
+  });
+
+  it('uses sidebar.label to override the sidebar text without changing the title', () => {
+    const groups = buildSidebar([page({ slug: 'x', title: 'A Very Long Page Title', label: 'Short' })]);
+    expect(groups[0].items[0].label).toBe('Short');
+  });
+});
+
+describe('replaceSidebarBlock', () => {
+  const config = `export const siteConfig = {
+  title: 'x',
+  sidebar: [
+    {
+      label: 'Old',
+      items: [
+        { label: 'One', slug: 'one' },
+      ],
+    },
+  ],
+};
+`;
+
+  it('replaces the sidebar and leaves the rest untouched', () => {
+    const out = replaceSidebarBlock(config, renderSidebar(buildSidebar([page()])))!;
+    expect(out).toContain("title: 'x'");
+    expect(out).not.toContain("label: 'Old'");
+    expect(out).toContain("slug: 'a'");
+    expect(out.trimEnd().endsWith('};')).toBe(true);
+  });
+
+  it('produces a config that still parses as one object', () => {
+    const out = replaceSidebarBlock(config, renderSidebar(buildSidebar([page()])))!;
+    // Balanced braces and exactly one sidebar key -- a second one would lose
+    // silently to the first at runtime.
+    expect(out.split('{').length).toBe(out.split('}').length);
+    expect(out.match(/sidebar: \[/g)).toHaveLength(1);
+  });
+
+  it('returns null when there is no sidebar block, rather than appending one', () => {
+    expect(replaceSidebarBlock('export const siteConfig = { title: 1 };', '  sidebar: [],')).toBeNull();
+  });
+
+  it('is not confused by a bracket inside a label', () => {
+    const tricky = `export const siteConfig = {
+  sidebar: [
+    { label: 'Arrays [and] things', items: [{ label: 'x', slug: 'x' }] },
+  ],
+  nav: [],
+};
+`;
+    const out = replaceSidebarBlock(tricky, '  sidebar: [],')!;
+    expect(out).toContain('nav: []');
+    expect(out).not.toContain('Arrays [and] things');
+  });
+});
+
+describe('findProblems', () => {
+  const src = (body: string) => new Map([['content/docs/a.md', body]]);
+
+  it('is quiet on a well-formed page', () => {
+    expect(findProblems([page()], src('---\ntitle: A\n---\n\n## Body'))).toEqual([]);
+  });
+
+  it('reports a missing title and description', () => {
+    const found = findProblems([page({ title: '', description: '' })], src('---\n---\n'));
+    expect(found.map((p) => p.kind).sort()).toEqual(['missing description', 'missing title']);
+  });
+
+  it('reports a body that opens with its own h1', () => {
+    const found = findProblems([page()], src('---\ntitle: A\n---\n\n# Duplicate\n'));
+    expect(found.map((p) => p.kind)).toContain('duplicate h1');
+  });
+
+  it('does not mistake a deep heading for an h1', () => {
+    const found = findProblems([page()], src('---\ntitle: A\n---\n\n## Fine\n### Also fine\n'));
+    expect(found).toEqual([]);
+  });
+
+  it('reports colliding slugs once, naming every file involved', () => {
+    const found = findProblems(
+      [
+        page({ slug: 'dup', relPath: 'content/docs/dup.md' }),
+        page({ slug: 'dup', relPath: 'content/blog/dup.md' }),
+      ],
+      new Map([
+        ['content/docs/dup.md', '---\ntitle: A\n---\n'],
+        ['content/blog/dup.md', '---\ntitle: A\n---\n'],
+      ]),
+    );
+    const dupes = found.filter((p) => p.kind === 'duplicate slug');
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0].relPath).toBe('content/blog/dup.md, content/docs/dup.md');
+  });
+});
+
+describe('existingGroups', () => {
+  const grouped = `export const siteConfig = {
+  nav: [],
+  sidebar: [
+    {
+      label: 'Start Here',
+      items: [
+        { label: 'Getting Started', slug: 'getting-started' },
+        { label: 'Setup',           slug: 'setup' },
+      ],
+    },
+    {
+      label: 'Reference',
+      items: [
+        { label: 'How It Works', slug: 'how-it-works' },
+      ],
+    },
+  ],
+};
+`;
+
+  it('reads each group and the slugs it owns', () => {
+    const groups = existingGroups(grouped);
+    expect([...groups.keys()]).toEqual(['Start Here', 'Reference']);
+    expect(groups.get('Start Here')).toEqual(['getting-started', 'setup']);
+    expect(groups.get('Reference')).toEqual(['how-it-works']);
+  });
+
+  it('returns nothing when there is no sidebar block', () => {
+    expect(existingGroups('export const siteConfig = { title: 1 };').size).toBe(0);
+  });
+
+  it('does not pick up slugs from nav or other keys', () => {
+    // Only the sidebar block counts -- a nav link is not a sidebar entry.
+    const withNav = grouped.replace("nav: [],", "nav: [{ label: 'Docs', slug: 'not-a-sidebar-entry' }],");
+    const all = [...existingGroups(withNav).values()].flat();
+    expect(all).not.toContain('not-a-sidebar-entry');
+  });
+});
+
+describe('sync round-trip', () => {
+  it('a rebuilt sidebar still contains every page exactly once', () => {
+    const pages = [
+      page({ slug: 'a', title: 'A', group: 'One', order: 1 }),
+      page({ slug: 'b', title: 'B', group: 'Two', order: 2 }),
+      page({ slug: 'c', title: 'C', group: 'One', order: 3 }),
+    ];
+    const config = `export const siteConfig = {\n  sidebar: [\n  ],\n};\n`;
+    const out = replaceSidebarBlock(config, renderSidebar(buildSidebar(pages)))!;
+    const slugs = [...out.matchAll(/slug: '([^']+)'/g)].map((m) => m[1]).sort();
+    expect(slugs).toEqual(['a', 'b', 'c']);
+    // and the groups survive the round trip
+    expect([...existingGroups(out).keys()]).toEqual(['One', 'Two']);
+  });
+});

--- a/packages/framework/src/cli/docs.ts
+++ b/packages/framework/src/cli/docs.ts
@@ -1,0 +1,475 @@
+/**
+ * `litro docs` — keep a docs site's navigation honest.
+ *
+ * WHY THIS EXISTS
+ *
+ * The starlight recipe has two sources of truth that can silently disagree:
+ * the Markdown files under the content directory, and the hand-written
+ * `sidebar` array in `server/starlight.config.js`. Add a page and forget the
+ * config and the page is live but unreachable — no link, no prev/next, and
+ * nothing anywhere says so.
+ *
+ * Worse, the recipe's own documentation claims `sidebar.order` in a page's
+ * frontmatter "controls sort order within the sidebar group". It never did:
+ * nothing read that field. `sync` makes that sentence true by generating the
+ * sidebar from the frontmatter, so the pages themselves are the source of
+ * truth and the config becomes derived output.
+ *
+ *   litro docs sync    regenerate the sidebar from the content directory
+ *   litro docs check   verify pages and sidebar agree (exit 1 if not)
+ *
+ * `check` is the CI-shaped half: it changes nothing and fails loudly.
+ */
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, resolve, basename, extname } from 'pathe';
+import process from 'node:process';
+import { resolveContentDir } from '../content/resolve-content-dir.js';
+
+/** A docs page as the sidebar cares about it. */
+export interface DocsPage {
+  /** URL slug, derived from the filename. */
+  slug: string;
+  /** Path relative to the project root, for error messages. */
+  relPath: string;
+  title: string;
+  description: string;
+  /** Sidebar label. Defaults to `title`; `sidebar.label` overrides it. */
+  label: string;
+  /** Sidebar group label. Pages with no group land in `defaultGroup`. */
+  group: string;
+  /** Sort key within the group. Pages without one sort last, then by title. */
+  order: number | null;
+}
+
+export interface SidebarGroup {
+  label: string;
+  items: Array<{ label: string; slug: string }>;
+}
+
+/** Problems `check` reports. Each one is a reason a reader hits a dead end. */
+export interface DocsProblem {
+  relPath: string;
+  kind: string;
+  detail: string;
+}
+
+const DEFAULT_GROUP = 'Documentation';
+
+/**
+ * Parse just enough YAML frontmatter for the fields the sidebar needs.
+ *
+ * Deliberately not a YAML parser: the recipe's frontmatter is a flat block of
+ * `key: value` plus an optional one-level `sidebar:` map, and pulling in a
+ * parser for that would be the only reason this module needed a dependency.
+ * Anything more exotic is reported by `check` rather than guessed at.
+ */
+export function parseFrontmatter(source: string): Record<string, string> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
+  if (!match) return {};
+
+  const fields: Record<string, string> = {};
+  let currentParent: string | null = null;
+
+  for (const rawLine of match[1].split(/\r?\n/)) {
+    if (rawLine.trim() === '' || rawLine.trimStart().startsWith('#')) continue;
+
+    const indented = /^\s/.test(rawLine);
+    const pair = /^\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/.exec(rawLine);
+    if (!pair) continue;
+
+    const [, key, rawValue] = pair;
+    const value = rawValue.trim().replace(/^['"]|['"]$/g, '');
+
+    if (!indented) {
+      currentParent = value === '' ? key : null;
+      if (value !== '') fields[key] = value;
+    } else if (currentParent) {
+      fields[`${currentParent}.${key}`] = value;
+    }
+  }
+
+  return fields;
+}
+
+/** Slug for a content file: the filename, or the directory for `index.md`. */
+function slugFor(filePath: string): string {
+  const base = basename(filePath, extname(filePath));
+  return base === 'index' ? basename(join(filePath, '..')) : base;
+}
+
+/** Every `.md` file under `dir`, recursively, sorted for stable output. */
+async function markdownFiles(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...(await markdownFiles(full)));
+    else if (entry.name.endsWith('.md')) found.push(full);
+  }
+  return found;
+}
+
+/** Read every docs page under `docsDir`. */
+export async function readDocsPages(
+  docsDir: string,
+  rootDir: string,
+): Promise<DocsPage[]> {
+  const files = await markdownFiles(docsDir);
+  const pages: DocsPage[] = [];
+
+  for (const file of files) {
+    const source = await readFile(file, 'utf-8');
+    const fm = parseFrontmatter(source);
+    const rawOrder = fm['sidebar.order'];
+    const parsedOrder = rawOrder === undefined ? NaN : Number(rawOrder);
+
+    pages.push({
+      slug: slugFor(file),
+      relPath: file.startsWith(rootDir) ? file.slice(rootDir.length + 1) : file,
+      title: fm.title ?? '',
+      description: fm.description ?? '',
+      label: fm['sidebar.label'] ?? fm.title ?? '',
+      group: fm['sidebar.group'] ?? DEFAULT_GROUP,
+      order: Number.isFinite(parsedOrder) ? parsedOrder : null,
+    });
+  }
+
+  return pages;
+}
+
+/**
+ * Build the sidebar tree from pages.
+ *
+ * Groups appear in the order their lowest-ordered page appears, so moving a
+ * page's `order` can promote its whole group. Within a group, pages sort by
+ * `order`; pages without one sort last, alphabetically by title, so a page
+ * that forgets the field is still reachable rather than dropped.
+ */
+export function buildSidebar(pages: DocsPage[]): SidebarGroup[] {
+  const byGroup = new Map<string, DocsPage[]>();
+  for (const page of pages) {
+    const bucket = byGroup.get(page.group);
+    if (bucket) bucket.push(page);
+    else byGroup.set(page.group, [page]);
+  }
+
+  const rank = (p: DocsPage) => (p.order === null ? Number.MAX_SAFE_INTEGER : p.order);
+
+  const groups: SidebarGroup[] = [];
+  for (const [label, groupPages] of byGroup) {
+    const sorted = [...groupPages].sort(
+      (a, b) => rank(a) - rank(b) || a.title.localeCompare(b.title),
+    );
+    groups.push({
+      label,
+      items: sorted.map((p) => ({ label: p.label || p.slug, slug: p.slug })),
+    });
+  }
+
+  return groups.sort(
+    (a, b) =>
+      Math.min(...byGroup.get(a.label)!.map(rank)) -
+      Math.min(...byGroup.get(b.label)!.map(rank)),
+  );
+}
+
+/** Render the sidebar as the `sidebar: [...]` literal for the config file. */
+export function renderSidebar(groups: SidebarGroup[]): string {
+  const width = Math.max(
+    0,
+    ...groups.flatMap((g) => g.items.map((i) => `'${i.label}',`.length)),
+  );
+
+  const body = groups
+    .map((group) => {
+      const items = group.items
+        .map((item) => {
+          const label = `'${item.label}',`.padEnd(width);
+          return `        { label: ${label} slug: '${item.slug}' },`;
+        })
+        .join('\n');
+      return `    {\n      label: '${group.label}',\n      items: [\n${items}\n      ],\n    },`;
+    })
+    .join('\n');
+
+  return `  sidebar: [\n${body}\n  ],`;
+}
+
+/**
+ * Replace the `sidebar: [...]` block in a starlight config.
+ *
+ * Returns null when the block cannot be found, so the caller can fail loudly
+ * rather than append a second `sidebar` key that silently loses to the first.
+ */
+export function replaceSidebarBlock(
+  configSource: string,
+  rendered: string,
+): string | null {
+  const start = configSource.indexOf('  sidebar: [');
+  if (start === -1) return null;
+
+  // Walk brackets so a `[` inside a label cannot end the block early.
+  let depth = 0;
+  let end = -1;
+  for (let i = configSource.indexOf('[', start); i < configSource.length; i++) {
+    const ch = configSource[i];
+    if (ch === '[') depth++;
+    else if (ch === ']') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return null;
+
+  const after = configSource.slice(end + 1);
+  const trailingComma = after.startsWith(',') ? 1 : 0;
+  return configSource.slice(0, start) + rendered + after.slice(trailingComma);
+}
+
+/** Everything `check` verifies. Pure, so it is straightforward to test. */
+export function findProblems(
+  pages: DocsPage[],
+  sources: Map<string, string>,
+): DocsProblem[] {
+  const problems: DocsProblem[] = [];
+
+  for (const page of pages) {
+    if (!page.title) {
+      problems.push({
+        relPath: page.relPath,
+        kind: 'missing title',
+        detail: 'Frontmatter needs a `title:` — it becomes the <h1> and the sidebar label.',
+      });
+    }
+    if (!page.description) {
+      problems.push({
+        relPath: page.relPath,
+        kind: 'missing description',
+        detail: 'Frontmatter needs a `description:` — it is used for SEO and the OG image.',
+      });
+    }
+
+    const body = (sources.get(page.relPath) ?? '').replace(/^---[\s\S]*?\r?\n---/, '');
+    if (/^\s*#\s+/m.test(body.split('\n').slice(0, 8).join('\n'))) {
+      problems.push({
+        relPath: page.relPath,
+        kind: 'duplicate h1',
+        detail:
+          'Body starts with `# ` but the frontmatter title is already rendered as the ' +
+          '<h1>. Start the body at `## `.',
+      });
+    }
+  }
+
+  const bySlug = new Map<string, DocsPage[]>();
+  for (const page of pages) {
+    const bucket = bySlug.get(page.slug);
+    if (bucket) bucket.push(page);
+    else bySlug.set(page.slug, [page]);
+  }
+  for (const [slug, dupes] of bySlug) {
+    if (dupes.length < 2) continue;
+    problems.push({
+      relPath: dupes.map((d) => d.relPath).sort().join(', '),
+      kind: 'duplicate slug',
+      detail:
+        `Slugs are filename-derived and must be unique across the whole content ` +
+        `directory; "${slug}" is claimed by ${dupes.length} files.`,
+    });
+  }
+
+  return problems;
+}
+
+/**
+ * Read the group structure already in a config file.
+ *
+ * Used to refuse a `sync` that would silently flatten a hand-built navigation:
+ * grouping is a design decision, and losing it should never be a side effect.
+ */
+export function existingGroups(configSource: string): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  const block = /sidebar:\s*\[([\s\S]*?)\n  \],/.exec(configSource);
+  if (!block) return groups;
+
+  const groupRe = /label:\s*'([^']+)',\s*\n\s*items:\s*\[([\s\S]*?)\]/g;
+  for (const match of block[1].matchAll(groupRe)) {
+    const slugs = [...match[2].matchAll(/slug:\s*'([^']+)'/g)].map((m) => m[1]);
+    groups.set(match[1], slugs);
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Command entry points
+// ---------------------------------------------------------------------------
+
+interface DocsPaths {
+  rootDir: string;
+  docsDir: string;
+  configPath: string;
+}
+
+async function resolvePaths(rootDir: string): Promise<DocsPaths | string> {
+  const contentDir = await resolveContentDir(rootDir, resolve(rootDir, 'content'));
+  const docsDir = existsSync(join(contentDir, 'docs'))
+    ? join(contentDir, 'docs')
+    : contentDir;
+  if (!existsSync(docsDir)) {
+    return `No content directory found. Looked for ${docsDir}. Is this a Litro docs site?`;
+  }
+
+  const configPath = join(rootDir, 'server/starlight.config.js');
+  if (!existsSync(configPath)) {
+    return `No ${configPath}. \`litro docs\` expects a site built from the starlight recipe.`;
+  }
+
+  return { rootDir, docsDir, configPath };
+}
+
+export async function docsSync(rootDir: string, force = false): Promise<number> {
+  const paths = await resolvePaths(rootDir);
+  if (typeof paths === 'string') {
+    console.error(`[litro docs] ${paths}`);
+    return 1;
+  }
+
+  const pages = await readDocsPages(paths.docsDir, rootDir);
+  if (pages.length === 0) {
+    console.error(`[litro docs] No .md pages under ${paths.docsDir}.`);
+    return 1;
+  }
+
+  const untitled = pages.filter((p) => !p.title);
+  if (untitled.length > 0) {
+    // Refuse rather than write a sidebar labelled with raw slugs: a wrong nav
+    // is harder to notice than a missing one.
+    console.error('[litro docs] Cannot sync — these pages have no frontmatter `title`:');
+    for (const p of untitled) console.error(`  ${p.relPath}`);
+    return 1;
+  }
+
+  const configSource = await readFile(paths.configPath, 'utf-8');
+
+  // Refuse to silently flatten a hand-built navigation. If the config already
+  // has several groups but no page says which group it belongs to, syncing
+  // would drop every group into one bucket -- a design decision quietly
+  // discarded. Print the mapping that already exists so restoring it is a
+  // copy-paste, and let --force through for a deliberate flatten.
+  const priorGroups = existingGroups(configSource);
+  const anyPageDeclaresGroup = pages.some((p) => p.group !== DEFAULT_GROUP);
+  if (priorGroups.size > 1 && !anyPageDeclaresGroup && !force) {
+    const groupOf = new Map<string, string>();
+    for (const [label, slugs] of priorGroups) {
+      for (const slug of slugs) groupOf.set(slug, label);
+    }
+    console.error(
+      `[litro docs] Refusing to sync: the sidebar has ${priorGroups.size} groups, but no\n` +
+        `page declares one, so syncing would collapse them into a single group.\n\n` +
+        `Add the group to each page's frontmatter to keep the current structure:\n`,
+    );
+    for (const p of pages) {
+      const label = groupOf.get(p.slug);
+      console.error(`  ${p.relPath}`);
+      console.error(`    sidebar:\n      group: ${label ?? '<new page — pick a group>'}`);
+    }
+    console.error(`\nOr re-run with --force to flatten the sidebar deliberately.`);
+    return 1;
+  }
+
+  const updated = replaceSidebarBlock(configSource, renderSidebar(buildSidebar(pages)));
+  if (updated === null) {
+    console.error(
+      `[litro docs] Could not find a \`sidebar: [ ... ]\` block in ${paths.configPath}.`,
+    );
+    return 1;
+  }
+
+  if (updated === configSource) {
+    console.log(`[litro docs] Sidebar already matches ${pages.length} pages. No change.`);
+    return 0;
+  }
+
+  await writeFile(paths.configPath, updated, 'utf-8');
+  console.log(`[litro docs] Sidebar rewritten from ${pages.length} pages.`);
+  return 0;
+}
+
+export async function docsCheck(rootDir: string): Promise<number> {
+  const paths = await resolvePaths(rootDir);
+  if (typeof paths === 'string') {
+    console.error(`[litro docs] ${paths}`);
+    return 1;
+  }
+
+  const pages = await readDocsPages(paths.docsDir, rootDir);
+  const sources = new Map<string, string>();
+  for (const page of pages) {
+    sources.set(page.relPath, await readFile(join(rootDir, page.relPath), 'utf-8'));
+  }
+
+  const problems = findProblems(pages, sources);
+
+  // A page missing from the sidebar is live but unreachable — the exact drift
+  // this command exists to catch.
+  const configSource = await readFile(paths.configPath, 'utf-8');
+  const listed = new Set(
+    [...configSource.matchAll(/slug:\s*'([^']+)'/g)].map((m) => m[1]),
+  );
+  for (const page of pages) {
+    if (!listed.has(page.slug)) {
+      problems.push({
+        relPath: page.relPath,
+        kind: 'not in sidebar',
+        detail: `"${page.slug}" is reachable by URL but has no sidebar link. Run \`litro docs sync\`.`,
+      });
+    }
+  }
+  for (const slug of listed) {
+    if (!pages.some((p) => p.slug === slug)) {
+      problems.push({
+        relPath: 'server/starlight.config.js',
+        kind: 'dangling sidebar link',
+        detail: `Sidebar links "${slug}" but no page has that slug — the link 404s.`,
+      });
+    }
+  }
+
+  if (problems.length === 0) {
+    console.log(`[litro docs] OK — ${pages.length} pages, sidebar in sync.`);
+    return 0;
+  }
+
+  console.error(
+    `[litro docs] ${problems.length} problem${problems.length === 1 ? '' : 's'}:\n`,
+  );
+  for (const p of problems) {
+    console.error(`  ${p.relPath}`);
+    console.error(`    [${p.kind}] ${p.detail}`);
+  }
+  return 1;
+}
+
+/** Dispatch for `litro docs <subcommand>`. */
+export async function docsCommand(args: string[], rootDir: string): Promise<number> {
+  const [subcommand] = args;
+  switch (subcommand) {
+    case 'sync':
+      return docsSync(rootDir, args.includes('--force'));
+    case 'check':
+      return docsCheck(rootDir);
+    default:
+      console.error(
+        `Usage: litro docs <sync|check>\n\n` +
+          `  sync   regenerate the sidebar in server/starlight.config.js from the\n` +
+          `         content directory's frontmatter (title, sidebar.group, sidebar.order)\n` +
+          `  check  verify every page has a title and description, slugs are unique,\n` +
+          `         and the sidebar and pages agree. Changes nothing; exits 1 on drift.\n`,
+      );
+      return subcommand === undefined ? 1 : 1;
+  }
+}

--- a/packages/framework/src/cli/index.ts
+++ b/packages/framework/src/cli/index.ts
@@ -11,6 +11,9 @@
  *
  * generate: Alias for `litro build --mode static`.
  *
+ * docs:     Keeps a starlight docs site's sidebar in step with its pages.
+ *           `sync` rewrites it from frontmatter; `check` reports drift and exits 1.
+ *
  * preview:  Runs the production server entry (.output/server/index.mjs) directly.
  *           `nitro preview` was removed in Nitro 2.13.
  *
@@ -25,6 +28,7 @@ import { join, extname } from 'node:path';
 import process from 'node:process';
 import { scanAndWriteClientRoutes } from '../plugins/pages.js';
 import { parsePortArg, resolvePort } from './port.js';
+import { docsCommand } from './docs.js';
 
 const [,, command, ...args] = process.argv;
 const cwd = process.cwd();
@@ -171,6 +175,14 @@ switch (command) {
     });
     break;
 
+  case 'docs': {
+    // Operates on files only — no dev server, no build. Exits with the
+    // command's own status so `litro docs check` works as a CI step.
+    const code = await docsCommand(args, cwd);
+    process.exit(code);
+    break;
+  }
+
   case 'preview': {
     const portlessUrlPreview = process.env.PORTLESS_URL;
     const { port: rawPort, explicit } = parsePortArg(args);
@@ -263,6 +275,8 @@ Commands:
   litro generate         Build static site (alias for litro build --mode static)
   litro preview          Preview production build
   litro preview --host   Expose preview server to network
+  litro docs sync        Regenerate the docs sidebar from page frontmatter
+  litro docs check       Verify pages and sidebar agree (exits 1 on drift)
     `);
     process.exit(0);
 }

--- a/scripts/verify-scaffolded-apps.mjs
+++ b/scripts/verify-scaffolded-apps.mjs
@@ -108,7 +108,10 @@ mkdirSync(scaffolderDir, { recursive: true });
 execFileSync('tar', ['-xzf', scaffolderTgz, '-C', scaffolderDir], { stdio: 'pipe' });
 const CREATE_CLI = join(scaffolderDir, 'package/dist/src/index.js');
 if (!existsSync(CREATE_CLI)) {
-  throw new Error(`[verify] scaffolder tarball has no ${CREATE_CLI}`);
+  throw new Error(
+    `[verify] the packed scaffolder has no dist/src/index.js.\n` +
+      `Build it first:  pnpm --filter create-litro build`,
+  );
 }
 console.log(`[verify] packed ${SCAFFOLDER.name} and unpacked it for scaffolding`);
 console.log('');


### PR DESCRIPTION
First half of the `litro docs` tooling we agreed on: the part that operates on
an existing site. Scaffolding (`--for-repo`) stays in `create-litro` and lands
separately, so each half keeps its own dependency lines.

## The problem

A starlight site has two sources of truth that can silently disagree: the
Markdown under the content directory, and the hand-written `sidebar` array in
`server/starlight.config.js`.

Add a page and forget the config, and the page is **live but unreachable** — no
sidebar link, no prev/next, and nothing anywhere tells you. It is easy to ship
and hard to notice.

## Two commands

```bash
litro docs sync    # rewrite the sidebar from your pages' frontmatter
litro docs check   # verify pages and sidebar agree; exits 1 on drift
```

`check` changes nothing and reports: a missing `title` or `description`, a body
that opens with its own `# ` heading (duplicating the frontmatter title,
producing two h1s), colliding slugs, a page missing from the sidebar, and a
sidebar link pointing at no page. It is shaped for CI.

## It makes the recipe's documentation true

`guides-first-page.md` has always contained this table:

| Field | Description |
|---|---|
| `sidebar.order` | Controls sort order within the sidebar group |
| `sidebar.label` | Override the label shown in the sidebar |

**Neither field was read by anything.** The table documented behaviour that did
not exist — a reader could set `sidebar.order` and watch nothing happen. Both
work now, `sidebar.group` joins them, and the page explains how to run the
commands.

## sync refuses rather than quietly destroying work

If the sidebar has several groups but no page declares one, syncing would
collapse a hand-built navigation into a single bucket. Grouping is a design
decision, and losing it should never be a side effect:

```
[litro docs] Refusing to sync: the sidebar has 3 groups, but no
page declares one, so syncing would collapse them into a single group.

Add the group to each page's frontmatter to keep the current structure:

  content/docs/getting-started.md
    sidebar:
      group: Start Here
  ...
Or re-run with --force to flatten the sidebar deliberately.
```

It prints the group each page belongs to today, so restoring the structure is
copy-paste.

## Verified against a real site

Run against roost's docs site, whose sidebar was written entirely by hand:

- `check` passes on it as-is (7 pages, sidebar in sync).
- Added a page without touching the config → `check` fails with
  `[not in sidebar] "keybindings" is reachable by URL but has no sidebar link`.
- `sync` then rewrites it correctly, ordered by `sidebar.order`.
- The emitted config still **parses as JavaScript** (imported it and read
  `siteConfig.sidebar`), and the site **builds** with the new page prerendered
  (18 routes, 8 docs pages).
- On the grouped copy, `sync` refuses as designed.

## Validation

Unit 443 in the framework (22 new) · router 29 · create-litro 19 · docs 104 ·
e2e 186/186 · doc-refs green · scaffolded-apps guard 6/6.

## Also

The scaffolded-apps guard now names the missing build step when the packed
scaffolder has no `dist`, instead of printing a bare path — I hit that myself
in a fresh worktree.
