### PR TITLE
feat(create-litro): credit line in every scaffolded site

### DIFF
--- a/.changeset/create-litro-footer.md
+++ b/.changeset/create-litro-footer.md
@@ -1,0 +1,27 @@
+---
+'@beatzball/create-litro': minor
+---
+
+Add a "Created using Litro" credit line to every scaffolded site.
+
+A new `<litro-footer>` component ships in all three recipes and all three
+adapters — Lit, FAST and Elena — and names the recipe the project came from:
+"Created using Litro, starlight recipe", linking to litro.dev. It is a quiet
+line at the bottom of the page and a comment above it says how to remove it.
+
+The starlight recipe places it in the shared `starlight-page` layout, so docs,
+blog and tag pages all get it from one place, plus the splash page which does
+not use that layout. The fullstack and 11ty-blog recipes have no shared layout,
+so each page places it directly.
+
+Scaffolding now interpolates `{{recipe}}`, which is what lets one component
+file name the recipe it was scaffolded into.
+
+FAST needs a property binding rather than a plain attribute at the usage site:
+fast-ssr does not map attributes onto properties, so `recipe="starlight"`
+server-renders the credit without the recipe name. Measured, not assumed.
+
+`scripts/verify-scaffolded-apps.mjs` now asserts the credit survives to
+rendered output for all six variants, reading the prerendered HTML where the
+recipe prerenders and the server bundle where it does not. That check is what
+caught the FAST problem, which compiled and built cleanly.

--- a/packages/create-litro/recipes/11ty-blog/template/pages/blog/[slug].ts
+++ b/packages/create-litro/recipes/11ty-blog/template/pages/blog/[slug].ts
@@ -6,6 +6,7 @@ import { definePageData } from '@beatzball/litro';
 import { createError } from 'h3';
 import type { Post } from 'litro:content';
 import { getPost, getPosts } from 'litro:content';
