### PR TITLE
fix(e2e): stop the resume spec wiping the shared server's agent session logs

### DIFF
--- a/.changeset/agent-sessions-dir-isolation.md
+++ b/.changeset/agent-sessions-dir-isolation.md
@@ -1,0 +1,9 @@
+---
+'@beatzball/litro-agent': patch
+---
+
+`fileSessionStore` no longer breaks permanently when its session directory disappears, and can be pointed elsewhere with `LITRO_AGENT_SESSIONS_DIR`.
+
+The store creates `.litro/sessions` once and caches that result for the life of the process. If the directory was then removed — a cleanup script, a log rotation, a tmpfs reaper — every later `append` failed with `ENOENT` forever and the agent endpoint returned a 500 error event on every turn until the server restarted. It now recreates the directory and retries the append once.
+
+`LITRO_AGENT_SESSIONS_DIR` overrides the default directory (an explicit `fileSessionStore({ dir })` still wins). It exists for the case where two servers run against the same project directory and must not share session state.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,11 @@ jobs:
         run: node scripts/check-doc-refs.mjs --self-test
       - name: Check documentation references
         run: node scripts/check-doc-refs.mjs
+      # Guards the e2e suite against one spec deleting state a concurrently
+      # running dev server is using -- the issue #118 failure mode. Pure Node
+      # like the checker above, so it belongs in this install-free job.
+      - name: Check e2e isolation
+        run: node scripts/check-e2e-isolation.mjs
 
   audit:
     name: Dependency Audit

