### PR TITLE
feat(create-litro): --for-repo builds a project's docs site from its repository

### DIFF
--- a/.changeset/create-litro-for-repo.md
+++ b/.changeset/create-litro-for-repo.md
@@ -1,0 +1,35 @@
+---
+'@beatzball/create-litro': minor
+---
+
+Add `--for-repo`, which turns a scaffolded starlight site into a specific
+project's documentation site.
+
+```sh
+npm create @beatzball/litro@latest -- site \
+  --recipe starlight --for-repo . --site-url https://example.dev
+```
+
+It reads the repository's name, description, remote and default branch, then
+writes `_data/metadata.js`, `server/starlight.config.js` (title, nav with a
+GitHub link, and "Edit this page" links pointing at the right branch and
+subdirectory), a `Dockerfile` + `nginx.conf` deploy, and an `AGENTS.md` that
+tells any coding agent how to add a page correctly.
+
+The sample blog is removed by default (`--with-blog` keeps it) — including the
+landing page's link to it and the blog routes in the generated e2e spec, so a
+new site has no dead link and its own test suite passes.
+
+It does **not** write your documentation. Turning a README into good pages is a
+judgement call, so it leaves one honest placeholder page and points the agent
+at `AGENTS.md`.
+
+Every lookup degrades rather than failing: with no git remote it falls back to
+the directory name, sets `editUrlBase: null`, omits the GitHub nav entry, and
+prints what you still need to fill in. Works offline and without `gh`.
+
+Other flags: `--site-url <url>`, `--deploy <docker|none>`, `--with-blog`.
+
+`packageManager` is now pinned in the scaffolded `package.json` to the pnpm
+that ran the scaffold, so the Docker build uses the same pnpm that produced
+the lockfile instead of whatever corepack resolves as newest.