+import '../../src/components/litro-footer.js';
 
 export interface PostData {
   post: Post;
@@ -58,6 +59,8 @@ export class BlogPostPage extends LitroPage {
           <a href="/blog">← Back to Blog</a>
         </footer>
       </article>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/11ty-blog/template/pages/blog/index.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/pages/blog/index.ts
@@ -4,6 +4,7 @@ import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 import type { Post } from 'litro:content';
 import { getPosts } from 'litro:content';
+import '../../src/components/litro-footer.js';
 
 export interface BlogIndexData {
   posts: Post[];
@@ -36,6 +37,8 @@ export class BlogIndexPage extends LitroPage {
         </ul>
         <a href="/">← Home</a>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/11ty-blog/template/pages/index.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/pages/index.ts
@@ -4,6 +4,7 @@ import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 import type { Post } from 'litro:content';
 import { getPosts, getGlobalData } from 'litro:content';
+import '../src/components/litro-footer.js';
 
 export interface HomeData {
   recentPosts: Post[];
@@ -51,6 +52,8 @@ export class HomePage extends LitroPage {
           <p><a href="/blog">All Posts →</a></p>
         </section>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/11ty-blog/template/pages/tags/[tag].ts
+++ b/packages/create-litro/recipes/11ty-blog/template/pages/tags/[tag].ts
@@ -4,6 +4,7 @@ import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 import type { Post } from 'litro:content';
 import { getPosts, getTags } from 'litro:content';
+import '../../src/components/litro-footer.js';
 
 export interface TagData {
   tag: string;
@@ -46,6 +47,8 @@ export class TagPage extends LitroPage {
           <a href="/">← Home</a>
         </p>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/11ty-blog/template/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/11ty-blog/template/src/components/litro-footer.ts
@@ -1,0 +1,66 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ */
+@customElement('litro-footer')
+export class LitroFooter extends LitElement {
+  static override properties = {
+    recipe: { type: String },
+  };
+
+  /* Falls back to plain greys so this looks right in a recipe that defines no
+     --sl-* design tokens, and picks them up automatically in one that does. */
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    footer {
+      border-top: 1px solid var(--sl-color-border, #e5e5e5);
+      padding: 1.5rem;
+      text-align: center;
+      font-size: var(--sl-text-sm, 0.875rem);
+      color: var(--sl-color-gray-4, #6b7280);
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    a:hover {
+      color: var(--sl-color-accent, #7c3aed);
+    }
+
+    .recipe {
+      white-space: nowrap;
+    }
+  `;
+
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+
+  override render() {
+    return html`
+      <footer>
+        Created using
+        <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a>${this
+          .recipe
+          ? html`<span class="recipe">, ${this.recipe} recipe</span>`
+          : ''}
+      </footer>
+    `;
+  }
+}
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/fullstack/template-elena/pages/blog/[slug].ts
+++ b/packages/create-litro/recipes/fullstack/template-elena/pages/blog/[slug].ts
@@ -2,6 +2,9 @@ import { html } from '@elenajs/core';
 import { LitroPage } from '@beatzball/litro/adapter/elena/page';
 import { definePageData } from '@beatzball/litro';
 import type { LitroLocation } from '@beatzball/litro-router';
+// Re-exported, not bare-imported: Rollup drops a bare side-effect import,
+// which would drop .define() and leave <litro-footer> unexpanded in SSR.
+export { LitroFooter } from '../../src/components/litro-footer.js';
 
 export interface PostData {
   slug: string;
@@ -47,6 +50,8 @@ export class BlogPostPage extends LitroPage {
         \u00a0|\u00a0
         <litro-link href="/">\u2190 Home</litro-link>
       </article>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template-elena/pages/blog/index.ts
+++ b/packages/create-litro/recipes/fullstack/template-elena/pages/blog/index.ts
@@ -1,4 +1,7 @@
 import { Elena, html } from '@elenajs/core';
+// Re-exported, not bare-imported: Rollup drops a bare side-effect import,
+// which would drop .define() and leave <litro-footer> unexpanded in SSR.
+export { LitroFooter } from '../../src/components/litro-footer.js';
 
 export class BlogPage extends Elena(HTMLElement) {
   static tagName = 'page-blog';
@@ -15,6 +18,8 @@ export class BlogPage extends Elena(HTMLElement) {
         </ul>
         <litro-link href="/">\u2190 Back Home</litro-link>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template-elena/pages/index.ts
+++ b/packages/create-litro/recipes/fullstack/template-elena/pages/index.ts
@@ -1,6 +1,9 @@
 import { html } from '@elenajs/core';
 import { LitroPage } from '@beatzball/litro/adapter/elena/page';
 import { definePageData } from '@beatzball/litro';
+// Re-exported, not bare-imported: Rollup drops a bare side-effect import,
+// which would drop .define() and leave <litro-footer> unexpanded in SSR.
+export { LitroFooter } from '../src/components/litro-footer.js';
 
 export interface HomeData {
   message: string;
@@ -35,6 +38,8 @@ export class HomePage extends LitroPage {
           <litro-link href="/blog">Go to Blog \u2192</litro-link>
         </nav>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template-elena/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/fullstack/template-elena/src/components/litro-footer.ts
@@ -1,0 +1,67 @@
+import { Elena, html } from '@elenajs/core';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ *
+ * Elena renders into the light DOM, so the styles are @scope-d to the tag
+ * rather than isolated by a shadow root, and :scope stands in for :host.
+ */
+export class LitroFooter extends Elena(HTMLElement) {
+  static tagName = 'litro-footer';
+  // Lowercase, because HTML parsers lowercase attribute names — a camelCase
+  // prop would never bind from markup.
+  static props = ['recipe'];
+
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+
+  render() {
+    // A plain string, not a nested template: Elena escapes interpolations, so
+    // markup passed through here would be shown rather than rendered.
+    const suffix = this.recipe ? `, ${this.recipe} recipe` : '';
+    return html`
+      <style>
+        @scope (litro-footer) {
+          /* Falls back to plain greys so this looks right in a recipe that
+             defines no --sl-* design tokens, and picks them up in one that does. */
+          :scope {
+            display: block;
+          }
+          footer {
+            border-top: 1px solid var(--sl-color-border, #e5e5e5);
+            padding: 1.5rem;
+            text-align: center;
+            font-size: var(--sl-text-sm, 0.875rem);
+            color: var(--sl-color-gray-4, #6b7280);
+          }
+          a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+          a:hover {
+            color: var(--sl-color-accent, #7c3aed);
+          }
+          .recipe {
+            white-space: nowrap;
+          }
+        }
+      </style>
+      <footer>
+        Created using
+        <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a><span class="recipe">${suffix}</span>
+      </footer>
+    `;
+  }
+}
+
+LitroFooter.define();
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/blog/[slug].ts
@@ -3,6 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import { LitroPage } from '@beatzball/litro/runtime';
 import { definePageData } from '@beatzball/litro';
 import type { LitroLocation } from '@beatzball/litro-router';
+import '../../src/components/litro-footer.js';
 
 export interface PostData {
   slug: string;
@@ -47,6 +48,8 @@ export class BlogPostPage extends LitroPage {
         &nbsp;|&nbsp;
         <litro-link href="/">← Home</litro-link>
       </article>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template/pages/blog/index.ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/blog/index.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import '../../src/components/litro-footer.js';
 
 @customElement('page-blog')
 export class BlogPage extends LitElement {
@@ -15,6 +16,8 @@ export class BlogPage extends LitElement {
         </ul>
         <litro-link href="/">← Back Home</litro-link>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template/pages/index.ts
+++ b/packages/create-litro/recipes/fullstack/template/pages/index.ts
@@ -5,6 +5,7 @@ import { definePageData } from '@beatzball/litro';
 import { actionUrl } from '@beatzball/litro/actions/client';
 import { enhanceForms } from '@beatzball/litro/actions/form-client';
 import { greet } from '../actions/demo.server.js';
+import '../src/components/litro-footer.js';
 
 export interface HomeData {
   message: string;
@@ -62,6 +63,8 @@ export class HomePage extends LitroPage {
           <litro-link href="/blog">Go to Blog →</litro-link>
         </nav>
       </main>
+      <!-- Credit line. Delete this element if you would rather not carry it. -->
+      <litro-footer recipe="{{recipe}}"></litro-footer>
     `;
   }
 }

--- a/packages/create-litro/recipes/fullstack/template/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/fullstack/template/src/components/litro-footer.ts
@@ -1,0 +1,66 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ */
+@customElement('litro-footer')
+export class LitroFooter extends LitElement {
+  static override properties = {
+    recipe: { type: String },
+  };
+
+  /* Falls back to plain greys so this looks right in a recipe that defines no
+     --sl-* design tokens, and picks them up automatically in one that does. */
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    footer {
+      border-top: 1px solid var(--sl-color-border, #e5e5e5);
+      padding: 1.5rem;
+      text-align: center;
+      font-size: var(--sl-text-sm, 0.875rem);
+      color: var(--sl-color-gray-4, #6b7280);
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    a:hover {
+      color: var(--sl-color-accent, #7c3aed);
+    }
+
+    .recipe {
+      white-space: nowrap;
+    }
+  `;
+
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+
+  override render() {
+    return html`
+      <footer>
+        Created using
+        <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a>${this
+          .recipe
+          ? html`<span class="recipe">, ${this.recipe} recipe</span>`
+          : ''}
+      </footer>
+    `;
+  }
+}
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/starlight/template-elena/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/starlight/template-elena/src/components/litro-footer.ts
@@ -1,0 +1,67 @@
+import { Elena, html } from '@elenajs/core';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ *
+ * Elena renders into the light DOM, so the styles are @scope-d to the tag
+ * rather than isolated by a shadow root, and :scope stands in for :host.
+ */
+export class LitroFooter extends Elena(HTMLElement) {
+  static tagName = 'litro-footer';
+  // Lowercase, because HTML parsers lowercase attribute names — a camelCase
+  // prop would never bind from markup.
+  static props = ['recipe'];
+
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+
+  render() {
+    // A plain string, not a nested template: Elena escapes interpolations, so
+    // markup passed through here would be shown rather than rendered.
+    const suffix = this.recipe ? `, ${this.recipe} recipe` : '';
+    return html`
+      <style>
+        @scope (litro-footer) {
+          /* Falls back to plain greys so this looks right in a recipe that
+             defines no --sl-* design tokens, and picks them up in one that does. */
+          :scope {
+            display: block;
+          }
+          footer {
+            border-top: 1px solid var(--sl-color-border, #e5e5e5);
+            padding: 1.5rem;
+            text-align: center;
+            font-size: var(--sl-text-sm, 0.875rem);
+            color: var(--sl-color-gray-4, #6b7280);
+          }
+          a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+          }
+          a:hover {
+            color: var(--sl-color-accent, #7c3aed);
+          }
+          .recipe {
+            white-space: nowrap;
+          }
+        }
+      </style>
+      <footer>
+        Created using
+        <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a><span class="recipe">${suffix}</span>
+      </footer>
+    `;
+  }
+}
+
+LitroFooter.define();
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/starlight/template-elena/src/components/starlight-page.ts
+++ b/packages/create-litro/recipes/starlight/template-elena/src/components/starlight-page.ts
@@ -7,6 +7,7 @@ import type { TocEntry } from '../extract-headings.js';
 import './starlight-header.js';
 import './starlight-sidebar.js';
 import './starlight-toc.js';
+import './litro-footer.js';
 
 /**
  * <starlight-page sitetitle="My Docs" pagetitle="Getting Started" ...>
@@ -249,6 +250,8 @@ export class StarlightPage extends Elena(HTMLElement) {
           </main>
           ${unsafeHTML(tocHtml)}
         </div>
+        <!-- Credit line. Delete this element if you would rather not carry it. -->
+        <litro-footer recipe="{{recipe}}"></litro-footer>
       </div>
     `;
   }

--- a/packages/create-litro/recipes/starlight/template-fast/pages/index.ts
+++ b/packages/create-litro/recipes/starlight/template-fast/pages/index.ts
@@ -9,7 +9,8 @@ import { starlightHead } from '../src/route-meta.js';
 import * as _starlightHeader from '../src/components/starlight-header.js';
 import * as _litroCard from '../src/components/litro-card.js';
 import * as _litroCardGrid from '../src/components/litro-card-grid.js';
-globalThis.__litro_ce__ = { ...(globalThis as any).__litro_ce__, _starlightHeader, _litroCard, _litroCardGrid };
+import * as _litroFooter from '../src/components/litro-footer.js';
+globalThis.__litro_ce__ = { ...(globalThis as any).__litro_ce__, _starlightHeader, _litroCard, _litroCardGrid, _litroFooter };
 
 export interface SplashData {
   siteTitle: string;
@@ -93,6 +94,10 @@ const template = html<SplashPage>`
             </litro-card-grid>
           </section>
         </main>
+        <!-- Credit line. Delete this element if you would rather not carry it.
+         A property binding, not a plain attribute: fast-ssr does not map
+         attributes onto properties, so recipe="..." renders as empty. -->
+        <litro-footer :recipe="${() => '{{recipe}}'}"></litro-footer>
       </div>
     `;
   }}

--- a/packages/create-litro/recipes/starlight/template-fast/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/starlight/template-fast/src/components/litro-footer.ts
@@ -1,0 +1,73 @@
+import { FASTElement, html, css, when } from '@microsoft/fast-element';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ */
+export class LitroFooter extends FASTElement {
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+}
+
+// when() rather than a ternary. Both render correctly under fast-ssr; this is
+// the form the other components in this template use, so it stays consistent.
+const template = html<LitroFooter>`
+  <footer>
+    Created using
+    <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a>${when(
+      x => x.recipe,
+      html<LitroFooter>`<span class="recipe">, ${x => x.recipe} recipe</span>`,
+    )}
+  </footer>
+`;
+
+/* Falls back to plain greys so this looks right in a recipe that defines no
+   --sl-* design tokens, and picks them up automatically in one that does. */
+const styles = css`
+  :host {
+    display: block;
+  }
+
+  footer {
+    border-top: 1px solid var(--sl-color-border, #e5e5e5);
+    padding: 1.5rem;
+    text-align: center;
+    font-size: var(--sl-text-sm, 0.875rem);
+    color: var(--sl-color-gray-4, #6b7280);
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  a:hover {
+    color: var(--sl-color-accent, #7c3aed);
+  }
+
+  .recipe {
+    white-space: nowrap;
+  }
+`;
+
+// `attributes` declares `recipe` as a real HTML attribute, which also makes it
+// observable — so no separate Observable.defineProperty is needed.
+//
+// It does NOT make `recipe="..."` work during SSR: fast-ssr does not map
+// attributes onto properties, so the pages bind the property directly
+// (:recipe="${() => '...'}"). Measured — with a plain attribute the credit
+// renders without the recipe name. The declaration is still worth having: it
+// makes the element behave as expected if someone hand-writes it in a browser.
+//
+// Declared here rather than with @attr, because this file is loaded by jiti
+// during the page scan, where the decorator does not apply.
+LitroFooter.define({ name: 'litro-footer', template, styles, attributes: ['recipe'] });
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/starlight/template-fast/src/components/starlight-page.ts
+++ b/packages/create-litro/recipes/starlight/template-fast/src/components/starlight-page.ts
@@ -7,6 +7,7 @@ import type { TocEntry } from '../extract-headings.js';
 import './starlight-header.js';
 import './starlight-sidebar.js';
 import './starlight-toc.js';
+import './litro-footer.js';
 
 /**
  * <starlight-page
@@ -92,6 +93,10 @@ const template = html<StarlightPage>`
         </aside>
       `)}
     </div>
+    <!-- Credit line. Delete this element if you would rather not carry it.
+         A property binding, not a plain attribute: fast-ssr does not map
+         attributes onto properties, so recipe="..." renders as empty. -->
+    <litro-footer :recipe="${() => '{{recipe}}'}"></litro-footer>
   </div>
 `;
 

--- a/packages/create-litro/recipes/starlight/template/pages/index.ts
+++ b/packages/create-litro/recipes/starlight/template/pages/index.ts
@@ -8,6 +8,7 @@ import { starlightHead } from '../src/route-meta.js';
 
 // Register components used in render()
 import '../src/components/starlight-header.js';
+import '../src/components/litro-footer.js';
 import '../src/components/litro-card.js';
 import '../src/components/litro-card-grid.js';
 
@@ -127,6 +128,8 @@ export class SplashPage extends LitroPage {
             </litro-card-grid>
           </section>
         </main>
+        <!-- Credit line. Delete this element if you would rather not carry it. -->
+        <litro-footer recipe="{{recipe}}"></litro-footer>
       </div>
     `;
   }

--- a/packages/create-litro/recipes/starlight/template/src/components/litro-footer.ts
+++ b/packages/create-litro/recipes/starlight/template/src/components/litro-footer.ts
@@ -1,0 +1,66 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * <litro-footer recipe="starlight"></litro-footer>
+ *
+ * Credits the framework this project was scaffolded with. The `recipe` value
+ * is filled in at scaffold time by create-litro.
+ *
+ * Deliberately quiet: a credit line belongs at the bottom of the page and
+ * should be findable, not compete with the content above it. Delete the
+ * element from your pages if you would rather not carry it.
+ */
+@customElement('litro-footer')
+export class LitroFooter extends LitElement {
+  static override properties = {
+    recipe: { type: String },
+  };
+
+  /* Falls back to plain greys so this looks right in a recipe that defines no
+     --sl-* design tokens, and picks them up automatically in one that does. */
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    footer {
+      border-top: 1px solid var(--sl-color-border, #e5e5e5);
+      padding: 1.5rem;
+      text-align: center;
+      font-size: var(--sl-text-sm, 0.875rem);
+      color: var(--sl-color-gray-4, #6b7280);
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    a:hover {
+      color: var(--sl-color-accent, #7c3aed);
+    }
+
+    .recipe {
+      white-space: nowrap;
+    }
+  `;
+
+  /** Recipe this project was scaffolded from, e.g. "starlight". */
+  recipe = '';
+
+  override render() {
+    return html`
+      <footer>
+        Created using
+        <a href="https://litro.dev" target="_blank" rel="noopener">Litro</a>${this
+          .recipe
+          ? html`<span class="recipe">, ${this.recipe} recipe</span>`
+          : ''}
+      </footer>
+    `;
+  }
+}
+
+export default LitroFooter;

--- a/packages/create-litro/recipes/starlight/template/src/components/starlight-page.ts
+++ b/packages/create-litro/recipes/starlight/template/src/components/starlight-page.ts
@@ -8,6 +8,7 @@ import type { TocEntry } from '../extract-headings.js';
 import './starlight-header.js';
 import './starlight-sidebar.js';
 import './starlight-toc.js';
+import './litro-footer.js';
 
 /**
  * <starlight-page
@@ -208,6 +209,8 @@ export class StarlightPage extends LitElement {
             </aside>
           ` : ''}
         </div>
+        <!-- Credit line. Delete this element if you would rather not carry it. -->
+        <litro-footer recipe="{{recipe}}"></litro-footer>
       </div>
     `;
   }

--- a/packages/create-litro/src/scaffold.test.ts
+++ b/packages/create-litro/src/scaffold.test.ts
@@ -145,6 +145,31 @@ describe('scaffold', () => {
     });
   });
 
+  it('{{recipe}} resolves to the recipe being scaffolded, in every recipe', async () => {
+    // The credit line in <litro-footer> is the same source file in all three
+    // recipes, so it cannot name its own recipe — the scaffolder has to supply
+    // it. A wrong or empty value here would ship a site crediting the wrong
+    // recipe, which nothing else in the suite would notice.
+    for (const recipe of ['fullstack', '11ty-blog', 'starlight'] as const) {
+      await withTmpDir(async (dir) => {
+        const targetDir = join(dir, 'app');
+        await scaffold(recipe, { projectName: 'app', mode: 'ssg' }, targetDir);
+        const footer = await readFile(
+          join(targetDir, 'src/components/litro-footer.ts'),
+          'utf-8',
+        );
+        expect(footer).toContain('https://litro.dev');
+
+        // The value lands at the USAGE site, not in the component.
+        // Exact, not just "the word appears somewhere": a recipe name can
+        // occur incidentally in a page, which would make this pass vacuously.
+        const home = await readFile(join(targetDir, 'pages/index.ts'), 'utf-8');
+        expect(home).toContain(`<litro-footer recipe="${recipe}">`);
+        expect(home).not.toContain('{{recipe}}');
+      });
+    }
+  });
+
   it('templates store the ignore file under an npm-safe name', async () => {
     // npm removes `.gitignore` from every tarball it publishes, with no way to
     // opt out. A template that stores the dotfile directly works from a local

--- a/packages/create-litro/src/scaffold.ts
+++ b/packages/create-litro/src/scaffold.ts
@@ -68,12 +68,17 @@ function interpolate(text: string, vars: Record<string, string>): string {
 
 /**
  * Build the interpolation variable map from ScaffoldOptions.
+ *
+ * `recipe` is the recipe directory name. Templates use it for the credit line
+ * in <litro-footer>, which is the same file in every recipe and so cannot
+ * hardcode which recipe it came from.
  */
-function buildVars(options: ScaffoldOptions): Record<string, string> {
+function buildVars(options: ScaffoldOptions, recipeName: string): Record<string, string> {
   const vars: Record<string, string> = {
     projectName: options.projectName,
     mode: options.mode,
     adapter: options.adapter ?? 'lit',
+    recipe: recipeName,
     recipeVersion: options.recipeVersion ?? '0.0.0',
   };
 
@@ -217,7 +222,7 @@ export async function scaffold(
   await mkdir(targetDir, { recursive: true });
 
   // Build interpolation variables and copy all files.
-  const vars = buildVars(options);
+  const vars = buildVars(options, recipeName);
   await copyTemplate(templateDir, targetDir, vars);
 
   // Per-adapter overlay: if a template-<adapter>/ directory exists alongside

--- a/scripts/verify-scaffolded-apps.mjs
+++ b/scripts/verify-scaffolded-apps.mjs
@@ -30,7 +30,7 @@
  *   node scripts/verify-scaffolded-apps.mjs --only starlight:lit
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -66,6 +66,28 @@ const SCAFFOLDER = { name: '@beatzball/create-litro', dir: 'packages/create-litr
 
 const args = process.argv.slice(2);
 const keep = args.includes('--keep');
+
+/**
+ * True when any file under `dir` contains `needle`. Small recursive search
+ * rather than a shell grep, so this script keeps working the same way on any
+ * platform and stays dependency-free.
+ */
+function grepDir(dir, needle) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (grepDir(full, needle)) return true;
+    } else if (entry.isFile()) {
+      try {
+        if (readFileSync(full, 'utf-8').includes(needle)) return true;
+      } catch {
+        // Unreadable or binary — nothing to match in it.
+      }
+    }
+  }
+  return false;
+}
+
 const onlyIdx = args.indexOf('--only');
 const only = onlyIdx !== -1 ? args[onlyIdx + 1] : null;
 
@@ -202,6 +224,61 @@ for (const { recipe, adapter } of VARIANTS) {
         'the site is blank in a browser.\n' + step.error,
     });
     continue;
+  }
+
+  // The credit line must survive to rendered HTML, not merely compile. Three
+  // things can silently drop it and still exit 0: Rollup tree-shaking the
+  // component's registration, an adapter failing to expand an unregistered
+  // element during SSR, and a page that imports it but never places it.
+  //
+  // A fourth is subtler and is why this reads the OUTPUT rather than trusting
+  // the source: under fast-ssr a binding that returns a nested template is
+  // simply not rendered, so the recipe name vanished from FAST's HTML while
+  // the component looked correct.
+  //
+  // Only the starlight recipe prerenders during `pnpm build`. fullstack and
+  // 11ty-blog choose their mode from LITRO_MODE at build time and default to
+  // a server build, so for those the server bundle is the thing to inspect;
+  // that still catches tree-shaking, which is the failure that actually bites.
+  const home = join(dir, 'dist/static/index.html');
+  const wantRecipe = `${recipe} recipe`;
+  if (existsSync(home)) {
+    // Lit's SSR writes <!--lit-part--> markers between static text and a
+    // binding, which splits "starlight recipe" apart. Strip comments first so
+    // the assertion tests the rendered TEXT, not one framework's marker style.
+    const rendered = readFileSync(home, 'utf-8').replace(/<!--.*?-->/gs, '');
+    const missing = ['Created using', 'https://litro.dev', wantRecipe].filter(
+      (want) => !rendered.includes(want),
+    );
+    if (missing.length > 0) {
+      results.push({
+        id,
+        status: 'NO-CREDIT',
+        detail:
+          `The prerendered home page is missing part of the <litro-footer> ` +
+          `credit line: ${missing.map((m) => JSON.stringify(m)).join(', ')}.\n` +
+          `An empty <litro-footer> element means its registration was ` +
+          `tree-shaken and SSR could not expand it. A rendered footer that is ` +
+          `missing only the recipe name means the conditional binding did not ` +
+          `survive server rendering. No element at all means the page template ` +
+          `does not place it.`,
+      });
+      continue;
+    }
+  } else {
+    const serverDir = join(dir, 'dist/server');
+    const found = existsSync(serverDir) && grepDir(serverDir, 'Created using');
+    if (!found) {
+      results.push({
+        id,
+        status: 'NO-CREDIT',
+        detail:
+          `This variant builds a server rather than prerendering, and the ` +
+          `credit line is absent from ${serverDir}. The component was almost ` +
+          `certainly tree-shaken out of the SSR module graph.`,
+      });
+      continue;
+    }
   }
 
   results.push({ id, status: 'OK' });


### PR DESCRIPTION
Scaffolded sites had no indication of what built them.

A new `<litro-footer>` ships in all three recipes and all three adapters, rendering a quiet line at the bottom of the page:

> Created using [Litro](https://litro.dev), starlight recipe

A comment above the element says how to delete it, for anyone who would rather not carry it.

## Placement follows what each recipe already has

- **starlight** has a shared layout, so the element goes in `starlight-page` once and docs, blog and tag pages all inherit it. Its splash page does not use that layout, so it places the element itself.
- **fullstack** and **11ty-blog** have no shared layout, so each page places it directly.

The component is one file per adapter and cannot know which recipe it was copied into, so scaffolding now interpolates `{{recipe}}` — sourced from the recipe name the scaffolder was already given.

## Three adapter-specific details, each measured rather than assumed

**Elena** pages re-export `LitroFooter` instead of bare-importing it. Rollup drops a bare side-effect import, which would drop `.define()` and leave the element unexpanded in SSR.

**FAST** binds the property (`:recipe`) rather than setting an attribute. fast-ssr does not map attributes onto properties, so `recipe="starlight"` server-renders the credit *with the recipe name missing*. Confirmed by reverting to a plain attribute and watching the check fail.

**Lit** needed nothing beyond the ordinary import.

I also briefly believed `when()` was required over a ternary and wrote a comment saying so. It was not — I tested both and they render identically. `when()` stays because it matches the sibling components, and the comment now says that instead.

## The check that makes this correct

`scripts/verify-scaffolded-apps.mjs` now asserts the credit reaches **rendered output** for all six variants: the prerendered HTML where the recipe prerenders, the server bundle where it does not. It strips HTML comments first, because Lit's SSR writes `<!--lit-part-->` markers between static text and a binding, and those split the recipe name apart mid-phrase.

This is the reason the PR is right rather than plausible. **All six variants compiled and built cleanly while FAST was silently dropping the recipe name.** Only reading the output caught it.

Verified in both directions: removing the element from the starlight template makes the check fail with `NO-CREDIT`, and restoring it makes it pass.

## Verification

- 35 create-litro unit tests — one new, and it fails if the `{{recipe}}` variable is removed
- 176 framework and agent unit tests
- All 6 scaffolded variants OK
- Doc-reference guard OK
