### PR TITLE
test(playground): an MCP server that puts packed ui:// docs in front of a real host

### DIFF
--- a/playground/mcp-server/README.md
+++ b/playground/mcp-server/README.md
@@ -1,0 +1,124 @@
+# playground MCP server — a host validation rig
+
+**This is a test rig, not the production MCP server.** It is not published, not
+wired into any recipe, and not the deferred Litro MCP server. Its only job is to
+put the packed `ui://` documents in front of a **real** MCP host and record what
+that host actually does.
+
+It exists because everything else that exercises the packager uses a fake host
+we wrote ourselves, from the same reading of the spec that produced the packager.
+All of it could be wrong in the same direction and stay green. It was, once —
+see [Traps a real host exposed](#traps-a-real-host-exposed).
+
+It does not re-implement the packer. It reads `dist/mcp-apps/manifest.json` and
+serves the bytes untouched, so a host renders exactly what `litro mcp-app build`
+produced.
+
+## Run
+
+```bash
+pnpm --filter playground mcp-app             # pack first; the server needs the manifest
+node playground/mcp-server/index.ts          # stdio (default) — for Claude Desktop
+node playground/mcp-server/index.ts --http   # http — for MCP Inspector
+```
+
+Node 24 strips the TypeScript types, so there is no build step.
+
+**stdio is the default** and is the transport a host launches on its own. The
+`--http` flag exists only because MCP Inspector V2 auto-connects to a URL and
+cannot spawn a stdio command. Both serve the same handlers from the same
+`buildServer()`, so neither host is shown a different server from the other.
+
+| Env var | Effect |
+| --- | --- |
+| `LITRO_MCP_APPS_DIR` | Where to read the packed apps from. Default `playground/dist/mcp-apps`. |
+| `LITRO_MCP_TOOL_DELAY_MS` | Delays every `tools/call`. Needed to see the shell hold the screen before the result — with an instant tool the two are indistinguishable. |
+| `PORT` | HTTP port, `--http` only. Default `3111`. |
+
+## What this rig proved
+
+Against MCP Inspector V2 (`@mcp-use/inspector@20.3.7`), with
+`LITRO_MCP_TOOL_DELAY_MS=4000`:
+
+```
+10593ms   — 0°C Waiting for the forecast…          <- server-rendered shell
+14380ms   Reykjavik 3°C Windy, snow showers        <- tool result arrives
+```
+
+**That is the central claim of the whole design, measured against a host we did
+not write.** A server-rendered shell is real, styled markup in the first byte,
+where a client-rendered bundle would show an empty iframe for those 3.8 seconds.
+Nothing else in this repo proves it.
+
+Also confirmed on the wire: the document renders under the host's **restrictive
+default CSP** with zero violations (the demo apps declare no `csp` at all, so
+this is the strict path, not a declared-domains one); `_meta.ui` is read in the
+nested shape the packer emits; `structuredContent` arrives as
+`{city, tempC, summary}` exactly as the bridge's fill step expects; and the
+`weather-refresh` button's own `tools/call` round-trips back to this server and
+updates the view.
+
+## Reproduce it
+
+```bash
+node playground/mcp-server/index.ts --http &
+npx @mcp-use/inspector --url http://localhost:3111/mcp --no-open
+node playground/mcp-server/inspector-probe.mjs
+```
+
+The probe drives the Inspector headlessly and prints the host↔view wire, the
+shell-before-result timeline, and the refresh round-trip. Every claim above came
+out of it, so a claim here that the probe no longer prints is a regression.
+
+## Traps a real host exposed
+
+Three protocol defects in the view bridge were found this way and fixed in
+[PR 130](https://github.com/beatzball/litro/pull/130); the trail is in that PR's
+[review record](https://github.com/beatzball/litro/pull/130#issuecomment-5550086270).
+The short version: the host rejected our `ui/initialize` with `-32602` for three
+missing params, and the demo only rendered because Inspector injects a
+compatibility shim that completed the handshake for us. Fifteen green unit tests
+had no idea.
+
+Two host behaviours are not bugs but will be rediscovered the hard way:
+
+- **`_meta.ui` is read from the `resources/read` contents, not from the
+  `resources/list` entry.** Omitting it from `list` changed nothing. Serving it
+  in both places is harmless; serving it *only* on `list` would not work.
+- **The host sends `ui/notifications/tool-input` 2–3 times, and `tool-result`
+  more than once, per call.** The bridge is idempotent so nothing breaks. Do not
+  "fix" it into assuming exactly-once delivery.
+
+## Claude Desktop
+
+Not automatable from here — it needs a config edit and an app restart. Add to
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "litro-playground": {
+      "command": "node",
+      "args": ["/absolute/path/to/litro/playground/mcp-server/index.ts"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop, then ask it for the weather in Tokyo.
+
+Note: `modelcontextprotocol/ext-apps` issue 671 reports a valid self-contained
+document failing to render in Claude Desktop while Inspector shows a correct
+exchange. Test in Inspector first; a difference between the two is likely not
+ours.
+
+## Tool visibility
+
+`get-weather` is published with `_meta.ui.visibility: ["model", "app"]`.
+
+`"app"` is required, not a default worth leaning on: the `weather-refresh`
+document's button calls this same tool back through `tools/call`, and the spec
+says a host MUST reject a call from an app for a tool whose visibility omits
+`"app"`. `"model"` is kept because the tool genuinely answers a question a user
+would ask in words — hiding it would buy nothing and would make the demo
+undrivable from a chat prompt, which is how a real host gets used.

--- a/playground/mcp-server/index.ts
+++ b/playground/mcp-server/index.ts
@@ -1,0 +1,252 @@
+/**
+ * A minimal stdio MCP server that serves the documents `litro mcp-app build`
+ * packs, so a REAL MCP host can render them.
+ *
+ * Everything else that exercises the packager is something we wrote — a fake
+ * host in jsdom, a fake host in Playwright. All of it agrees with our reading
+ * of the spec because all of it came from that reading. This server exists so
+ * a host we did not write gets a turn.
+ *
+ * It deliberately does NOT re-implement the packer. It reads
+ * `dist/mcp-apps/manifest.json` and hands the bytes over untouched, so what a
+ * host renders is what `litro mcp-app build` actually produced.
+ *
+ * Run (stdio, for Claude Desktop):  node playground/mcp-server/index.ts
+ * Run (http, for MCP Inspector):     node playground/mcp-server/index.ts --http
+ * Pack first:  pnpm --filter playground mcp-app
+ *
+ * Two transports because MCP Inspector V2 auto-connects only to a URL, and
+ * Claude Desktop launches only a stdio command. Same handlers behind both, so
+ * neither host is being shown a different server from the other.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(process.env.LITRO_MCP_APPS_DIR ?? join(HERE, '..', 'dist', 'mcp-apps'));
+
+/** One entry of the packer's `manifest.json`. */
+interface ManifestEntry {
+  name: string;
+  uri: string;
+  html: string;
+  descriptor: string;
+}
+
+/** The descriptor the packer writes beside each document. */
+interface Descriptor {
+  uri: string;
+  /** The packer names the resource now; the manifest stem is only a filename. */
+  name?: string;
+  mimeType: string;
+  _meta: { ui: Record<string, unknown> };
+}
+
+interface LoadedApp {
+  name: string;
+  descriptor: Descriptor;
+  html: string;
+}
+
+async function loadApps(): Promise<LoadedApp[]> {
+  let manifest: ManifestEntry[];
+  try {
+    manifest = JSON.parse(await readFile(join(OUT_DIR, 'manifest.json'), 'utf8')) as ManifestEntry[];
+  } catch {
+    // stderr, not stdout: stdout is the JSON-RPC channel and a stray byte on it
+    // desyncs the framing for the rest of the session.
+    process.stderr.write(
+      `litro mcp-server: no manifest at ${join(OUT_DIR, 'manifest.json')}\n` +
+        '  Run: pnpm --filter playground mcp-app\n',
+    );
+    process.exit(1);
+  }
+
+  return Promise.all(
+    manifest.map(async (entry) => ({
+      name: entry.name,
+      // Passed through byte for byte. Reshaping _meta here would mean the host
+      // is checking this file's reading of the spec rather than the packer's.
+      descriptor: JSON.parse(await readFile(join(OUT_DIR, entry.descriptor), 'utf8')) as Descriptor,
+      html: await readFile(join(OUT_DIR, entry.html), 'utf8'),
+    })),
+  );
+}
+
+const apps = await loadApps();
+const byUri = new Map(apps.map((a) => [a.descriptor.uri, a]));
+
+/** Counts calls so a refresh visibly changes the view even for a canned city. */
+let calls = 0;
+
+/** Canned, on purpose: this server tests rendering, not a weather API. */
+function forecast(city: string) {
+  const cities: Record<string, { tempC: number; summary: string }> = {
+    london: { tempC: 12, summary: 'Overcast with light drizzle' },
+    tokyo: { tempC: 21, summary: 'Clear and mild' },
+    reykjavik: { tempC: 3, summary: 'Windy, snow showers' },
+  };
+  calls += 1;
+  const hit = cities[city.trim().toLowerCase()] ?? { tempC: 15, summary: 'Partly cloudy' };
+  // The call number rides along in the summary. Without it a refresh of a
+  // canned city renders identically whether the round-trip happened or not,
+  // and the screenshot proves nothing.
+  return { tempC: hit.tempC, summary: `${hit.summary} (reading #${calls})` };
+}
+
+/**
+ * A fresh Server per connection. The HTTP transport is stateless — one
+ * transport per request — so a single shared Server would be re-connected
+ * under each new one and lose the previous session's state.
+ */
+function buildServer(): Server {
+const server = new Server(
+  { name: 'litro-playground', version: '0.0.1' },
+  { capabilities: { resources: {}, tools: {} } },
+);
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+  resources: apps.map((app) => ({
+    uri: app.descriptor.uri,
+    name: app.descriptor.name ?? app.name,
+    description: `Litro MCP App: ${app.descriptor.name ?? app.name}`,
+    mimeType: app.descriptor.mimeType,
+    // The spec puts `_meta.ui` on the resource DECLARATION as well as on the
+    // read contents, so a host that decides CSP at prefetch time has it.
+    _meta: app.descriptor._meta,
+  })),
+}));
+
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const app = byUri.get(request.params.uri);
+  if (!app) throw new Error(`Unknown resource: ${request.params.uri}`);
+  return {
+    contents: [
+      {
+        uri: app.descriptor.uri,
+        mimeType: app.descriptor.mimeType,
+        text: app.html,
+        _meta: app.descriptor._meta,
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'get-weather',
+      description: 'Current weather for a city.',
+      inputSchema: {
+        type: 'object',
+        properties: { city: { type: 'string', description: 'City name' } },
+        required: ['city'],
+      },
+      _meta: {
+        ui: {
+          resourceUri: 'ui://playground/weather-card',
+          // ["model", "app"], not the ["app"]-only form.
+          //
+          // "app" is REQUIRED here and is not a default we can lean on: the
+          // weather-refresh document's button calls this same tool back
+          // through tools/call, and the spec says the host MUST reject a call
+          // from an app for a tool whose visibility omits "app". Dropping it
+          // would kill the refresh round-trip, which is one of the things this
+          // server exists to test.
+          //
+          // "model" is kept because this tool is genuinely useful to the agent
+          // — it answers a question a user would ask in words. Hiding it would
+          // buy nothing and would make the demo untestable from a chat prompt,
+          // which is how a real host is driven.
+          visibility: ['model', 'app'],
+        },
+      },
+    },
+    {
+      name: 'weather-refresh-demo',
+      description: 'Shows the refreshable weather card, whose button calls get-weather back.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      _meta: {
+        ui: {
+          resourceUri: 'ui://playground/weather-refresh',
+          visibility: ['model', 'app'],
+        },
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  // Deliberately slow, when asked. The claim this whole design rests on is that
+  // the server-rendered shell is on screen BEFORE the result arrives; with an
+  // instant tool the two are indistinguishable in a screenshot.
+  const delay = Number(process.env.LITRO_MCP_TOOL_DELAY_MS ?? 0);
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+
+  const name = request.params.name;
+  const args = (request.params.arguments ?? {}) as { city?: string };
+  const city = (args.city ?? '').trim() || 'London';
+  const { tempC, summary } = forecast(city);
+
+  if (name === 'get-weather' || name === 'weather-refresh-demo') {
+    return {
+      // `content` is what the model reads. `structuredContent` is what the
+      // view fills from. The spec keeps them separate and so does this.
+      content: [{ type: 'text', text: `${city}: ${tempC}°C, ${summary}.` }],
+      structuredContent: { city, tempC, summary },
+    };
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+});
+
+  return server;
+}
+
+if (process.argv.includes('--http')) {
+  const { StreamableHTTPServerTransport } = await import(
+    '@modelcontextprotocol/sdk/server/streamableHttp.js'
+  );
+  const { createServer: createHttpServer } = await import('node:http');
+
+  // Stateless: a new transport and a new Server per request. A single shared
+  // transport would hold one session, and the Inspector opens more than one.
+  const port = Number(process.env.PORT ?? 3111);
+  createHttpServer(async (req, res) => {
+    // The Inspector runs on its own origin, so without CORS the browser never
+    // even sends the POST and the failure looks like a dead server.
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', '*');
+    res.setHeader('Access-Control-Expose-Headers', 'mcp-session-id');
+    if (req.method === 'OPTIONS') return void res.writeHead(204).end();
+
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => void transport.close());
+    await buildServer().connect(transport);
+
+    let body: unknown;
+    if (req.method === 'POST') {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const raw = Buffer.concat(chunks).toString('utf8');
+      body = raw ? JSON.parse(raw) : undefined;
+    }
+    await transport.handleRequest(req, res, body);
+  }).listen(port, () => {
+    process.stderr.write(
+      `litro mcp-server: http on http://localhost:${port}/mcp — ${apps.length} app(s) from ${OUT_DIR}\n`,
+    );
+  });
+} else {
+  await buildServer().connect(new StdioServerTransport());
+  process.stderr.write(`litro mcp-server: stdio — ${apps.length} app(s) from ${OUT_DIR}\n`);
+}

--- a/playground/mcp-server/inspector-probe.mjs
+++ b/playground/mcp-server/inspector-probe.mjs
@@ -1,0 +1,88 @@
+/**
+ * Drives MCP Inspector V2 in a headless browser and prints what a REAL host
+ * does with the packed documents. This is how every finding in the MCP Apps
+ * host report was produced, so it is here rather than in a scratch directory —
+ * a finding nobody can re-run is a claim, not a result.
+ *
+ *   1. pnpm --filter playground mcp-app
+ *   2. node playground/mcp-server/index.ts --http
+ *   3. npx @mcp-use/inspector --url http://localhost:3111/mcp --no-open
+ *   4. node playground/mcp-server/inspector-probe.mjs [--inspector <url>]
+ *
+ * It reports three things the fake hosts in our own tests cannot:
+ *  - the host's reply to the bridge's `ui/initialize` (ours is rejected),
+ *  - whether the server-rendered shell is on screen before the result,
+ *  - whether the view's own `tools/call` round-trip reaches the server.
+ */
+import { chromium } from '@playwright/test';
+
+const arg = (flag, fallback) => {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+const INSPECTOR = arg('--inspector', 'http://localhost:8082/inspector');
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1600, height: 1100 } });
+
+const wire = [];
+page.on('console', async (m) => {
+  if (!/Sending message|Parsed message|MCP Apps CSP/.test(m.text())) return;
+  try {
+    const args = await Promise.all(m.args().map((a) => a.jsonValue().catch(() => '<?>')));
+    wire.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  } catch {
+    /* a console arg that will not serialise is not worth failing the probe over */
+  }
+});
+
+/** The View itself is the `about:srcdoc` frame the sandbox writes our HTML into. */
+const view = () => page.frames().find((f) => f.url() === 'about:srcdoc');
+const viewText = async () => {
+  const f = view();
+  if (!f) return '<no view frame>';
+  return f.evaluate(() => {
+    const el = document.body.firstElementChild;
+    // The weather card fills its shadow root; the refresh card fills light DOM.
+    const shadow = el && el.shadowRoot ? el.shadowRoot.textContent : '';
+    return `${shadow} ${document.body.innerText}`.replace(/\s+/g, ' ').trim();
+  });
+};
+
+async function runTool(label, city) {
+  await page.goto(INSPECTOR, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.waitForTimeout(8000);
+  await page.getByText(label, { exact: true }).first().click();
+  await page.waitForTimeout(1500);
+  if (city) await page.locator('input[type="text"], input:not([type])').first().fill(city);
+  await page.getByRole('button', { name: /execute/i }).first().click();
+}
+
+console.log('### 1. get-weather: does the shell paint before the result? ###');
+console.log('    (set LITRO_MCP_TOOL_DELAY_MS on the server to widen the gap)');
+const started = Date.now();
+await runTool('get-weather', 'Reykjavik');
+let last = '';
+for (let i = 0; i < 60; i++) {
+  const now = await viewText();
+  if (now !== last && now !== '<no view frame>') {
+    console.log(`  ${String(Date.now() - started).padStart(5)}ms  ${now.slice(-70)}`);
+    last = now;
+  }
+  await page.waitForTimeout(250);
+}
+
+console.log('\n### 2. weather-refresh: does the view own tools/call round-trip? ###');
+await runTool('weather-refresh-demo');
+await page.waitForTimeout(8000);
+console.log('  before click:', await viewText());
+await view().locator('#refresh').click();
+await page.waitForTimeout(400);
+console.log('  mid-flight  :', await viewText());
+await page.waitForTimeout(6000);
+console.log('  after result:', await viewText());
+
+console.log('\n### 3. host <-> view wire ###');
+for (const line of wire) console.log('  ' + line.slice(0, 500));
+
+await browser.close();

--- a/playground/package.json
+++ b/playground/package.json
@@ -25,7 +25,8 @@
     "lit": "^3.2.1",
     "@lit-labs/ssr": "^3.3.0",
     "@lit-labs/ssr-client": "^1.1.7",
-    "h3": "^1.15.6"
+    "h3": "^1.15.6",
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
     "nitropack": "^2.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
       '@lit-labs/ssr-client':
         specifier: ^1.1.7
         version: 1.1.8
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@3.25.76)
       h3:
         specifier: ^1.15.6
         version: 1.15.9
@@ -1365,6 +1368,12 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -1443,6 +1452,16 @@ packages:
 
   '@minimistjs/subarg@1.0.0':
     resolution: {integrity: sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -2435,6 +2454,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2448,6 +2471,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -2602,6 +2633,10 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
@@ -2656,6 +2691,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   camelcase@7.0.1:
@@ -2816,6 +2855,18 @@ packages:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
@@ -2828,8 +2879,20 @@ packages:
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -3178,6 +3241,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -3185,6 +3256,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3246,6 +3327,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3264,6 +3349,10 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -3429,6 +3518,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -3522,6 +3615,10 @@ packages:
     resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -3586,6 +3683,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -3622,6 +3722,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.11:
+    resolution: {integrity: sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg==}
+
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
@@ -3651,6 +3754,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -3879,6 +3985,14 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4064,6 +4178,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -4128,6 +4246,14 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -4246,6 +4372,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -4287,6 +4416,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -4364,6 +4497,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -4385,6 +4522,10 @@ packages:
   qr-creator@1.0.0:
     resolution: {integrity: sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==}
 
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -4401,6 +4542,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -4526,6 +4671,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -4608,6 +4757,22 @@ packages:
 
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4892,6 +5057,10 @@ packages:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-query-selector@2.12.1:
     resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
 
@@ -4961,6 +5130,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
@@ -5372,6 +5545,11 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -5870,6 +6048,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@hono/node-server@2.1.1(hono@4.13.7)':
+    dependencies:
+      hono: 4.13.7
+
   '@inquirer/external-editor@1.0.3(@types/node@22.19.13)':
     dependencies:
       chardet: 2.1.1
@@ -5986,6 +6168,28 @@ snapshots:
   '@minimistjs/subarg@1.0.0':
     dependencies:
       minimist: 1.2.8
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.7)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.7
+      jose: 6.2.11
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6914,6 +7118,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -6921,6 +7130,10 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@8.18.0:
     dependencies:
@@ -7084,6 +7297,20 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.16.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boxen@7.0.0:
     dependencies:
       ansi-align: 3.0.1
@@ -7150,6 +7377,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase@7.0.1: {}
 
@@ -7308,6 +7540,12 @@ snapshots:
 
   content-disposition@0.5.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   cookie-es@1.2.2: {}
 
   cookie-es@1.2.3: {}
@@ -7316,7 +7554,16 @@ snapshots:
 
   cookie-es@3.1.1: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crc-32@1.2.2: {}
 
@@ -7650,6 +7897,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7663,6 +7916,47 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.7.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.16.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -7723,6 +8017,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7746,6 +8051,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded-parse@2.1.2: {}
+
+  forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
@@ -7986,6 +8293,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hono@4.13.7: {}
+
   hookable@5.5.3: {}
 
   html-encoding-sniffer@4.0.0:
@@ -8089,6 +8398,8 @@ snapshots:
 
   ip-address@10.5.0: {}
 
+  ipaddr.js@1.9.1: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-core-module@2.16.1:
@@ -8127,6 +8438,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -8158,6 +8471,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
+
+  jose@6.2.11: {}
 
   jpeg-js@0.4.4: {}
 
@@ -8203,6 +8518,8 @@ snapshots:
       - utf-8-validate
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -8527,6 +8844,10 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -8796,6 +9117,10 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   netmask@2.0.2: {}
 
   nitropack@2.13.4(rolldown@1.0.3)(vite@8.0.16(@types/node@22.19.13)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)):