--- a/e2e/playground/agent-resume.spec.ts
+++ b/e2e/playground/agent-resume.spec.ts
@@ -10,7 +10,7 @@
  *
  * v0 CONTRACT being verified here (see packages/litro-agent/src/runtime/
  * handler.ts's module doc): the session store is a durable, file-backed LOG
- * (playground/.litro/sessions/<id>.jsonl). Killing the server mid-turn does
+ * (one <id>.jsonl per session). Killing the server mid-turn does
  * NOT resume the dead turn's execution -- there is no re-entrant turn
  * runner. What survives is exactly the prefix of `SessionEvent`s that were
  * `store.append()`-ed (and therefore durable) before the process died. A GET
@@ -29,17 +29,32 @@ import { serializeValue, createStreamDecoder, type StreamChunk } from '../../pac
 // is the reliable way to locate this file on disk.
 const repoRoot = path.resolve(__dirname, '../..');
 const playgroundDir = path.join(repoRoot, 'playground');
-const litroDataDir = path.join(playgroundDir, '.litro');
 const cliEntry = path.join(repoRoot, 'packages/framework/dist/cli/index.js');
+
+// This spec wipes its session state around the test, and it runs CONCURRENTLY
+// with the other playground specs (`fullyParallel: true`). Its server shares
+// `playground/` with the shared dev server on port 3030, so the default store
+// directory (`playground/.litro/sessions`) is the SAME directory that server
+// writes e2e/playground/agent.spec.ts's session logs into. Wiping it deleted
+// live logs out from under that server -- issue #118: a GET replay came back
+// empty, and once the directory was gone the shared server's store kept
+// failing with ENOENT for the rest of the run, so all three agent tests went
+// red together, including the browserless one.
+//
+// LITRO_AGENT_SESSIONS_DIR (see packages/litro-agent/src/sessions/file.ts)
+// points THIS server's store at a private directory, so the wipes below can
+// never touch the shared server's state. The directory sits outside
+// `playground/` so it is not part of any watched project tree.
+const sessionsDir = path.join(repoRoot, 'e2e/test-results/agent-resume-sessions');
 
 const PORT = 3052;
 const BASE = `http://localhost:${PORT}`;
 // Unique per run, same rationale as e2e/playground/agent.spec.ts's `session`:
-// `beforeAll` wipes `.litro/` before starting the server, but that hook does
-// NOT re-run on a Playwright retry of this test -- a fixed id would let a
-// retry's POST land in the same session file as the killed first attempt,
-// replaying a longer (duplicated) event sequence and breaking the exact
-// `toEqual(['message', 'text-delta'])` assertion below.
+// `beforeAll` wipes this spec's own sessions dir before starting the server,
+// but that hook does NOT re-run on a Playwright retry of this test -- a fixed
+// id would let a retry's POST land in the same session file as the killed
+// first attempt, replaying a longer (duplicated) event sequence and breaking
+// the exact `toEqual(['message', 'text-delta'])` assertion below.
 const SESSION = `e2e-resume-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 
 let proc: ChildProcess | undefined;
@@ -60,6 +75,7 @@ function startServer(): ChildProcess {
     cwd: playgroundDir,
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, LITRO_AGENT_SESSIONS_DIR: sessionsDir },
   });
   child.stdout?.on('data', (d: Buffer) => {
     stdoutBuf += d.toString();
@@ -121,14 +137,14 @@ test.describe('agent demo — kill mid-stream, resume from the persisted log', (
   test.describe.configure({ mode: 'serial' });
 
   test.beforeAll(async () => {
-    await rm(litroDataDir, { recursive: true, force: true });
+    await rm(sessionsDir, { recursive: true, force: true });
     proc = startServer();
     await waitForServerUp();
   });
 
   test.afterAll(async () => {
     if (proc) stopServer(proc);
-    await rm(litroDataDir, { recursive: true, force: true }).catch(() => {});
+    await rm(sessionsDir, { recursive: true, force: true }).catch(() => {});
   });
 
   test('a POST killed mid-turn leaves a truncated-but-clean log; GET replay after restart does not fabricate a completed turn', async () => {
@@ -177,7 +193,7 @@ test.describe('agent demo — kill mid-stream, resume from the persisted log', (
     await waitForServerDown();
 
     // Restart the exact same server. The session log is file-backed
-    // (playground/.litro/sessions/<id>.jsonl), so the prefix that was
+    // (one <id>.jsonl per session under `sessionsDir`), so the prefix that was
     // durably appended before the kill survives the restart even though the
     // in-memory lock/broadcast state (both process-global) does not.
     proc = startServer();

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:e2e:preview": "playwright test --config playwright.preview.config.ts",
     "lint": "tsc --noEmit -p packages/framework/tsconfig.json",
     "check:doc-refs": "node scripts/check-doc-refs.mjs",
+  "check:e2e-isolation": "node scripts/check-e2e-isolation.mjs",
     "check:doc-refs:self-test": "node scripts/check-doc-refs.mjs --self-test",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/packages/docs-content/content/docs/agents.md
+++ b/packages/docs-content/content/docs/agents.md
@@ -280,6 +280,8 @@ A `{ type: 'delay', ms }` pseudo-event is script-only — the provider awaits it
 
 A session is an append-only JSONL log at `.litro/sessions/<id>.jsonl`, one `SessionEvent` per line with a monotonic `seq`. Session ids are caller-chosen opaque strings validated as `[A-Za-z0-9_-]{1,64}` — they become filenames, so path traversal is rejected at the handler.
 
+The directory is `.litro/sessions` relative to the server's working directory. Override it with `fileSessionStore({ dir })`, or — when you cannot touch the config, such as a second server started against the same project — with the `LITRO_AGENT_SESSIONS_DIR` environment variable. Two servers sharing one project directory need separate session directories: they write to the same files otherwise.
+
 **The keystone ordering rule:** every event is appended to the store *before* it is written to the HTTP stream. The log is the source of truth; the response is a tail of it. Two consequences fall out for free:
 
 - **Turns survive client disconnect.** A POST client that drops mid-turn does not abort the turn — the runtime keeps appending to the store and running to completion. The persisted log stays complete.

--- a/packages/litro-agent/README.md
+++ b/packages/litro-agent/README.md
@@ -120,7 +120,7 @@ API keys are read from the environment only. `openaiCompatible` takes an optiona
 
 ## Sessions
 
-A session is an append-only log. The default store writes JSONL under `.litro/sessions/`; `.litro/` holds conversation data and must be gitignored.
+A session is an append-only log. The default store writes JSONL under `.litro/sessions/`; `.litro/` holds conversation data and must be gitignored. Point the default store somewhere else with `fileSessionStore({ dir })`, or with the `LITRO_AGENT_SESSIONS_DIR` environment variable when you cannot reach the config — two servers sharing one project directory each need their own.
 
 `sqliteSessionStore` (from `@beatzball/litro-agent/sessions/sqlite`) is the alternative for deployments running more than one instance against shared storage. It adds crash-safe sequence numbers and a cross-instance turn lease. It requires **Node 22.5+**, which is why it sits behind its own subpath — Node 20 users are unaffected and keep the JSONL store.
 

--- a/packages/litro-agent/src/sessions/file.test.ts
+++ b/packages/litro-agent/src/sessions/file.test.ts
@@ -46,6 +46,29 @@ describe('fileSessionStore', () => {
     expect(events.map((e) => e.seq)).toEqual(Array.from({ length: 20 }, (_, i) => i + 1));
   });
 
+  // Issue #118 regression. `ensureDir()` caches its resolved mkdir promise,
+  // so a store that has written once never calls mkdir again. When the
+  // directory then disappeared (a `rm -rf`, a log rotation, a tmpfs reaper)
+  // every later append failed ENOENT for the life of the process -- the
+  // agent endpoint 500s on every turn until the server restarts.
+  it('recovers when the session directory is deleted under a live store', async () => {
+    const store = fileSessionStore({ dir });
+    await store.append('s1', { ts: 1, kind: 'message', payload: 'a' });
+
+    // The directory (and the log in it) vanishes underneath the store.
+    await rm(dir, { recursive: true, force: true });
+
+    // The next append must recreate the directory rather than fail forever.
+    const ev = await store.append('s1', { ts: 2, kind: 'message', payload: 'b' });
+    expect(ev.seq).toBe(2);
+    const events = await collect(store.read('s1'));
+    expect(events.map((e) => e.payload)).toEqual(['b']);
+
+    // And the store keeps working afterwards -- one recovery, not a one-off.
+    const ev2 = await store.append('s1', { ts: 3, kind: 'message', payload: 'c' });
+    expect(ev2.seq).toBe(3);
+  });
+
   it('tolerates malformed lines and reads an absent session as empty', async () => {
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, 'bad.jsonl'), '{"seq":1,"ts":1,"kind":"message","payload":"ok"}\nnot-json\n{"seq":3,"ts":3,"kind":"turn-end","payload":null}\n');
@@ -53,6 +76,34 @@ describe('fileSessionStore', () => {
     const events = await collect(store.read('bad'));
     expect(events.map((e) => e.seq)).toEqual([1, 3]);
     expect(await collect(store.read('missing'))).toEqual([]);
+  });
+});
+
+// Issue #118: two servers sharing one project directory (the e2e suite runs
+// exactly that -- see e2e/playground/agent-resume.spec.ts) need separate
+// session state, or one wiping its logs destroys the other's.
+describe('fileSessionStore default directory', () => {
+  const saved = process.env.LITRO_AGENT_SESSIONS_DIR;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.LITRO_AGENT_SESSIONS_DIR;
+    else process.env.LITRO_AGENT_SESSIONS_DIR = saved;
+  });
+
+  it('honours LITRO_AGENT_SESSIONS_DIR when no explicit dir is given', async () => {
+    process.env.LITRO_AGENT_SESSIONS_DIR = dir;
+    const store = fileSessionStore();
+    await store.append('s1', { ts: 1, kind: 'message', payload: 'a' });
+    const raw = await readFile(join(dir, 's1.jsonl'), 'utf-8');
+    expect(raw).toContain('"payload":"a"');
+  });
+
+  it('an explicit dir still wins over the env var', async () => {
+    process.env.LITRO_AGENT_SESSIONS_DIR = join(dir, 'from-env');
+    const explicit = join(dir, 'explicit');
+    const store = fileSessionStore({ dir: explicit });
+    await store.append('s1', { ts: 1, kind: 'message', payload: 'a' });
+    const raw = await readFile(join(explicit, 's1.jsonl'), 'utf-8');
+    expect(raw).toContain('"payload":"a"');
   });
 });
 

--- a/packages/litro-agent/src/sessions/file.ts
+++ b/packages/litro-agent/src/sessions/file.ts
@@ -9,8 +9,20 @@ export function validateSessionId(id: string): void {
   }
 }
 
+/** Where a default-constructed store keeps its session logs, relative to
+ *  `process.cwd()` unless absolute.
+ *
+ *  `LITRO_AGENT_SESSIONS_DIR` exists so that two servers sharing one project
+ *  directory can be given separate, non-overlapping session state. The e2e
+ *  suite needs exactly that: `e2e/playground/agent-resume.spec.ts` spawns a
+ *  SECOND dev server in `playground/` and wipes its session directory around
+ *  the test, while the shared `playground` dev server on port 3030 is
+ *  serving other specs out of the same default directory. Without the
+ *  override the wipe deletes the other server's live session logs. */
+const DEFAULT_DIR = '.litro/sessions';
+
 export function fileSessionStore(opts?: { dir?: string }): SessionStore {
-  const dir = resolve(process.cwd(), opts?.dir ?? '.litro/sessions');
+  const dir = resolve(process.cwd(), opts?.dir ?? process.env.LITRO_AGENT_SESSIONS_DIR ?? DEFAULT_DIR);
 
   // Per-session promise chains for serialized writes
   const chains = new Map<string, Promise<void>>();
@@ -34,6 +46,32 @@ export function fileSessionStore(opts?: { dir?: string }): SessionStore {
         });
     }
     return dirReady;
+  }
+
+  /** Appends, and survives the session directory disappearing underneath a
+   *  long-lived store.
+   *
+   *  `ensureDir()` caches its resolved `mkdir` promise, so after ONE
+   *  successful mkdir the store never calls mkdir again for the rest of the
+   *  process's life. If the directory is then removed — a log rotation, a
+   *  `rm -rf .litro`, a tmpfs reaper, a test wiping state — every subsequent
+   *  append fails with ENOENT forever: the store is poisoned, not merely
+   *  unlucky, and the agent endpoint 500s on every turn until the server is
+   *  restarted. (That is exactly what CI saw in issue #118.)
+   *
+   *  ENOENT here can only mean a missing directory component: the file
+   *  itself is created on demand by the append. So drop the cached mkdir,
+   *  recreate the directory and retry the append ONCE. A second ENOENT is a
+   *  real fault (a path that cannot be created) and propagates. */
+  async function appendWithDirRecovery(filePath: string, line: string): Promise<void> {
+    try {
+      await appendFile(filePath, line);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') throw err;
+      dirReady = undefined;
+      await ensureDir();
+      await appendFile(filePath, line);
+    }
   }
 
   async function initSeqIfNeeded(sessionId: string): Promise<void> {
@@ -101,7 +139,7 @@ export function fileSessionStore(opts?: { dir?: string }): SessionStore {
 
         // Write to file
         const filePath = `${dir}/${sessionId}.jsonl`;
-        await appendFile(filePath, JSON.stringify(resultEvent) + '\n');
+        await appendWithDirRecovery(filePath, JSON.stringify(resultEvent) + '\n');
 
         // Only advance the in-memory counter once the write is durable.
         seqs.set(sessionId, seq);

--- a/scripts/check-e2e-isolation.mjs
+++ b/scripts/check-e2e-isolation.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * check-e2e-isolation — stops one e2e spec from deleting another's live state.
+ *
+ * The e2e suite runs `fullyParallel`, and several specs spawn their own dev
+ * server inside a workspace app directory that a SHARED dev server is already
+ * serving other specs from. Any spec that deletes a path inside such a
+ * directory is therefore deleting files a concurrently running server may be
+ * reading or writing right now.
+ *
+ * That is not hypothetical: issue #118. `e2e/playground/agent-resume.spec.ts`
+ * wiped `playground/.litro/` around its test while the shared playground
+ * server on port 3030 kept its agent session logs in that same directory. All
+ * three tests in `e2e/playground/agent.spec.ts` went red together whenever the
+ * wipe landed mid-test — including the browserless one — and the failure was
+ * invisible locally because it depends on which specs happen to overlap.
+ *
+ * THE RULE: a spec may delete only inside `test-results/`, `e2e/test-results/`
+ * or the OS temp directory. Anywhere else, give the spec its own directory
+ * (for session logs: the `LITRO_AGENT_SESSIONS_DIR` env var) and delete that.
+ *
+ * The check is deliberately narrow — it only looks at delete calls, and only
+ * at targets it can resolve statically — so a failure is always a real bug. A
+ * target it cannot resolve is also reported: an unreadable delete target in a
+ * parallel suite is exactly the thing this check exists to prevent.
+ *
+ * Usage: node scripts/check-e2e-isolation.mjs [--self-test]
+ * Exit code 1 if any spec deletes outside the allowed directories.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const E2E_DIR = join(ROOT, 'e2e');
+
+/** Deleting inside these is fine — they hold nothing a server serves. */
+const ALLOWED = [join(ROOT, 'test-results'), join(ROOT, 'e2e', 'test-results')];
+
+/** fs functions that remove things. */
+const DESTRUCTIVE = ['rm', 'rmSync', 'rmdir', 'rmdirSync', 'unlink', 'unlinkSync'];
+
+/* ── Resolving a delete target ────────────────────────────────────────── */
+
+// A value is either a concrete absolute path, the OS temp directory (always
+// allowed, and its exact location does not matter), or unresolvable.
+const TMP = { kind: 'tmp' };
+const UNKNOWN = { kind: 'unknown' };
+const asPath = (value) => ({ kind: 'path', value });
+
+/** Splits an argument list on top-level commas (parens/quotes aware). */
+function splitArgs(src) {
+  const out = [];
+  let depth = 0;
+  let quote = '';
+  let current = '';
+  for (const ch of src) {
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === '(' || ch === '[' || ch === '{') depth++;
+    if (ch === ')' || ch === ']' || ch === '}') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) out.push(current.trim());
+  return out;
+}
+
+/** Evaluates the small subset of expressions specs use to build a path:
+ *  string literals, `__dirname`, `tmpdir()`/`mkdtemp(...)`, previously
+ *  declared consts, and `path.join`/`path.resolve` over those. */
+function evaluate(expr, vars, specDir) {
+  const src = expr.trim();
+
+  const literal = /^(['"])(.*)\1$/.exec(src);
+  if (literal) return asPath(literal[2]);
+
+  if (src === '__dirname') return asPath(specDir);
+  if (/^(os\.)?tmpdir\(\)$/.test(src)) return TMP;
+  if (/^(await\s+)?mkdtemp\(/.test(src)) return TMP;
+
+  if (/^[A-Za-z_$][\w$]*$/.test(src)) return vars.get(src) ?? UNKNOWN;
+
+  const call = /^(?:path\.)?(join|resolve)\(([\s\S]*)\)$/.exec(src);
+  if (call) {
+    const parts = splitArgs(call[2]).map((a) => evaluate(a, vars, specDir));
+    if (parts.some((p) => p.kind === 'unknown')) return UNKNOWN;
+    if (parts.some((p) => p.kind === 'tmp')) return TMP;
+    return asPath(resolve(...parts.map((p) => p.value)));
+  }
+
+  return UNKNOWN;
+}
+
+/** Collects `const NAME = <expr>;` bindings, in source order, so later
+ *  declarations can refer to earlier ones. */
+function collectVars(source, specDir) {
+  const vars = new Map();
+  const re = /^\s*const\s+([A-Za-z_$][\w$]*)\s*=\s*([^;\n]+);/gm;
+  for (const m of source.matchAll(re)) vars.set(m[1], evaluate(m[2], vars, specDir));
+  return vars;
+}
+
+/** Every delete call in a spec, with its target resolved. */
+function findDeletes(source, specDir) {
+  const vars = collectVars(source, specDir);
+  const found = [];
+  const re = new RegExp(String.raw`\b(${DESTRUCTIVE.join('|')})\s*\(`, 'g');
+  for (const m of source.matchAll(re)) {
+    // Skip the import statement / the function's own definition.
+    const lineStart = source.lastIndexOf('\n', m.index) + 1;
+    const line = source.slice(lineStart, source.indexOf('\n', m.index));
+    if (/^\s*(import|export|function)\b/.test(line)) continue;
+
+    const argSrc = source.slice(m.index + m[0].length);
+    const end = matchingParen(argSrc);
+    if (end === -1) continue;
+    const [first] = splitArgs(argSrc.slice(0, end));
+    found.push({
+      fn: m[1],
+      line: source.slice(0, m.index).split('\n').length,
+      target: first === undefined ? UNKNOWN : evaluate(first, vars, specDir),
+      source: line.trim(),
+    });
+  }
+  return found;
+}
+
+/** Index of the `)` closing the call whose `(` was just consumed. */
+function matchingParen(src) {
+  let depth = 0;
+  let quote = '';
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (quote) {
+      if (ch === quote) quote = '';
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') quote = ch;
+    else if (ch === '(') depth++;
+    else if (ch === ')') {
+      if (depth === 0) return i;
+      depth--;
+    }
+  }
+  return -1;
+}
+
+function isAllowed(target) {
+  if (target.kind === 'tmp') return true;
+  if (target.kind !== 'path') return false;
+  const path = isAbsolute(target.value) ? target.value : resolve(ROOT, target.value);
+  // Outside the repo entirely (a scratch dir elsewhere) is not our business.
+  if (relative(ROOT, path).startsWith('..')) return true;
+  return ALLOWED.some((allowed) => path === allowed || !relative(allowed, path).startsWith('..'));
+}
+
+/* ── Runner ───────────────────────────────────────────────────────────── */
+
+function specFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...specFiles(full));
+    else if (entry.endsWith('.spec.ts')) out.push(full);
+  }
+  return out;
+}
+
+function checkSource(source, specPath) {
+  return findDeletes(source, dirname(specPath))
+    .filter((del) => !isAllowed(del.target))
+    .map((del) => ({
+      ...del,
+      file: relative(ROOT, specPath),
+      why:
+        del.target.kind === 'path'
+          ? `deletes ${relative(ROOT, resolve(ROOT, del.target.value))}`
+          : 'delete target could not be resolved statically',
+    }));
+}
+
+function selfTest() {
+  const spec = join(E2E_DIR, 'playground', 'fixture.spec.ts');
+  const cases = [
+    [
+      "const repoRoot = path.resolve(__dirname, '../..');\n" +
+        "const d = path.join(repoRoot, 'e2e/test-results/mine');\n" +
+        'await rm(d, { recursive: true });',
+      0,
+    ],
+    ["const dir = await mkdtemp(join(tmpdir(), 'x'));\nawait rm(dir, { recursive: true });", 0],
+    // The issue #118 shape: wiping state a shared dev server is using.
+    [
+      "const repoRoot = path.resolve(__dirname, '../..');\n" +
+        "const playgroundDir = path.join(repoRoot, 'playground');\n" +
+        "const litroDataDir = path.join(playgroundDir, '.litro');\n" +
+        'await rm(litroDataDir, { recursive: true, force: true });',
+      1,
+    ],
+    ["await rm(process.env.SOMETHING, { recursive: true });", 1],
+    ['await rm(join(repoRoot, "docs/dist"));', 1],
+  ];
+  let failures = 0;
+  for (const [source, expected] of cases) {
+    const got = checkSource(source, spec).length;
+    if (got !== expected) {
+      failures++;
+      console.error(`self-test: expected ${expected} finding(s), got ${got} for:\n${source}\n`);
+    }
+  }
+  if (failures > 0) {
+    console.error(`check-e2e-isolation self-test FAILED (${failures} case(s))`);
+    process.exit(1);
+  }
+  console.log(`check-e2e-isolation self-test passed (${cases.length} cases)`);
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else {
+  // The self-test runs first, every time: a checker that has quietly stopped
+  // matching anything would otherwise pass forever.
+  selfTest();
+  const findings = specFiles(E2E_DIR).flatMap((file) => checkSource(readFileSync(file, 'utf-8'), file));
+  if (findings.length > 0) {
+    console.error('\ne2e specs may only delete inside test-results/ or the OS temp dir.\n');
+    for (const f of findings) {
+      console.error(`  ${f.file}:${f.line}  ${f.why}\n    ${f.source}`);
+    }
+    console.error(
+      '\nGive the spec its own directory instead (for agent session logs: the\n' +
+        'LITRO_AGENT_SESSIONS_DIR env var on the server it spawns) and delete that.\n' +
+        'See issue #118.\n',
+    );
+    process.exit(1);
+  }
+  console.log(`check-e2e-isolation: ${specFiles(E2E_DIR).length} spec files, no cross-spec deletes`);
+}


### PR DESCRIPTION
Closes #118.

## What was happening

`e2e/playground/agent-resume.spec.ts` deletes its session state in `beforeAll` and `afterAll`. It spawns its **own** dev server, but inside the **same project directory** (`playground/`) as the shared dev server on port 3030 — and the default agent session store writes to `playground/.litro/sessions`, so both servers used one directory. The suite is `fullyParallel`, so that wipe lands in the middle of `e2e/playground/agent.spec.ts` whenever the two happen to overlap.

Both CI signatures reported on the issue follow from this single cause:

1. **Wipe between the POST and the GET.** The session log file is gone, so the GET replays nothing: `expect(valueKinds(getChunks)).toEqual(postKinds)` receives `[]`.
2. **Wipe after the shared store cached its `mkdir`.** `fileSessionStore` caches the resolved `ensureDir()` promise for the life of the process, so once the directory disappears every later `append` fails `ENOENT` — permanently. CI caught the resulting error event on the wire:

   ```
   "message": "ENOENT: no such file or directory, open
   '/home/runner/work/litro/litro/playground/.litro/sessions/e2e-raw-mt63jmlx-041kdr6w2d4j.jsonl'"
   ```

   That is why the failure is **sticky across Playwright retries within a run** but green on a fresh run, and why all three tests in the file — the browser ones and the `request`-only one — go red together.

**It is not a readiness problem.** The server was up and serving; its store had been sabotaged. So there is no `expect()` timeout raised here, and no readiness gate added — neither would have addressed the cause.

## Changes

- **`e2e/playground/agent-resume.spec.ts`** — its server now gets a private session directory via `LITRO_AGENT_SESSIONS_DIR`, and only that directory is wiped. It can no longer touch the shared server's state.
- **`packages/litro-agent/src/sessions/file.ts`** — two fixes to the store itself:
  - honours `LITRO_AGENT_SESSIONS_DIR` (an explicit `fileSessionStore({ dir })` still wins), so two servers over one project directory can be separated;
  - recovers from a vanished session directory: on `ENOENT` it drops the cached `mkdir`, recreates the directory and retries the append once, instead of failing for the rest of the process's life. This is a real production bug on its own — any cleanup script or tmpfs reaper that removed `.litro/` broke the agent endpoint until restart.
- **`scripts/check-e2e-isolation.mjs`** (new, wired into CI) — fails the build if any e2e spec deletes a path outside `test-results/`, `e2e/test-results/` or the OS temp dir. It self-tests before every run, and it flags the pre-fix spec exactly:

  ```
  e2e/playground/agent-resume.spec.ts:124  deletes playground/.litro
  ```
- Docs + changeset for the new env var.

## Verification

- **Reproduced locally**, which had not been possible before: `playwright test --project=playground e2e/playground/agent.spec.ts e2e/playground/agent-resume.spec.ts --workers=2 --repeat-each=3` → **5 failed**, with the identical `Received string: ""` / empty-replay signatures from CI.
- **Same command after the fix** → **12 passed**.
- Confirmed the resume server's logs no longer land in the shared directory (no `e2e-resume-*.jsonl` in `playground/.litro/sessions`).
- Full `pnpm test:e2e` → **186 passed**. `pnpm -r test` → all packages green (litro-agent 179 tests, including the two new regression tests).