--- a/packages/create-litro/src/for-repo.test.ts
+++ b/packages/create-litro/src/for-repo.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeRemote,
+  renderMetadata,
+  renderStarlightConfig,
+  renderAgentsMd,
+  renderNginxConf,
+  type RepoInfo,
+} from './for-repo.js';
+
+const repo: RepoInfo = {
+  name: 'roost',
+  description: 'An on-demand tmux agent view.',
+  repoUrl: 'https://github.com/beatzball/roost',
+  defaultBranch: 'main',
+};
+
+describe('normalizeRemote', () => {
+  it('converts an scp-style ssh remote to https', () => {
+    expect(normalizeRemote('git@github.com:owner/repo.git')).toBe('https://github.com/owner/repo');
+  });
+
+  it('resolves an ssh host alias back to the real host', () => {
+    // Multi-account setups use aliases like github.com-work in ~/.ssh/config;
+    // the alias must not leak into a public "Edit this page" link.
+    expect(normalizeRemote('git@github.com-work:owner/repo.git')).toBe(
+      'https://github.com/owner/repo',
+    );
+  });
+
+  it('strips credentials and the .git suffix from an https remote', () => {
+    expect(normalizeRemote('https://token@github.com/owner/repo.git')).toBe(
+      'https://github.com/owner/repo',
+    );
+  });
+
+  it('returns empty for something that is not a remote', () => {
+    expect(normalizeRemote('')).toBe('');
+    expect(normalizeRemote('not a url')).toBe('');
+  });
+});
+
+describe('rendered files', () => {
+  it('escapes a quote in the description rather than breaking the literal', () => {
+    const out = renderMetadata({ ...repo, description: "it's fine" }, 'https://x.dev');
+    expect(out).toContain("\\'");
+    // The emitted module must still be one valid object literal.
+    expect(out.split('{').length).toBe(out.split('}').length);
+  });
+
+  it('points edit links at the repo, branch and site subdirectory', () => {
+    const out = renderStarlightConfig(repo, 'site');
+    expect(out).toContain("editUrlBase: 'https://github.com/beatzball/roost/edit/main/site/content/docs'");
+  });
+
+  it('omits the GitHub nav entry and edit links when there is no remote', () => {
+    const out = renderStarlightConfig({ ...repo, repoUrl: '' }, 'site');
+    expect(out).toContain('editUrlBase: null');
+    expect(out).not.toContain("label: 'GitHub'");
+  });
+
+  it('seeds a sidebar that matches the starter page it writes', () => {
+    // A sidebar naming a slug that does not exist would 404 on first build.
+    expect(renderStarlightConfig(repo, 'site')).toContain("slug: 'getting-started'");
+  });
+
+  it('tells agents not to hand-edit the sidebar', () => {
+    const out = renderAgentsMd(repo, 'https://roosting.dev', 'site');
+    expect(out).toContain('litro docs sync');
+    expect(out).toContain('Do **not** hand-edit the `sidebar` array');
+  });
+
+  it('ships the nginx config that does not drop the port', () => {
+    const conf = renderNginxConf();
+    expect(conf).toContain('absolute_redirect off;');
+    expect(conf).toContain('try_files $uri $uri.html $uri/index.html =404;');
+    expect(conf).not.toContain('$uri/ ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: scaffold a real site, then shape it.
+// These cover bugs that only appear once the pieces are combined -- unit tests
+// on the renderers cannot see a dangling link left behind in another file.
+// ---------------------------------------------------------------------------
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scaffold } from './scaffold.js';
+import { applyForRepo } from './for-repo.js';
+
+async function withSite(fn: (siteDir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'for-repo-'));
+  const siteDir = join(dir, 'site');
+  try {
+    await scaffold('starlight', { projectName: 'site', mode: 'ssg' }, siteDir);
+    await applyForRepo({
+      repoDir: dir,
+      siteDir,
+      siteUrl: 'https://example.dev',
+      siteRelPath: 'site',
+      deploy: 'docker',
+      withBlog: false,
+    });
+    await fn(siteDir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('applyForRepo (integration)', () => {
+  it('leaves no dangling link to the blog it removed', async () => {
+    await withSite(async (siteDir) => {
+      // Deleting pages/blog is not enough: the landing page linked to /blog,
+      // which would 404 on a brand-new site.
+      const index = await readFile(join(siteDir, 'pages/index.ts'), 'utf-8');
+      expect(index).not.toContain('/blog');
+      expect(index).not.toContain("title: 'Blog'");
+      expect(existsSync(join(siteDir, 'pages/blog'))).toBe(false);
+      expect(existsSync(join(siteDir, 'content/blog'))).toBe(false);
+    });
+  });
+
+  it('rewrites the generated e2e spec to routes that exist', async () => {
+    await withSite(async (siteDir) => {
+      const spec = await readFile(join(siteDir, 'e2e/index.spec.ts'), 'utf-8');
+      expect(spec).not.toContain('/blog');
+      expect(spec).toContain("'/docs/getting-started'");
+    });
+  });
+
+  it('pins packageManager so the Docker build uses the right pnpm', async () => {
+    await withSite(async (siteDir) => {
+      // Without this, corepack in the image resolves the newest pnpm, which
+      // can reject a lockfile written by an older one.
+      const pkg = JSON.parse(await readFile(join(siteDir, 'package.json'), 'utf-8'));
+      expect(pkg.packageManager ?? '').toMatch(/^pnpm@\d+\.\d+\.\d+/);
+      expect(pkg.name).toMatch(/-docs$/);
+    });
+  });
+
+  it('writes a starter page whose slug the seeded sidebar actually links', async () => {
+    await withSite(async (siteDir) => {
+      expect(existsSync(join(siteDir, 'content/docs/getting-started.md'))).toBe(true);
+      const config = await readFile(join(siteDir, 'server/starlight.config.js'), 'utf-8');
+      expect(config).toContain("slug: 'getting-started'");
+      // and the recipe's Litro-specific sample pages are gone
+      expect(existsSync(join(siteDir, 'content/docs/guides-deploying.md'))).toBe(false);
+    });
+  });
+
+  it('emits the deploy files and agent instructions', async () => {
+    await withSite(async (siteDir) => {
+      for (const f of ['Dockerfile', 'nginx.conf', '.dockerignore', 'AGENTS.md']) {
+        expect(existsSync(join(siteDir, f)), `${f} missing`).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/create-litro/src/for-repo.ts
+++ b/packages/create-litro/src/for-repo.ts
@@ -1,0 +1,495 @@
+/**
+ * `--for-repo` — turn a freshly scaffolded starlight site into *this project's*
+ * documentation site.
+ *
+ * WHY THIS EXISTS
+ *
+ * The starlight recipe produces a generic site: placeholder title, example
+ * URL, a sample blog, a sidebar listing pages about Litro itself. Pointing it
+ * at a real project meant a dozen mechanical edits — rename, retitle, set the
+ * canonical URL, point "Edit this page" at the right branch, wire a deploy,
+ * and write the instructions an agent needs to add a page correctly.
+ *
+ * All of that is derivable from the repository, so it is done here instead of
+ * being retyped (or half-remembered) each time. What is NOT done here is the
+ * writing: turning a README into good pages is a judgement call, and this
+ * module deliberately leaves it to a human or an agent, guided by the
+ * AGENTS.md it drops next to the content.
+ */
+import { readFile, writeFile, rm, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, basename, resolve } from 'node:path';
+
+export interface RepoInfo {
+  /** Short project name, e.g. "roost". */
+  name: string;
+  /** One-line description, or '' when nothing could be found. */
+  description: string;
+  /** Canonical https URL of the repository, or '' if not a GitHub remote. */
+  repoUrl: string;
+  /** Default branch, used to build "edit this page" links. */
+  defaultBranch: string;
+}
+
+export interface ForRepoOptions {
+  /** Path to the repository the docs are for. */
+  repoDir: string;
+  /** Where the site was scaffolded. */
+  siteDir: string;
+  /** Public URL the site will be served from, e.g. https://roosting.dev. */
+  siteUrl?: string;
+  /** Site directory name relative to the repo root, for edit links. */
+  siteRelPath: string;
+  /** Emit Dockerfile + nginx.conf. */
+  deploy: 'docker' | 'none';
+  /** Keep the recipe's sample blog. */
+  withBlog: boolean;
+}
+
+/** Run a command, returning '' instead of throwing when it is unavailable. */
+function tryExec(cmd: string, args: string[], cwd: string): string {
+  try {
+    return execFileSync(cmd, args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Normalise any git remote form to an https URL. */
+export function normalizeRemote(remote: string): string {
+  if (!remote) return '';
+  // git@github.com:owner/repo.git, ssh://git@host/owner/repo, https://…/repo.git
+  const ssh = /^[^@]+@([^:]+):(.+?)(?:\.git)?$/.exec(remote);
+  if (ssh) {
+    // A host alias like github.com-work resolves to the real host for URLs.
+    const host = ssh[1].replace(/-.*$/, '') || ssh[1];
+    return `https://${host}/${ssh[2]}`;
+  }
+  const url = /^(?:ssh|https?):\/\/(?:[^@]+@)?([^/]+)\/(.+?)(?:\.git)?$/.exec(remote);
+  if (url) return `https://${url[1]}/${url[2]}`;
+  return '';
+}
+
+/**
+ * Learn what we can about the repository.
+ *
+ * Every lookup degrades to a sensible default rather than failing: scaffolding
+ * must work in a directory with no git remote, no `gh`, and no network.
+ */
+export async function detectRepo(repoDir: string): Promise<RepoInfo> {
+  const root = resolve(repoDir);
+  const remote = tryExec('git', ['remote', 'get-url', 'origin'], root);
+  const repoUrl = normalizeRemote(remote);
+
+  const name = repoUrl ? basename(repoUrl) : basename(root);
+
+  let defaultBranch =
+    tryExec('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], root)
+      .split('/')
+      .pop() ?? '';
+  if (!defaultBranch) defaultBranch = tryExec('git', ['branch', '--show-current'], root);
+  if (!defaultBranch) defaultBranch = 'main';
+
+  // Description: the repo's own package.json first (offline, authoritative),
+  // then GitHub via `gh` if it happens to be installed and authenticated.
+  let description = '';
+  const pkgPath = join(root, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      if (typeof pkg.description === 'string') description = pkg.description;
+    } catch {
+      // A malformed package.json is the repo's problem, not a reason to fail here.
+    }
+  }
+  if (!description && repoUrl.includes('github.com')) {
+    const slug = repoUrl.split('github.com/')[1];
+    const json = tryExec('gh', ['repo', 'view', slug, '--json', 'description'], root);
+    if (json) {
+      try {
+        description = JSON.parse(json).description ?? '';
+      } catch {
+        /* leave empty */
+      }
+    }
+  }
+
+  return { name, description, repoUrl, defaultBranch };
+}
+
+/** Escape a value for embedding in a single-quoted JS string literal. */
+function js(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+export function renderMetadata(repo: RepoInfo, siteUrl: string): string {
+  return `export default {
+  title: '${js(repo.name)}',
+  url: '${js(siteUrl)}',
+  language: 'en',
+  description:
+    '${js(repo.description)}',
+  author: {
+    name: '',
+    email: '',
+  },
+};
+`;
+}
+
+export function renderStarlightConfig(repo: RepoInfo, siteRelPath: string): string {
+  const editBase = repo.repoUrl
+    ? `'${js(repo.repoUrl)}/edit/${js(repo.defaultBranch)}/${js(siteRelPath)}/content/docs'`
+    : 'null';
+  const githubNav = repo.repoUrl
+    ? `\n    { label: 'GitHub', href: '${js(repo.repoUrl)}' },`
+    : '';
+
+  return `export const siteConfig = {
+  title: '${js(repo.name)}',
+  description:
+    '${js(repo.description)}',
+  logo: null,
+  // "Edit this page" links. Points at the default branch at scaffold time.
+  editUrlBase: ${editBase},
+  nav: [
+    { label: 'Docs', href: '/docs/getting-started' },${githubNav}
+  ],
+  // Generated by \`litro docs sync\` from each page's frontmatter
+  // (sidebar.order / sidebar.group / sidebar.label). Edit the pages, not this.
+  sidebar: [
+    {
+      label: 'Documentation',
+      items: [
+        { label: 'Getting Started', slug: 'getting-started' },
+      ],
+    },
+  ],
+};
+
+export default siteConfig;
+`;
+}
+
+/**
+ * The starter page.
+ *
+ * Deliberately short and obviously a placeholder: a scaffolder that writes
+ * plausible-looking prose invites shipping text nobody wrote.
+ */
+export function renderStarterPage(repo: RepoInfo): string {
+  return `---
+title: Getting Started
+description: ${repo.description || `What ${repo.name} is and how to install it.`}
+sidebar:
+  order: 1
+  group: Documentation
+---
+
+## What ${repo.name} is
+
+${repo.description || `_Describe ${repo.name} in a sentence or two._`}
+
+## Install
+
+\`\`\`sh
+# TODO: the real install steps
+\`\`\`
+
+## Next steps
+
+Replace this page, then add more under \`content/docs/\`. After adding or
+renaming a page run:
+
+\`\`\`sh
+litro docs sync    # regenerate the sidebar from your pages
+litro docs check   # verify pages and sidebar agree
+\`\`\`
+`;
+}
+
+export function renderDockerfile(): string {
+  return `# Build the static site, then serve it with nginx.
+#
+# The build context is this directory, so a platform that builds from a
+# subdirectory (Coolify: Base Directory) needs no extra path juggling.
+
+FROM node:22-slim AS builder
+
+RUN corepack enable
+
+WORKDIR /app
+# The lockfile glob tolerates its absence on a first build, before anyone has
+# run install. corepack reads "packageManager" from package.json, so the image
+# uses the same pnpm that produced the lockfile rather than the newest release.
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile || pnpm install
+
+COPY . .
+RUN pnpm build
+
+FROM nginx:alpine
+
+COPY --from=builder /app/dist/static /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`;
+}
+
+export function renderNginxConf(): string {
+  return `server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Keep redirects relative so a non-80 port or a proxy prefix survives.
+    # With absolute_redirect on (the default), a trailing-slash redirect
+    # rewrites the Host to nginx's own server_name and drops the port.
+    absolute_redirect off;
+
+    # Clean URLs. Serve the directory's index.html directly instead of
+    # redirecting to the trailing-slash form: one fewer round trip, and no
+    # chance of nginx rewriting host or port on the way.
+    location / {
+        try_files $uri $uri.html $uri/index.html =404;
+    }
+
+    # The client bundle has a stable name, but every deploy rewrites the file.
+    location /_litro/ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Shoelace icon assets are not content-hashed, so no immutable here.
+    location /shoelace/ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+    }
+
+    location ~* \\.html$ {
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    gzip on;
+    gzip_types text/html text/css application/javascript application/json image/svg+xml text/xml;
+}
+`;
+}
+
+export function renderDockerignore(): string {
+  return `node_modules
+dist
+.output
+.nitro
+routes.generated.ts
+server/stubs
+*.tsbuildinfo
+.DS_Store
+`;
+}
+
+/**
+ * Instructions any coding agent reads before touching the site.
+ *
+ * Harness-agnostic on purpose: it is plain Markdown, so Claude Code, Codex,
+ * opencode and Cursor all work from the same rules instead of each needing
+ * its own plugin.
+ */
+export function renderAgentsMd(repo: RepoInfo, siteUrl: string, siteRelPath: string): string {
+  const site = siteUrl || 'the documentation site';
+  return `# ${repo.name} docs site — agent instructions
+
+This directory is the source for **${site}**. It is a Litro \`starlight\` site
+in SSG mode: Markdown in, static HTML out.
+
+Read this before changing anything in \`${siteRelPath}/\`.
+
+## Where things live
+
+| Path | What it is |
+|------|-----------|
+| \`content/docs/*.md\` | Every documentation page. One file = one page. |
+| \`server/starlight.config.js\` | Site title, top nav, and the sidebar tree. |
+| \`_data/metadata.js\` | Title, canonical URL, description (SEO and OG images). |
+| \`pages/index.ts\` | The landing page (a Lit component, not Markdown). |
+| \`pages/docs/[slug].ts\` | The doc page template. Not where you add a page. |
+
+## Add a page
+
+1. Create \`content/docs/<slug>.md\`. The filename becomes the URL:
+   \`content/docs/foo.md\` → \`/docs/foo\`.
+
+2. Give it frontmatter. \`title\` and \`description\` are required:
+
+   \`\`\`markdown
+   ---
+   title: Your Page Title
+   description: One sentence. Used for SEO and the OG image.
+   sidebar:
+     order: 2
+     group: Documentation
+   ---
+
+   ## First heading
+
+   Body starts here.
+   \`\`\`
+
+3. Regenerate the sidebar and verify:
+
+   \`\`\`sh
+   litro docs sync
+   litro docs check
+   \`\`\`
+
+   Do **not** hand-edit the \`sidebar\` array — \`sync\` rewrites it from your
+   pages' frontmatter.
+
+## Rules
+
+- **Start the body at \`##\`, not \`#\`.** The frontmatter \`title\` is already
+  rendered as the page's \`<h1>\`; a \`#\` in the body makes a second one.
+  \`litro docs check\` fails on this.
+- **Slugs must be unique across the whole \`content/\` directory.** The build
+  throws on a collision rather than silently dropping a page.
+- **Internal links are absolute paths**: \`/docs/setup\`, not \`setup.md\`.
+- **Never edit \`routes.generated.ts\` or anything in \`server/stubs/\`.** Both
+  are regenerated on every build and are gitignored.
+- **This site is for users. The repo \`README.md\` is for contributors.** Put a
+  fact in one and link from the other rather than duplicating it.
+
+## Verify
+
+\`\`\`sh
+pnpm install      # first time only
+pnpm build        # must exit 0; prints every prerendered route
+litro docs check  # pages and sidebar agree
+pnpm dev          # live-reload while writing
+\`\`\`
+
+\`pnpm build\` is the real check: it fails on a duplicate slug, a missing
+\`title\`, or a broken component, and prints the full route list so you can
+confirm your page is there.
+`;
+}
+
+
+/**
+ * Remove what the recipe's landing page and e2e spec assume about the blog.
+ *
+ * Each edit asserts its target exists. If the recipe template is reshaped and
+ * one of these no longer matches, scaffolding fails loudly here rather than
+ * emitting a site with a dead link nobody notices until a reader clicks it.
+ */
+async function unlinkBlogReferences(siteDir: string, repo: RepoInfo): Promise<void> {
+  const indexPath = join(siteDir, 'pages/index.ts');
+  let index = await readFile(indexPath, 'utf-8');
+
+  const blogCta = '<a href="/blog"';
+  if (!index.includes(blogCta)) {
+    throw new Error(
+      `[create-litro] Expected a /blog link in pages/index.ts to rewrite. The ` +
+        `starlight template changed shape; update unlinkBlogReferences().`,
+    );
+  }
+  if (repo.repoUrl) {
+    index = index.replace(blogCta, `<a href="${repo.repoUrl}"`).replace('">Blog</a>', '">GitHub</a>');
+  } else {
+    // No remote to point at, so drop the second call to action entirely
+    // rather than leaving a button that goes nowhere.
+    index = index.replace(/\s*<a href="\/blog"[\s\S]*?">Blog<\/a>/, '');
+  }
+
+  // The "Blog" feature card advertises a section that no longer exists.
+  index = index.replace(
+    /\s*\{\s*icon: '[^']*',\s*title: 'Blog',[\s\S]*?\},/,
+    '',
+  );
+  await writeFile(indexPath, index, 'utf-8');
+
+  // Point the generated e2e spec at the routes that actually exist.
+  const specPath = join(siteDir, 'e2e/index.spec.ts');
+  if (existsSync(specPath)) {
+    const spec = await readFile(specPath, 'utf-8');
+    const routes = [
+      "const PRERENDERED_ROUTES = [",
+      "  '/',",
+      "  '/docs/getting-started',",
+      "];",
+    ].join('\n');
+    const replaced = spec.replace(/const PRERENDERED_ROUTES = \[[\s\S]*?\];/, routes);
+    if (replaced === spec) {
+      throw new Error(
+        `[create-litro] Expected PRERENDERED_ROUTES in e2e/index.spec.ts to rewrite.`,
+      );
+    }
+    await writeFile(specPath, replaced, 'utf-8');
+  }
+}
+
+/** Apply everything derivable from the repo to a freshly scaffolded site. */
+export async function applyForRepo(options: ForRepoOptions): Promise<RepoInfo> {
+  const repo = await detectRepo(options.repoDir);
+  const { siteDir, siteRelPath } = options;
+  const siteUrl = options.siteUrl ?? '';
+
+  await writeFile(join(siteDir, '_data/metadata.js'), renderMetadata(repo, siteUrl), 'utf-8');
+  await writeFile(
+    join(siteDir, 'server/starlight.config.js'),
+    renderStarlightConfig(repo, siteRelPath),
+    'utf-8',
+  );
+
+  // Replace the recipe's Litro-specific sample pages with one honest starter.
+  const docsDir = join(siteDir, 'content/docs');
+  await rm(docsDir, { recursive: true, force: true });
+  await mkdir(docsDir, { recursive: true });
+  await writeFile(join(docsDir, 'getting-started.md'), renderStarterPage(repo), 'utf-8');
+  await writeFile(join(docsDir, '.11tydata.json'), '{ "section": "docs" }\n', 'utf-8');
+
+  if (!options.withBlog) {
+    await rm(join(siteDir, 'content/blog'), { recursive: true, force: true });
+    await rm(join(siteDir, 'pages/blog'), { recursive: true, force: true });
+    // Deleting the pages is not enough: the landing page links to /blog and
+    // the generated e2e spec asserts the blog routes return 200. Left alone,
+    // a brand-new site ships a dead link and a failing test suite.
+    await unlinkBlogReferences(siteDir, repo);
+  }
+
+  const pkgPath = join(siteDir, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+  pkg.name = `${repo.name}-docs`;
+
+  // Pin the package manager to the one running now. Without this, corepack in
+  // the Docker build resolves "pnpm" to the newest release rather than the one
+  // that produced the lockfile -- which fails outright when the two disagree
+  // about lockfile format or policy (pnpm 11 rejects recently-published
+  // versions by default, so an install that works locally dies in the image).
+  const pnpmVersion = tryExec('pnpm', ['--version'], siteDir);
+  if (/^\d+\.\d+\.\d+/.test(pnpmVersion)) {
+    pkg.packageManager = `pnpm@${pnpmVersion}`;
+  }
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
+
+  if (options.deploy === 'docker') {
+    await writeFile(join(siteDir, 'Dockerfile'), renderDockerfile(), 'utf-8');
+    await writeFile(join(siteDir, 'nginx.conf'), renderNginxConf(), 'utf-8');
+    await writeFile(join(siteDir, '.dockerignore'), renderDockerignore(), 'utf-8');
+  }
+
+  await writeFile(
+    join(siteDir, 'AGENTS.md'),
+    renderAgentsMd(repo, siteUrl, siteRelPath),
+    'utf-8',
+  );
+
+  return repo;
+}

--- a/packages/create-litro/src/index.ts
+++ b/packages/create-litro/src/index.ts
@@ -6,6 +6,17 @@
  *   npm create @beatzball/litro
  *   npx @beatzball/create-litro
  *   npx @beatzball/create-litro <project-name> [--recipe <recipe>] [--mode <ssg|ssr>] [--adapter <lit|fast|elena>]
+ *
+ * Documentation site for an existing repository:
+ *   npx @beatzball/create-litro site --recipe starlight --for-repo . \
+ *     --site-url https://example.dev
+ *
+ *   --for-repo <dir>   read the repo's name, description, remote and default
+ *                      branch, then write metadata, the starlight config,
+ *                      a deploy (Dockerfile + nginx.conf) and an AGENTS.md
+ *   --site-url <url>   canonical URL the site is served from
+ *   --deploy <docker|none>   deploy files to emit (default: docker)
+ *   --with-blog        keep the recipe's sample blog (default: removed)
  *   npx @beatzball/create-litro --list-recipes
  *
  * Prompts for project name, recipe, and mode, then scaffolds a complete
@@ -20,6 +31,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import process from 'node:process';
 import { listRecipes, loadRecipe, scaffold } from './scaffold.js';
+import { applyForRepo } from './for-repo.js';
 import type { LitroRecipe } from './types.js';
 import type { ScaffoldOptions } from './scaffold.js';
 
@@ -78,6 +90,11 @@ interface ParsedArgs {
   mode: 'ssg' | 'ssr' | undefined;
   adapter: 'lit' | 'fast' | 'elena' | undefined;
   listRecipes: boolean;
+  /** Repository the docs are for; enables --for-repo post-processing. */
+  forRepo: string | undefined;
+  siteUrl: string | undefined;
+  deploy: 'docker' | 'none';
+  withBlog: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -87,6 +104,10 @@ function parseArgs(argv: string[]): ParsedArgs {
   let mode: 'ssg' | 'ssr' | undefined;
   let adapter: 'lit' | 'fast' | 'elena' | undefined;
   let listRecipesFlag = false;
+  let forRepo: string | undefined;
+  let siteUrl: string | undefined;
+  let deploy: 'docker' | 'none' = 'docker';
+  let withBlog = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -100,12 +121,28 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === '--adapter' || arg === '-a') {
       const val = argv[++i];
       if (val === 'lit' || val === 'fast' || val === 'elena') adapter = val;
+    } else if (arg === '--for-repo') {
+      forRepo = argv[++i] ?? '.';
+    } else if (arg.startsWith('--for-repo=')) {
+      forRepo = arg.slice('--for-repo='.length);
+    } else if (arg === '--site-url') {
+      siteUrl = argv[++i];
+    } else if (arg.startsWith('--site-url=')) {
+      siteUrl = arg.slice('--site-url='.length);
+    } else if (arg === '--deploy') {
+      const val = argv[++i];
+      if (val === 'docker' || val === 'none') deploy = val;
+    } else if (arg === '--with-blog') {
+      withBlog = true;
     } else if (!arg.startsWith('-') && projectName === undefined) {
       projectName = arg;
     }
   }
 
-  return { projectName, recipe, mode, adapter, listRecipes: listRecipesFlag };
+  return {
+    projectName, recipe, mode, adapter, listRecipes: listRecipesFlag,
+    forRepo, siteUrl, deploy, withBlog,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -226,8 +263,43 @@ async function main(): Promise<void> {
 
   await scaffold(chosenRecipe.name, options, projectDir);
 
+  // --for-repo turns the generic recipe output into *this project's* docs
+  // site. Only the starlight recipe produces a docs site, so refuse loudly
+  // rather than half-applying to a template with no content/docs.
+  let forRepoSummary = '';
+  if (args.forRepo !== undefined) {
+    if (chosenRecipe.name !== 'starlight') {
+      console.error(
+        `\n  --for-repo builds a documentation site, which only the ` +
+          `'starlight' recipe provides.\n  Got '${chosenRecipe.name}'. ` +
+          `Re-run with --recipe starlight.\n`,
+      );
+      process.exit(1);
+    }
+    const { relative, resolve: resolvePath } = await import('node:path');
+    const repoDir = resolvePath(args.forRepo);
+    const siteRelPath = relative(repoDir, projectDir) || projectName;
+
+    const repo = await applyForRepo({
+      repoDir,
+      siteDir: projectDir,
+      siteUrl: args.siteUrl,
+      siteRelPath,
+      deploy: args.deploy,
+      withBlog: args.withBlog,
+    });
+
+    forRepoSummary =
+      `\n  Shaped for ${repo.name}` +
+      (repo.repoUrl ? ` (${repo.repoUrl})` : ' (no git remote found)') +
+      (args.siteUrl ? `\n  Site URL: ${args.siteUrl}` : '') +
+      (repo.description ? '' : '\n  No description found — set one in _data/metadata.js.') +
+      (args.siteUrl ? '' : '\n  No --site-url given — set `url` in _data/metadata.js.') +
+      `\n  Wrote AGENTS.md — point your coding agent at it before editing pages.`;
+  }
+
   console.log(`
-  Created ${projectName}
+  Created ${projectName}${forRepoSummary}
 
   Next steps:
 


### PR DESCRIPTION
Second half of the `litro docs` tooling. PR 122 shipped the commands that
operate on an existing site; this is the one that creates it.

```sh
npm create @beatzball/litro@latest -- site \
  --recipe starlight --for-repo . --site-url https://example.dev
```

## What it derives from the repository

The starlight recipe produces a generic site: placeholder title, example URL, a
sample blog, and a sidebar of pages about Litro itself. Pointing it at a real
project meant a dozen mechanical edits, done from memory each time.

`--for-repo` reads the repo's name, description, remote and default branch, then
writes `_data/metadata.js`, `server/starlight.config.js` (title, nav with a
GitHub link, "Edit this page" links aimed at the right branch and
subdirectory), a `Dockerfile` + `nginx.conf` deploy, and an `AGENTS.md`.

**It does not write your documentation.** Turning a README into good pages is a
judgement call. It leaves one honest placeholder page and points the agent at
`AGENTS.md` — a scaffolder that emits plausible-looking prose invites shipping
text nobody wrote.

## Two bugs that only surfaced by running it

Both were found by generating a site against a throwaway clone of a real repo
and then actually building it — neither is visible from unit tests on the
renderers.

**1. Removing the blog left dead references.** Deleting `pages/blog` is not
enough: the landing page linked to `/blog`, and the generated e2e spec asserted
the blog routes returned 200. A brand-new site shipped a dead link *and* a
failing test suite. Both are rewritten now, and each edit asserts its target
exists so a reshaped template fails loudly here rather than emitting a broken
site.

**2. The generated Dockerfile did not build.** Without a `packageManager`
field, corepack resolved the newest pnpm (11) instead of the one that wrote the
lockfile, and pnpm 11's minimum-release-age policy then rejected the
dependencies:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 3 lockfile entries failed verification
```

`packageManager` is now pinned to the pnpm that ran the scaffold.

## Degrades rather than fails

With no git remote it falls back to the directory name, sets `editUrlBase:
null`, omits the GitHub nav entry and the second call to action, and prints
what still needs filling in. No network and no `gh` required. Verified against
a bare `git init` directory — it builds.

## Verified end to end

Against a throwaway clone of a real repository (never the working copy):

- Site generates; the ssh host alias in the remote is normalised to the real
  host, so no local alias leaks into public "Edit this page" links.
- `litro docs check` passes on the generated site immediately, and
  `litro docs sync` is a no-op — the two halves compose.
- The full loop works: add a page → `check` fails → `sync` → `check` passes →
  build (6 routes).
- The emitted `Dockerfile` builds an image that serves `/` and
  `/docs/getting-started` as 200 and an unknown path as 404.
- The no-remote path builds too.

## Validation

framework 443 · router 29 · create-litro 34 (11 new, incl. 5 integration tests
covering the two bugs above) · docs 104 · e2e 186/186 · doc-refs green ·
scaffolded-apps guard 6/6.