@@ -8942,6 +9267,10 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -9062,6 +9391,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -9091,6 +9422,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -9148,6 +9481,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -9189,6 +9527,11 @@ snapshots:
 
   qr-creator@1.0.0: {}
 
+  qs@6.16.0:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -9198,6 +9541,13 @@ snapshots:
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc9@3.0.1:
     dependencies:
@@ -9426,6 +9776,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -9537,6 +9897,34 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shimmer@1.2.1: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -9810,6 +10198,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typed-query-selector@2.12.1: {}
 
   typescript@5.9.3: {}
@@ -9904,6 +10298,8 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
+
+  unpipe@1.0.0: {}
 
   unplugin-utils@0.3.1:
     dependencies:
@@ -10222,6 +10618,10 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Every other test of the MCP Apps packager talks to a fake host we wrote
ourselves, from the same reading of the spec that produced the packager. All of
it can be wrong in the same direction and stay green.

It was. This rig caught the view bridge sending `ui/initialize` with three
required params missing — a real host answered `-32602` and the demo only
rendered because MCP Inspector injects a compatibility shim that completed the
handshake for us. Fifteen green unit tests had no idea. That fix shipped in
#130; this PR is the rig that found it, so the next defect of that shape is
caught the same way.

**What it is.** A minimal stdio MCP server over the output of
`litro mcp-app build`. It reads `dist/mcp-apps/manifest.json` and serves the
bytes untouched rather than re-implementing the packer, so a host renders
exactly what the packer produced. `inspector-probe.mjs` drives MCP Inspector
headlessly and prints the host/view wire, the shell-before-result timeline and
the refresh round-trip.

**What it measures.** With a 4s tool delay, against `@mcp-use/inspector@20.3.7`:

```
10589ms   — 0°C Waiting for the forecast…      <- server-rendered shell
14380ms   Reykjavik 3°C Windy, snow showers    <- tool result arrives
```

That is the central claim of the design, measured against a host we did not
write. Nothing else in this repo proves it. Also confirmed on the wire: the
document runs under the host's **restrictive default** CSP with zero violations
(the demos declare no `csp` at all, so this is the strict path); `_meta.ui` is
read in the nested shape the packer emits; `structuredContent` arrives as the
bridge's fill step expects; the refresh button's own `tools/call` round-trips.

**Scope.** A test rig, not the deferred production MCP server — the README says
so at the top. stdio is the default; `--http` exists only because Inspector
auto-connects to a URL and cannot spawn a stdio command. Nothing under
`packages/` is touched, so there is no changeset (`playground` is on the
changesets ignore list). The only dependency change is
`@modelcontextprotocol/sdk` in `playground`: 400 lock lines added, 0 removed,
nothing beyond the SDK's own transitives.

920 unit tests pass on this commit.
