### PR TITLE
feat(mcp-app): derive an app's ui:// address from its file path

### DIFF
--- a/.changeset/mcp-app-uri-from-path-agent.md
+++ b/.changeset/mcp-app-uri-from-path-agent.md
@@ -5,7 +5,8 @@
 MCP Apps: `uri` is now optional in `defineMcpApp()`
 
 `buildMcpAppDocument(app, { uri })` takes a fallback address, which is what
-lets `litro mcp-app build` derive one from the file path. An app that declares
+lets `litro mcp-app build` derive one — package name as the authority, file
+path as the path. An app that declares
 its own `uri` keeps it — the config wins over the fallback — so no existing app
 needs an edit.
 

--- a/.changeset/mcp-app-uri-from-path-agent.md
+++ b/.changeset/mcp-app-uri-from-path-agent.md
@@ -1,0 +1,19 @@
+---
+'@beatzball/litro-agent': minor
+---
+
+MCP Apps: `uri` is now optional in `defineMcpApp()`
+
+`buildMcpAppDocument(app, { uri })` takes a fallback address, which is what
+lets `litro mcp-app build` derive one from the file path. An app that declares
+its own `uri` keeps it — the config wins over the fallback — so no existing app
+needs an edit.
+
+URI validation moved from `defineMcpApp()` to `buildMcpAppDocument()`. An
+absent `uri` is only an error once it is known that no fallback is coming, and
+`defineMcpApp()` cannot know that. A malformed one is still rejected, and now
+a path-derived address is held to the same standard as a hand-written one.
+
+Calling `buildMcpAppDocument()` standalone is unchanged: with no file there is
+nothing to derive from, so it throws unless the config carries a `uri` or one
+is passed in.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -1,0 +1,25 @@
+---
+'@beatzball/litro': minor
+---
+
+`litro mcp-app build` derives each app's `ui://` address from its file path
+
+`mcp-apps/weather/card.ts` packs as `ui://weather/card`, the way
+`pages/blog/index.ts` serves `/blog`. Filesystem-as-routing is the convention
+everywhere else in Litro, and an app declaring its own address was the odd one
+out. An explicit `uri` in the config still wins, so nothing existing changes.
+
+A `ui://` address needs a host and a path, so one segment is not enough on its
+own: for a file sitting flat in `mcp-apps/`, the package name fills the first
+segment, and a package with no usable name gets an error naming both ways out.
+
+Dynamic segments are rejected. `[slug]`, `[[opt]]` and `[...all]` mean
+something in `pages/` and nothing here — a `ui://` resource is a static
+template the host caches by address, so there is no request to fill a
+parameter from.
+
+The uri and the output filename now come from one function, since the manifest
+pairs them and deriving them apart would let them drift.
+
+Also: an error thrown while loading an app file is now reported with the file
+named, instead of escaping the command as a raw stack.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -33,14 +33,16 @@ while the host caches it under another. This also closes a silent collision:
 address. An app that sets its own `uri` is exempt — the filename is only a
 filename then.
 
-Three refusals are NOT exemptible, because an address cannot answer them: a `.`
+Five refusals are NOT exemptible, because an address cannot answer them: a `.`
 or `..` segment, which does not survive path normalisation and, with a leading
-`..`, writes outside the output directory; a `#` or `?`, which the module loader
-reads as url syntax and then reports the file as missing; a C0 control
-character or Unicode line separator, which has no printable form and would
-appear as itself in the manifest, the descriptor and every error message
-(U+007F is deliberately allowed — it prints and it loads); and an app packing to
-`manifest` at the top level, where the index would overwrite its own descriptor
+`..`, writes outside the output directory; a backslash, which the glob's
+absolute form rewrites into `/` so the loader looks for a file that is not
+there; a `#` or `?`, which the module loader reads as url syntax and then
+reports the file as missing; a C0 control character or Unicode line separator,
+which has no printable form and would appear as itself in the manifest, the
+descriptor and every error message (U+007F is allowed: the line is drawn at the
+C0 range and DEL sits just outside it); and an app packing to `manifest` at the
+top level, where the index would overwrite its own descriptor
 (matched by Unicode case folding, since `Manifest.json` and `manifeſt.json` are
 both the same file as `manifest.json` on macOS and Windows).
 

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -4,19 +4,23 @@
 
 `litro mcp-app build` derives each app's `ui://` address from its file path
 
-`mcp-apps/weather/card.ts` packs as `ui://weather/card`, the way
-`pages/blog/index.ts` serves `/blog`. Filesystem-as-routing is the convention
+The package name is the authority and the file path is the path, so
+`mcp-apps/weather/card.ts` in a package named `playground` packs as
+`ui://playground/weather/card`. Filesystem-as-routing is the convention
 everywhere else in Litro, and an app declaring its own address was the odd one
 out. An explicit `uri` in the config still wins, so nothing existing changes.
 
-A `ui://` address needs a host and a path, so one segment is not enough on its
-own: for a file sitting flat in `mcp-apps/`, the package name fills the first
-segment, and a package with no usable name gets an error naming both ways out.
+One rule with no special cases: rename the package and every address moves
+together, which is what an authority is for. The authority comes from the
+package rather than the first folder because a `ui://` address needs a host AND
+a path — with the first folder as authority, a file sitting flat in `mcp-apps/`
+would give host `weather-card` and an empty path, a different shape from every
+nested file. A scoped name contributes only its last part.
 
 Dynamic segments are rejected. `[slug]`, `[[opt]]` and `[...all]` mean
 something in `pages/` and nothing here — a `ui://` resource is a static
 template the host caches by address, so there is no request to fill a
-parameter from.
+parameter from. `index.ts` is not the folder root here either.
 
 The uri and the output filename now come from one function, since the manifest
 pairs them and deriving them apart would let them drift.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -8,22 +8,40 @@ The package name is the authority and the file path is the path, so
 `mcp-apps/weather/card.ts` in a package named `playground` packs as
 `ui://playground/weather/card`. Filesystem-as-routing is the convention
 everywhere else in Litro, and an app declaring its own address was the odd one
-out. An explicit `uri` in the config still wins, so nothing existing changes.
+out. An explicit `uri` in the config still wins.
 
 One rule with no special cases: rename the package and every address moves
 together, which is what an authority is for. The authority comes from the
 package rather than the first folder because a `ui://` address needs a host AND
 a path — with the first folder as authority, a file sitting flat in `mcp-apps/`
 would give host `weather-card` and an empty path, a different shape from every
-nested file. A scoped name contributes only its last part.
+nested file. A scoped name contributes only its last part, and a name that
+cannot be a uri host means every app in that project must set `uri` itself.
+
+**The output now mirrors the source tree.** `mcp-apps/weather/card.ts` writes
+`dist/mcp-apps/weather/card.html`, not `weather-card.html`. The old flattening
+let `weather/card.ts` and `weather-card.ts` — two files with two DIFFERENT
+addresses — claim one output file, so the build had to detect the clash and
+refuse; mirroring makes it unrepresentable. `manifest.json` paths stay relative
+to the output directory, so a server reading the manifest needs no change.
+Nested app files are new in this release, so no existing output moves.
+
+**Names that cannot become an address are refused.** File and folder names may
+use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a
+non-ASCII letter is rejected: a parser rewrites it, so the descriptor would
+name a resource under one address while the host caches it under another. This
+also closes a silent collision — `big card.ts` and `big%20card.ts` are two raw
+strings that resolve to one address, which neither the output check nor the uri
+check could see. Dot segments (`.`, `..`) are refused for the same reason.
+
+**Every problem is reported at once**, before a module is loaded or a byte is
+written, instead of one failed build per mistake. `assertUniqueUris` now
+compares what a parser resolves an address to, not the raw text, and lists
+every clash rather than the first.
 
 Dynamic segments are rejected. `[slug]`, `[[opt]]` and `[...all]` mean
-something in `pages/` and nothing here — a `ui://` resource is a static
-template the host caches by address, so there is no request to fill a
-parameter from. `index.ts` is not the folder root here either.
+something in `pages/` and nothing here. `index.ts` is not the folder root here
+either.
 
-The uri and the output filename now come from one function, since the manifest
-pairs them and deriving them apart would let them drift.
-
-Also: an error thrown while loading an app file is now reported with the file
+Also: an error thrown while loading an app file is reported with the file
 named, instead of escaping the command as a raw stack.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -34,24 +34,31 @@ cannot be a uri host means every app in that project must set `uri` itself.
 
 **Names that cannot become an address are refused — unless the app names one.**
 For a DERIVED address, file and folder names may use letters, digits, `.`, `_`,
-`~` and `-`; a space, `?`, `#`, `%` or a non-ASCII letter is rejected, because a
-parser rewrites it and the descriptor would then name a resource under one
-address while the host caches it under another. This also closes a silent
-collision: `big card.ts` and `big%20card.ts` are two raw strings that resolve to
-one address. An app that sets its own `uri` is exempt — the filename is only a
-filename then. Only `.` and `..` are refused outright, since they would write
-outside the output directory.
+`~` and `-`; a space, `%` or a non-ASCII letter is rejected, because a parser
+rewrites it and the descriptor would then name a resource under one address
+while the host caches it under another. This also closes a silent collision:
+`big card.ts` and `big%20card.ts` are two raw strings that resolve to one
+address. An app that sets its own `uri` is exempt — the filename is only a
+filename then.
 
-**Every problem is reported at once**, before a module is loaded or a byte is
-written, instead of one failed build per mistake. `assertUniqueUris` compares
-RFC 3986 equivalence — folding host case and percent-triplet case on top of
-what `new URL()` does — and lists every clash rather than the first. An app
-packing to `manifest` at the top level is refused, because the index would
-overwrite its descriptor.
+Three refusals are NOT exemptible, because an address cannot answer them: a `.`
+or `..` segment, which would write outside the output directory; a `#`, `?` or
+control character, which the module loader reads as part of a url and then
+reports the file as missing; and an app packing to `manifest` at the top level,
+where the index would overwrite its own descriptor (matched without regard to
+case, since `Manifest.json` is the same file on macOS and Windows).
 
-Dynamic segments are rejected for a derived address. `[slug]`, `[[opt]]` and
-`[...all]` mean something in `pages/` and nothing here. `index.ts` is not the
-folder root here either.
+**Problems are reported at once** where they can be, before a module is loaded
+or a byte is written, instead of one failed build per mistake. The exception is
+a character that only breaks a DERIVED address: whether it matters depends on
+whether the app declares its own `uri`, which is not known until the file
+loads. `assertUniqueUris` compares RFC 3986 equivalence — folding host case and
+percent-triplet case on top of what `new URL()` does — and lists every clash
+rather than the first.
+
+Dynamic segments are rejected for a derived address, and exempt alongside an
+explicit one. `[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and
+nothing here. `index.ts` is not the folder root here either.
 
 Also: an error thrown while loading an app file is reported with the file
 named, instead of escaping the command as a raw stack.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -4,9 +4,23 @@
 
 `litro mcp-app build` derives each app's `ui://` address from its file path
 
-The package name is the authority and the file path is the path, so
-`mcp-apps/weather/card.ts` in a package named `playground` packs as
-`ui://playground/weather/card`. Filesystem-as-routing is the convention
+**BREAKING for a project with app files in subfolders.** The output now mirrors
+the source tree: `mcp-apps/weather/card.ts` writes
+`dist/mcp-apps/weather/card.html`, where 0.15.0 wrote `weather-card.html`. The
+recursive glob is already published, so this MOVES existing output. Anything
+pinned to the flat path has to follow — a static mount, a `COPY` line, a path
+written into a server config. Reading `manifest.json` and using its `html` and
+`descriptor` entries needs no change; they stay relative to the output
+directory. A project whose app files all sit flat in `mcp-apps/` is unaffected.
+
+The reason for the move is that flattening let `weather/card.ts` and
+`weather-card.ts` — two files with two DIFFERENT addresses — claim one output
+file, so the build had to detect that clash and refuse. Mirroring makes it
+unrepresentable instead of merely detected.
+
+**The address itself.** The package name is the authority and the file path is
+the path, so `mcp-apps/weather/card.ts` in a package named `playground` packs
+as `ui://playground/weather/card`. Filesystem-as-routing is the convention
 everywhere else in Litro, and an app declaring its own address was the odd one
 out. An explicit `uri` in the config still wins.
 
@@ -18,30 +32,26 @@ would give host `weather-card` and an empty path, a different shape from every
 nested file. A scoped name contributes only its last part, and a name that
 cannot be a uri host means every app in that project must set `uri` itself.
 
-**The output now mirrors the source tree.** `mcp-apps/weather/card.ts` writes
-`dist/mcp-apps/weather/card.html`, not `weather-card.html`. The old flattening
-let `weather/card.ts` and `weather-card.ts` — two files with two DIFFERENT
-addresses — claim one output file, so the build had to detect the clash and
-refuse; mirroring makes it unrepresentable. `manifest.json` paths stay relative
-to the output directory, so a server reading the manifest needs no change.
-Nested app files are new in this release, so no existing output moves.
-
-**Names that cannot become an address are refused.** File and folder names may
-use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a
-non-ASCII letter is rejected: a parser rewrites it, so the descriptor would
-name a resource under one address while the host caches it under another. This
-also closes a silent collision — `big card.ts` and `big%20card.ts` are two raw
-strings that resolve to one address, which neither the output check nor the uri
-check could see. Dot segments (`.`, `..`) are refused for the same reason.
+**Names that cannot become an address are refused — unless the app names one.**
+For a DERIVED address, file and folder names may use letters, digits, `.`, `_`,
+`~` and `-`; a space, `?`, `#`, `%` or a non-ASCII letter is rejected, because a
+parser rewrites it and the descriptor would then name a resource under one
+address while the host caches it under another. This also closes a silent
+collision: `big card.ts` and `big%20card.ts` are two raw strings that resolve to
+one address. An app that sets its own `uri` is exempt — the filename is only a
+filename then. Only `.` and `..` are refused outright, since they would write
+outside the output directory.
 
 **Every problem is reported at once**, before a module is loaded or a byte is
-written, instead of one failed build per mistake. `assertUniqueUris` now
-compares what a parser resolves an address to, not the raw text, and lists
-every clash rather than the first.
+written, instead of one failed build per mistake. `assertUniqueUris` compares
+RFC 3986 equivalence — folding host case and percent-triplet case on top of
+what `new URL()` does — and lists every clash rather than the first. An app
+packing to `manifest` at the top level is refused, because the index would
+overwrite its descriptor.
 
-Dynamic segments are rejected. `[slug]`, `[[opt]]` and `[...all]` mean
-something in `pages/` and nothing here. `index.ts` is not the folder root here
-either.
+Dynamic segments are rejected for a derived address. `[slug]`, `[[opt]]` and
+`[...all]` mean something in `pages/` and nothing here. `index.ts` is not the
+folder root here either.
 
 Also: an error thrown while loading an app file is reported with the file
 named, instead of escaping the command as a raw stack.

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -4,25 +4,17 @@
 
 `litro mcp-app build` derives each app's `ui://` address from its file path
 
-**BREAKING for a project with app files in subfolders.** The output now mirrors
-the source tree: `mcp-apps/weather/card.ts` writes
-`dist/mcp-apps/weather/card.html`, where 0.15.0 wrote `weather-card.html`. The
-recursive glob is already published, so this MOVES existing output. Anything
-pinned to the flat path has to follow — a static mount, a `COPY` line, a path
-written into a server config. Reading `manifest.json` and using its `html` and
-`descriptor` entries needs no change; they stay relative to the output
-directory. A project whose app files all sit flat in `mcp-apps/` is unaffected.
-
-The reason for the move is that flattening let `weather/card.ts` and
-`weather-card.ts` — two files with two DIFFERENT addresses — claim one output
-file, so the build had to detect that clash and refuse. Mirroring makes it
-unrepresentable instead of merely detected.
-
-**The address itself.** The package name is the authority and the file path is
-the path, so `mcp-apps/weather/card.ts` in a package named `playground` packs
-as `ui://playground/weather/card`. Filesystem-as-routing is the convention
+The package name is the authority and the file path is the path, so
+`mcp-apps/weather/card.ts` in a package named `playground` packs as
+`ui://playground/weather/card`. Filesystem-as-routing is the convention
 everywhere else in Litro, and an app declaring its own address was the odd one
 out. An explicit `uri` in the config still wins.
+
+The output mirrors the source tree to match, so `mcp-apps/weather/card.ts`
+writes `dist/mcp-apps/weather/card.html` — 0.15.0 flattened that to
+`weather-card.html`, which let it collide with a real `weather-card.ts`. If you
+already had app files in subfolders, their output paths move; `manifest.json`
+entries stay relative to the output directory, so reading those needs no change.
 
 One rule with no special cases: rename the package and every address moves
 together, which is what an authority is for. The authority comes from the

--- a/.changeset/mcp-app-uri-from-path-cli.md
+++ b/.changeset/mcp-app-uri-from-path-cli.md
@@ -34,11 +34,15 @@ address. An app that sets its own `uri` is exempt — the filename is only a
 filename then.
 
 Three refusals are NOT exemptible, because an address cannot answer them: a `.`
-or `..` segment, which would write outside the output directory; a `#`, `?` or
-control character, which the module loader reads as part of a url and then
-reports the file as missing; and an app packing to `manifest` at the top level,
-where the index would overwrite its own descriptor (matched without regard to
-case, since `Manifest.json` is the same file on macOS and Windows).
+or `..` segment, which does not survive path normalisation and, with a leading
+`..`, writes outside the output directory; a `#` or `?`, which the module loader
+reads as url syntax and then reports the file as missing; a C0 control
+character or Unicode line separator, which has no printable form and would
+appear as itself in the manifest, the descriptor and every error message
+(U+007F is deliberately allowed — it prints and it loads); and an app packing to
+`manifest` at the top level, where the index would overwrite its own descriptor
+(matched by Unicode case folding, since `Manifest.json` and `manifeſt.json` are
+both the same file as `manifest.json` on macOS and Windows).
 
 **Problems are reported at once** where they can be, before a module is loaded
 or a byte is written, instead of one failed build per mistake. The exception is

--- a/e2e/mcp-app/document.spec.ts
+++ b/e2e/mcp-app/document.spec.ts
@@ -132,3 +132,42 @@ test('the document loads nothing from the network', async ({ page }) => {
   // would fail silently there, so it must request nothing.
   expect(external).toEqual([]);
 });
+
+/**
+ * The derived address, end to end through the real CLI.
+ *
+ * The unit tests cover `uriFromFile` as a pure function, and `index.test.ts`
+ * covers the packager taking a uri. NOTHING joined the two: the line that hands
+ * the derived value to the packager could be deleted — the whole feature — and
+ * all 46 unit tests still passed. That mutation now fails here.
+ */
+test('the manifest carries the address derived from each file path', () => {
+  const outDir = join(playground, 'dist', 'mcp-apps');
+  const manifest = JSON.parse(readFileSync(join(outDir, 'manifest.json'), 'utf8')) as {
+    name: string;
+    uri: string;
+    html: string;
+    descriptor: string;
+  }[];
+
+  // Neither app file declares a `uri`. The package is named "playground" and
+  // the files sit flat in `mcp-apps/`, so these are what the path must produce.
+  expect(manifest.map((a) => a.uri).sort()).toEqual([
+    'ui://playground/weather-card',
+    'ui://playground/weather-refresh',
+  ]);
+
+  for (const app of manifest) {
+    // The output path mirrors the uri path — the invariant that makes an
+    // output-file clash unrepresentable rather than merely detected.
+    expect(app.html).toBe(`${app.uri.replace('ui://playground/', '')}.html`);
+    expect(existsSync(join(outDir, app.html))).toBe(true);
+
+    // The descriptor a host actually reads must carry the same address, not
+    // just the manifest index.
+    const descriptor = JSON.parse(readFileSync(join(outDir, app.descriptor), 'utf8')) as {
+      uri: string;
+    };
+    expect(descriptor.uri).toBe(app.uri);
+  }
+});

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -67,7 +67,7 @@ For a project whose `package.json` says `"name": "playground"`:
 
 One rule, no special cases: rename the package and every address moves together, which is what an authority is for.
 
-The authority comes from the package rather than the first folder because a `ui://` address needs a host **and** a path. If the first folder were the authority, a file sitting flat in `mcp-apps/` would give host `weather-card` and an *empty* path — a different shape from every nested file, which a host that groups by authority treats differently. A scoped name contributes only its last part: `@beatzball/playground` gives `playground`.
+The authority comes from the package rather than the first folder because a `ui://` address needs a host **and** a path. If the first folder were the authority, a file sitting flat in `mcp-apps/` would give host `weather-card` and an *empty* path — a different shape from every nested file, which a host that groups by authority treats differently. A scoped name contributes only its last part: `@beatzball/playground` gives `playground`. The name must be usable as a uri host — lowercase letters, digits, `.`, `_` and `-` — so a package called `@acme/MyApp` cannot supply one. Such a project still packs, but every app in it has to set `uri` itself.
 
 **`index.ts` is not special.** In `pages/`, `blog/index.ts` serves the folder root. Here `weather/index.ts` is `ui://playground/weather/index` — collapsing it would silently merge with a sibling `weather.ts`.
 
@@ -96,15 +96,25 @@ await buildMcpAppDocument(app, { uri: 'ui://weather/card' });
 litro mcp-app build
 ```
 
-For each `mcp-apps/*.ts` this writes, into `dist/mcp-apps/`:
+Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/`. **The output mirrors the source tree**, so the file path, the output path and the address are the same path three times:
 
-| File | Contents |
-|---|---|
-| `<name>.html` | the self-contained document |
-| `<name>.json` | the resource descriptor — `text/html;profile=mcp-app` plus `_meta.ui` |
-| `manifest.json` | every app, so a server can load them in one read |
+| Source | Output | Address |
+|---|---|---|
+| `mcp-apps/weather-card.ts` | `dist/mcp-apps/weather-card.html` + `.json` | `ui://playground/weather-card` |
+| `mcp-apps/weather/card.ts` | `dist/mcp-apps/weather/card.html` + `.json` | `ui://playground/weather/card` |
 
-`--dir` and `--out` override the defaults. The build **fails** if two apps declare the same `ui://` address: a host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup.
+`manifest.json` lists every app, so a server can load them in one read. Its `html` and `descriptor` entries are paths relative to the output directory, so a nested app is `weather/card.html`.
+
+`--dir` and `--out` override the defaults.
+
+### When the build refuses
+
+It reports **every** problem it can see from the file paths alone, in one list, before loading a module or writing a byte:
+
+- **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
+- **A character a uri parser would rewrite.** File and folder names may use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a non-ASCII letter is refused, because a parser rewrites it — `big card.ts` would ship the address `ui://playground/big card` while a host caches under `ui://playground/big%20card`, and the descriptor would name a resource the host cannot find. Rename the file, or set `uri` yourself.
+- **A dynamic segment**, or a `.` / `..` segment.
+- **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by what a parser resolves the address to, not by the raw text.
 
 The output is plain files. Any MCP server can serve them; nothing assumes the serving side is a Litro one.
 

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -40,7 +40,6 @@ import { DemoWeatherCard } from '../components/demo-weather-card.js';
 void DemoWeatherCard; // named import + void: bare side-effect imports get tree-shaken
 
 export default defineMcpApp({
-  uri: 'ui://playground/weather-card',
   title: 'Weather',
 
   // Rendered with no data — a host caches this and reuses it every call.
@@ -52,7 +51,40 @@ export default defineMcpApp({
 });
 ```
 
-`uri` must start with `ui://`. `shell` is a template for whichever renderer `LITRO_ADAPTER` selects — a Lit `TemplateResult`, or an HTML string for FAST. Elena is not supported, because `ui()` does not support it yet.
+`shell` is a template for whichever renderer `LITRO_ADAPTER` selects — a Lit `TemplateResult`, or an HTML string for FAST. Elena is not supported, because `ui()` does not support it yet.
+
+## The uri comes from the file path
+
+There is no `uri` in that file. The packer derives one from where the file sits, the way `pages/blog/index.ts` serves `/blog`:
+
+| File in `mcp-apps/` | Address |
+|---|---|
+| `weather/card.ts` | `ui://weather/card` |
+| `dashboard/charts/bar.ts` | `ui://dashboard/charts/bar` |
+| `weather-card.ts` | `ui://<package name>/weather-card` |
+
+A `ui://` address needs a host and a path, so a single segment is not enough on its own. For a file sitting flat in `mcp-apps/`, the **package name** fills the first segment — `weather-card.ts` in a package named `playground` becomes `ui://playground/weather-card`. Give the file a folder instead if you would rather see the whole address in the file tree.
+
+**`index.ts` is not special.** In `pages/`, `blog/index.ts` serves the folder root. Here `weather/index.ts` is `ui://weather/index` — collapsing it would leave `ui://weather`, a host with no path, which is the one shape this convention avoids.
+
+**No dynamic segments.** `[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and nothing here. A `ui://` resource is a static template the host caches by address, so there is no request to fill a parameter from. The build rejects them rather than shipping a literal `[slug]` in a protocol-visible address.
+
+### Setting one by hand
+
+`uri` is still accepted, and an explicit one always wins over the derived value:
+
+```ts
+export default defineMcpApp({
+  uri: 'ui://weather/current-conditions',
+  shell,
+});
+```
+
+Use it when the address must not follow the filename, or when you call `buildMcpAppDocument()` yourself — with no file there is nothing to derive from, and it throws unless the config carries a `uri` or you pass one:
+
+```ts
+await buildMcpAppDocument(app, { uri: 'ui://weather/card' });
+```
 
 ## Building
 

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -67,11 +67,11 @@ For a project whose `package.json` says `"name": "playground"`:
 
 One rule, no special cases: rename the package and every address moves together, which is what an authority is for.
 
-The authority comes from the package rather than the first folder because a `ui://` address needs a host **and** a path. If the first folder were the authority, a file sitting flat in `mcp-apps/` would give host `weather-card` and an *empty* path — a different shape from every nested file, which a host that groups by authority treats differently. A scoped name contributes only its last part: `@beatzball/playground` gives `playground`. The name must be usable as a uri host — lowercase letters, digits, `.`, `_` and `-` — so a package called `@acme/MyApp` cannot supply one. Such a project still packs, but every app in it has to set `uri` itself.
+The authority comes from the package rather than the first folder because a `ui://` address needs a host **and** a path. If the first folder were the authority, a file sitting flat in `mcp-apps/` would give host `weather-card` and an *empty* path — a different shape from every nested file, which a host that groups by authority treats differently. A scoped name contributes only its last part: `@beatzball/playground` gives `playground`. The name must be usable as a uri host — lowercase letters, digits, `.`, `_` and `-`, starting with a letter or digit — so a package called `@acme/MyApp` cannot supply one. Such a project still packs, but every app in it has to set `uri` itself.
 
 **`index.ts` is not special.** In `pages/`, `blog/index.ts` serves the folder root. Here `weather/index.ts` is `ui://playground/weather/index` — collapsing it would silently merge with a sibling `weather.ts`.
 
-**No dynamic segments.** `[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and nothing here. A `ui://` resource is a static template the host caches by address, so there is no request to fill a parameter from. The build rejects them rather than shipping a literal `[slug]` in a protocol-visible address.
+**No dynamic segments in a derived address.** `[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and nothing here. A `ui://` resource is a static template the host caches by address, so there is no request to fill a parameter from. The build rejects them rather than shipping a literal `[slug]` in a protocol-visible address — unless the app sets its own `uri`, in which case the filename is just a filename.
 
 ### Setting one by hand
 
@@ -96,7 +96,7 @@ await buildMcpAppDocument(app, { uri: 'ui://weather/card' });
 litro mcp-app build
 ```
 
-Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/`. **The output mirrors the source tree**, so the file path, the output path and the address are the same path three times:
+Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/` — except four names that are skipped without a word: `*.d.ts`, `*.test.ts`, `*.spec.ts`, and anything starting with `-`. The leading dash is the convention for a partial an app imports rather than an app itself. A file matching one of those produces no output and no warning, so check the name first if an app seems to vanish. **The output mirrors the source tree**, so the file path and the output path are the same path — and so is the address, whenever it is derived:
 
 | Source | Output | Address |
 |---|---|---|
@@ -114,8 +114,11 @@ Most problems are reported **all at once**, before a module is loaded or a byte 
 Refused no matter what the app says:
 
 - **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
-- **A `#`, `?`, C0 control character or line separator in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists. Setting `uri` does not help: a file has to be loadable before its address matters. (A literal backslash in a filename is the one gap here — it is folded to `/` for Windows before the check sees it, and still fails at load.)
-- **A `.` or `..` segment.** It would resolve to a path outside the output directory.
+- **A `#` or `?` in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists.
+- **A C0 control character or line separator (U+2028, U+2029) in the name.** These have no printable form, and the path is written verbatim into `manifest.json`, into the descriptor, and into every error message about the app. `U+007F` is *not* refused — it prints, it loads, and a rule with no failure behind it is noise.
+
+  Setting `uri` does not help for either of those: neither failure is about the address. A literal backslash is the one gap — `fast-glob` reports `a\b.ts` as `a/b.ts` before the build sees it, so it slips past and then fails loudly at load.
+- **A `.` or `..` segment.** Neither survives normalisation, so the path written down is not the path that gets resolved — and enough leading `..` lands outside the output directory entirely.
 - **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it. Matched without regard to case, because `Manifest.json` is the same file on macOS and Windows.
 - **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by RFC 3986 equivalence, so `ui://PKG/a` and `ui://pkg/a` are one address, not two.
 

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -96,7 +96,7 @@ await buildMcpAppDocument(app, { uri: 'ui://weather/card' });
 litro mcp-app build
 ```
 
-Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/` — except four names that are skipped without a word: `*.d.ts`, `*.test.ts`, `*.spec.ts`, and anything starting with `-`. The leading dash is the convention for a partial an app imports rather than an app itself. A file matching one of those produces no output and no warning, so check the name first if an app seems to vanish. **The output mirrors the source tree**, so the file path and the output path are the same path — and so is the address, whenever it is derived:
+Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/` — except four names that are skipped without a word: `*.d.ts`, `*.test.ts`, `*.spec.ts`, and anything starting with `-`. The leading dash is the same switch `pages/` uses — rename a file to `-card.ts` to turn it off without deleting it. A file matching any of those produces no output and no warning, so check the name first if an app seems to vanish. **The output mirrors the source tree**, so the file path and the output path are the same path — and so is the address, whenever it is derived:
 
 | Source | Output | Address |
 |---|---|---|
@@ -115,9 +115,11 @@ Refused no matter what the app says:
 
 - **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
 - **A `#` or `?` in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists.
-- **A C0 control character or line separator (U+2028, U+2029) in the name.** These have no printable form, and the path is written verbatim into `manifest.json`, into the descriptor, and into every error message about the app. `U+007F` is *not* refused — it prints, it loads, and a rule with no failure behind it is noise.
+- **A C0 control character or line separator (U+2028, U+2029) in the name.** These have no printable form, and the path is written verbatim into `manifest.json`, into the descriptor, and into every error message about the app. `U+007F` is *not* refused: the line is drawn at the C0 range, and DEL sits just outside it. It is invisible too, so this is a boundary rather than a principle — as are the zero-width characters above it.
 
-  Setting `uri` does not help for either of those: neither failure is about the address. A literal backslash is the one gap — `fast-glob` reports `a\b.ts` as `a/b.ts` before the build sees it, so it slips past and then fails loudly at load.
+- **A backslash in the name.** The build resolves app files to absolute paths, and that rewrites `a\b.ts` into `a/b.ts` — so the loader would look for a file that is not there.
+
+  Setting `uri` does not help for any of those three: none of them is about the address.
 - **A `.` or `..` segment.** Neither survives normalisation, so the path written down is not the path that gets resolved — and enough leading `..` lands outside the output directory entirely.
 - **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it. Matched without regard to case, because `Manifest.json` is the same file on macOS and Windows.
 - **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by RFC 3986 equivalence, so `ui://PKG/a` and `ui://pkg/a` are one address, not two.

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -55,17 +55,21 @@ export default defineMcpApp({
 
 ## The uri comes from the file path
 
-There is no `uri` in that file. The packer derives one from where the file sits, the way `pages/blog/index.ts` serves `/blog`:
+There is no `uri` in that file. The packer derives one: the **package name** is the authority, and the **file path** is the path.
+
+For a project whose `package.json` says `"name": "playground"`:
 
 | File in `mcp-apps/` | Address |
 |---|---|
-| `weather/card.ts` | `ui://weather/card` |
-| `dashboard/charts/bar.ts` | `ui://dashboard/charts/bar` |
-| `weather-card.ts` | `ui://<package name>/weather-card` |
+| `weather-card.ts` | `ui://playground/weather-card` |
+| `weather/card.ts` | `ui://playground/weather/card` |
+| `dashboard/charts/bar.ts` | `ui://playground/dashboard/charts/bar` |
 
-A `ui://` address needs a host and a path, so a single segment is not enough on its own. For a file sitting flat in `mcp-apps/`, the **package name** fills the first segment — `weather-card.ts` in a package named `playground` becomes `ui://playground/weather-card`. Give the file a folder instead if you would rather see the whole address in the file tree.
+One rule, no special cases: rename the package and every address moves together, which is what an authority is for.
 
-**`index.ts` is not special.** In `pages/`, `blog/index.ts` serves the folder root. Here `weather/index.ts` is `ui://weather/index` — collapsing it would leave `ui://weather`, a host with no path, which is the one shape this convention avoids.
+The authority comes from the package rather than the first folder because a `ui://` address needs a host **and** a path. If the first folder were the authority, a file sitting flat in `mcp-apps/` would give host `weather-card` and an *empty* path — a different shape from every nested file, which a host that groups by authority treats differently. A scoped name contributes only its last part: `@beatzball/playground` gives `playground`.
+
+**`index.ts` is not special.** In `pages/`, `blog/index.ts` serves the folder root. Here `weather/index.ts` is `ui://playground/weather/index` — collapsing it would silently merge with a sibling `weather.ts`.
 
 **No dynamic segments.** `[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and nothing here. A `ui://` resource is a static template the host caches by address, so there is no request to fill a parameter from. The build rejects them rather than shipping a literal `[slug]` in a protocol-visible address.
 

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -96,7 +96,7 @@ await buildMcpAppDocument(app, { uri: 'ui://weather/card' });
 litro mcp-app build
 ```
 
-Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/` — except four names that are skipped without a word: `*.d.ts`, `*.test.ts`, `*.spec.ts`, and anything starting with `-`. The leading dash is the same switch `pages/` uses — rename a file to `-card.ts` to turn it off without deleting it. A file matching any of those produces no output and no warning, so check the name first if an app seems to vanish. **The output mirrors the source tree**, so the file path and the output path are the same path — and so is the address, whenever it is derived:
+Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed into `dist/mcp-apps/` — except four kinds of name that are skipped without a word: a declaration file (`*.d.ts`, `*.d.mts`), a test (`*.test.*`), a spec (`*.spec.*`), and any **file** whose name starts with `-`. The leading dash is the same switch `pages/` uses — rename `card.tsx` to `-card.tsx` to turn it off without deleting it. It matches a filename, not a folder, so `-drafts/card.ts` still builds. A skipped file produces no output and no warning, so check the name first if an app seems to vanish. **The output mirrors the source tree**, so the file path and the output path are the same path — and so is the address, whenever it is derived:
 
 | Source | Output | Address |
 |---|---|---|

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -109,12 +109,12 @@ Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed i
 
 ### When the build refuses
 
-Most problems are reported **all at once**, before a module is loaded or a byte is written. The last one below is the exception: whether it applies depends on what the app declares, so it can only surface once the file is loaded — by which time earlier apps are already on disk.
+Most problems are reported **all at once**, before a module is loaded or a byte is written. The second group below is the exception: whether those apply depends on what the app declares, so they can only surface once the file is loaded — by which time earlier apps are already on disk.
 
 Refused no matter what the app says:
 
 - **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
-- **A `#`, `?` or control character in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists. Setting `uri` does not help: a file has to be loadable before its address matters.
+- **A `#`, `?`, C0 control character or line separator in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists. Setting `uri` does not help: a file has to be loadable before its address matters. (A literal backslash in a filename is the one gap here — it is folded to `/` for Windows before the check sees it, and still fails at load.)
 - **A `.` or `..` segment.** It would resolve to a path outside the output directory.
 - **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it. Matched without regard to case, because `Manifest.json` is the same file on macOS and Windows.
 - **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by RFC 3986 equivalence, so `ui://PKG/a` and `ui://pkg/a` are one address, not two.

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -112,9 +112,10 @@ Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed i
 It reports **every** problem it can see from the file paths alone, in one list, before loading a module or writing a byte:
 
 - **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
-- **A character a uri parser would rewrite.** File and folder names may use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a non-ASCII letter is refused, because a parser rewrites it — `big card.ts` would ship the address `ui://playground/big card` while a host caches under `ui://playground/big%20card`, and the descriptor would name a resource the host cannot find. Rename the file, or set `uri` yourself.
-- **A dynamic segment**, or a `.` / `..` segment.
-- **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by what a parser resolves the address to, not by the raw text.
+- **A character a uri parser would rewrite**, in a file whose address is being derived. Names may use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a non-ASCII letter is refused, because a parser rewrites it — `big card.ts` would ship the address `ui://playground/big card` while a host caches under `ui://playground/big%20card`, and the descriptor would name a resource the host cannot find. **An app that sets its own `uri` is exempt:** the filename is only a filename then, and `big card.ts` packs happily to `big card.html`. Dynamic segments (`[slug]`, `[[opt]]`, `[...all]`) work the same way — refused for a derived address, fine alongside an explicit one.
+- **A `.` or `..` segment**, always. That one no `uri` can excuse: it would write outside the output directory.
+- **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it.
+- **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by RFC 3986 equivalence, so `ui://PKG/a` and `ui://pkg/a` are one address, not two.
 
 The output is plain files. Any MCP server can serve them; nothing assumes the serving side is a Litro one.
 

--- a/packages/docs-content/content/docs/mcp-apps.md
+++ b/packages/docs-content/content/docs/mcp-apps.md
@@ -109,13 +109,20 @@ Every `.ts`, `.tsx` and `.mts` file under `mcp-apps/`, at any depth, is packed i
 
 ### When the build refuses
 
-It reports **every** problem it can see from the file paths alone, in one list, before loading a module or writing a byte:
+Most problems are reported **all at once**, before a module is loaded or a byte is written. The last one below is the exception: whether it applies depends on what the app declares, so it can only surface once the file is loaded — by which time earlier apps are already on disk.
+
+Refused no matter what the app says:
 
 - **Two files, one output.** `weather/card.ts` and `weather/card.tsx` both pack to `weather/card.html`. (`weather/card.ts` and `weather-card.ts` do **not** clash — mirroring the tree is what makes that impossible.)
-- **A character a uri parser would rewrite**, in a file whose address is being derived. Names may use letters, digits, `.`, `_`, `~` and `-`. A space, `?`, `#`, `%` or a non-ASCII letter is refused, because a parser rewrites it — `big card.ts` would ship the address `ui://playground/big card` while a host caches under `ui://playground/big%20card`, and the descriptor would name a resource the host cannot find. **An app that sets its own `uri` is exempt:** the filename is only a filename then, and `big card.ts` packs happily to `big card.html`. Dynamic segments (`[slug]`, `[[opt]]`, `[...all]`) work the same way — refused for a derived address, fine alongside an explicit one.
-- **A `.` or `..` segment**, always. That one no `uri` can excuse: it would write outside the output directory.
-- **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it.
+- **A `#`, `?` or control character in the name.** The module loader reads an id as a url, so `weather#card.ts` is looked up as `weather` and reported as missing for a file that plainly exists. Setting `uri` does not help: a file has to be loadable before its address matters.
+- **A `.` or `..` segment.** It would resolve to a path outside the output directory.
+- **An app packing to `manifest` at the top level.** `manifest.json` is the index, and it would overwrite the app's own descriptor. Put it in a folder, or rename it. Matched without regard to case, because `Manifest.json` is the same file on macOS and Windows.
 - **Two apps claiming one address.** Only reachable by writing `uri` by hand. A host caches templates by URI, so a collision does not merge or warn — one app would quietly serve the other's markup. Compared by RFC 3986 equivalence, so `ui://PKG/a` and `ui://pkg/a` are one address, not two.
+
+Refused only when the address is being **derived**, and excused by setting `uri` yourself:
+
+- **A character a uri parser would rewrite.** A derived name may use letters, digits, `.`, `_`, `~` and `-`. A space, `%` or a non-ASCII letter is refused, because a parser rewrites it — `big card.ts` would ship `ui://playground/big card` while a host caches under `ui://playground/big%20card`, and the descriptor would name a resource the host cannot find. With an explicit `uri` the filename is only a filename, and `big card.ts` packs to `big card.html`.
+- **A dynamic segment** — `[slug]`, `[[opt]]`, `[...all]`. Same rule: refused for a derived address, fine alongside an explicit one.
 
 The output is plain files. Any MCP server can serve them; nothing assumes the serving side is a Litro one.
 

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   appSegmentsFromFile,
   assertUniqueUris,
@@ -44,8 +47,19 @@ describe('outputPathFromFile', () => {
     },
   );
 
-  it('refuses a control character in the name', () => {
-    expect(() => outputPathFromFile('weather\u0001card.ts')).toThrow(/module loader/);
+  it.each([
+    ['weather\u0001card.ts', 'a C0 control character'],
+    ['weather\u2028card.ts', 'U+2028, a line separator above the C0 range'],
+    ['weather\u2029card.ts', 'U+2029, a paragraph separator'],
+  ])('refuses %s (%s)', (input) => {
+    expect(() => outputPathFromFile(input)).toThrow(/module loader/);
+  });
+
+  it('does NOT refuse DEL, which the loader handles fine', () => {
+    // U+007F is a control character by Unicode category but sits above the C0
+    // range, and Vite loads it without complaint. Refusing it would be a rule
+    // with no failure behind it.
+    expect(outputPathFromFile('weather\u007Fcard.ts')).toBe('weather\u007Fcard');
   });
 
   it('says plainly that an explicit uri does not help for a loader character', () => {
@@ -165,7 +179,73 @@ describe('uriFromFile', () => {
   });
 });
 
+/**
+ * Drives the REAL command against a throwaway project.
+ *
+ * Everything asserted here is refused in the pre-flight, which returns before
+ * Vite is ever created — so these need no module resolution and stay fast. That
+ * is also the point: the pre-flight is CLI code, and pure-function tests cannot
+ * reach it. The manifest guard was reverted to its broken form and 62 tests
+ * stayed green, twice over three rounds.
+ */
+function buildWith(files: Record<string, string>): Promise<{ code: number; errors: string }> {
+  const root = mkdtempSync(join(tmpdir(), 'litro-mcp-app-'));
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fixture' }));
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(root, 'mcp-apps', rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  }
+  const errors: string[] = [];
+  const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
+    errors.push(a.join(' '));
+  });
+  return mcpAppCommand(['build'], root)
+    .then((code) => ({ code, errors: errors.join('\n') }))
+    .finally(() => {
+      spy.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    });
+}
+
 describe('the reserved manifest stem', () => {
+  const APP = 'export default {};';
+
+  it('refuses a top-level manifest.ts through the real command', async () => {
+    const { code, errors } = await buildWith({ 'manifest.ts': APP });
+    expect(code).toBe(1);
+    expect(errors).toMatch(/index listing every app/);
+  });
+
+  it('refuses Manifest.ts, because the filesystem does not distinguish one', async () => {
+    // On APFS and NTFS `Manifest.json` IS `manifest.json`, so a case-sensitive
+    // check let one capital letter reproduce the whole clobber. Shipped broken
+    // once, fixed, and the suite never noticed either time.
+    const { code, errors } = await buildWith({ 'Manifest.ts': APP });
+    expect(code).toBe(1);
+    expect(errors).toMatch(/index listing every app/);
+  });
+
+  it('refuses manifeſt.ts, which toLowerCase() alone does not fold', async () => {
+    // U+017F LONG S folds to "s" under the full Unicode rules APFS uses, but is
+    // ALREADY lowercase — so `toLowerCase()` leaves it and the filesystem still
+    // collides it. Verified against the real filesystem: writing `manifeſt.json`
+    // overwrites `manifest.json`.
+    const { code, errors } = await buildWith({ 'manife\u017Ft.ts': APP });
+    expect(code).toBe(1);
+    expect(errors).toMatch(/index listing every app/);
+  });
+
+  it('leaves a NESTED manifest.ts alone, which collides with nothing', async () => {
+    // Not refused by the pre-flight, so this one gets as far as loading the
+    // module — which fails for a fixture with no defineMcpApp(). Reaching that
+    // failure is the assertion: the manifest guard did not fire.
+    const { errors } = await buildWith({ 'sub/manifest.ts': APP });
+    expect(errors).not.toMatch(/index listing every app/);
+  });
+});
+
+describe('the reserved manifest stem, as a derivation', () => {
   // `manifest.json` is the index listing every app. An app packing to that stem
   // writes its descriptor there and has the index overwrite it, leaving the
   // manifest entry pointing `descriptor` at the array itself — exit 0, silent.

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -23,6 +23,23 @@ describe('outputPathFromFile', () => {
     expect(outputPathFromFile('weather.v2.ts')).toBe('weather.v2');
   });
 
+  it.each(['../escape.ts', 'a/../b.ts', 'a/./b.ts'])(
+    'refuses %s, which would write outside the output directory',
+    (input) => {
+      // The ONLY thing an output path refuses: `.` and `..` are resolved by the
+      // filesystem, so `../x` escapes the out dir. No explicit uri makes that
+      // safe, which is why this one is not recoverable.
+      expect(() => outputPathFromFile(input)).toThrow(/outside the output directory/);
+    },
+  );
+
+  it('refuses a path with no name left after the extension', () => {
+    // uriFromFile has the same guard; they must not disagree on emptiness, or
+    // an empty stem would reach join(outDir, '.html').
+    expect(() => outputPathFromFile('.ts')).toThrow(/no name to build an output file/);
+    expect(() => uriFromFile('.ts', 'playground')).toThrow(/no name to build a uri/);
+  });
+
   it('mirrors the uri path, so two files can never claim one output file', () => {
     // The old scheme flattened with "-", which let `weather/card.ts` and
     // `weather-card.ts` — two DIFFERENT addresses — both claim
@@ -116,10 +133,13 @@ describe('uriFromFile', () => {
       );
     });
 
-    it('rejects the same characters for the OUTPUT PATH, not only the uri', () => {
-      // Both derivations share one validator, so a file cannot be rejected as
-      // an address yet accepted as a filename.
-      expect(() => outputPathFromFile('big card.ts')).toThrow(/rewrites or reads as syntax/);
+    it('does NOT reject them for the OUTPUT PATH, so an explicit uri can rescue', () => {
+      // "big card.html" is a perfectly legal filename. Refusing it here would
+      // refuse an app that names its own uri and never needed one derived —
+      // an error naming a remedy the author had already applied.
+      expect(outputPathFromFile('big card.ts')).toBe('big card');
+      expect(outputPathFromFile('café.ts')).toBe('café');
+      expect(outputPathFromFile('[slug].ts')).toBe('[slug]');
     });
   });
 });
@@ -166,7 +186,37 @@ describe('assertUniqueUris', () => {
         { name: 'weather-card', uri: 'ui://x/a' },
         { name: 'weather-refresh', uri: 'ui://x/a' },
       ]),
-    ).toThrow(/weather-card, weather-refresh/);
+    ).toThrow(/weather-card and weather-refresh/);
+  });
+
+  it('folds authority case, which a ui:// parser does not', () => {
+    // `ui:` is not a WHATWG "special" scheme, so `new URL()` leaves the host's
+    // case alone — but RFC 3986 makes it case-insensitive. Only reachable via a
+    // hand-written uri; a derived authority is lowercase by construction.
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a', uri: 'ui://PKG/card' },
+        { name: 'b', uri: 'ui://pkg/card' },
+      ]),
+    ).toThrow(/resolve to the uri/);
+  });
+
+  it('folds percent-triplet case, the example the old comment got wrong', () => {
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a', uri: 'ui://pkg/a%2Fb' },
+        { name: 'b', uri: 'ui://pkg/a%2fb' },
+      ]),
+    ).toThrow(/resolve to the uri/);
+  });
+
+  it('names both apps with "and", not "all", when there are two', () => {
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a', uri: 'ui://x/a' },
+        { name: 'b', uri: 'ui://x/a' },
+      ]),
+    ).toThrow(/a and b resolve to/);
   });
 
   it('compares what a parser resolves to, not the raw string', () => {

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -33,6 +33,27 @@ describe('outputPathFromFile', () => {
     },
   );
 
+  it.each(['weather#card.ts', 'weather?card.ts', 'a/b#c/d.ts'])(
+    'refuses %s, which the module loader cannot address',
+    (input) => {
+      // Vite resolves a module by a URL-shaped id, so `#` opens a fragment and
+      // `?` a query: the file is looked up under a shorter name and reported
+      // as missing when it plainly exists. NOT excusable by setting `uri` —
+      // the docs used to promise it was, and it never was.
+      expect(() => outputPathFromFile(input)).toThrow(/module loader reads as part of a url/);
+    },
+  );
+
+  it('refuses a control character in the name', () => {
+    expect(() => outputPathFromFile('weather\u0001card.ts')).toThrow(/module loader/);
+  });
+
+  it('says plainly that an explicit uri does not help for a loader character', () => {
+    // Every other refusal points at "or set uri". This one must not, because
+    // that advice does nothing — the failure is before an address is consulted.
+    expect(() => outputPathFromFile('weather#card.ts')).toThrow(/Setting "uri" does not/);
+  });
+
   it('refuses a path with no name left after the extension', () => {
     // uriFromFile has the same guard; they must not disagree on emptiness, or
     // an empty stem would reach join(outDir, '.html').
@@ -144,6 +165,29 @@ describe('uriFromFile', () => {
   });
 });
 
+describe('the reserved manifest stem', () => {
+  // `manifest.json` is the index listing every app. An app packing to that stem
+  // writes its descriptor there and has the index overwrite it, leaving the
+  // manifest entry pointing `descriptor` at the array itself — exit 0, silent.
+  //
+  // The CLI does the refusing, so these pin the two derivations it compares.
+  it('is what a top-level manifest.ts packs to', () => {
+    expect(outputPathFromFile('manifest.ts')).toBe('manifest');
+  });
+
+  it('catches a capital, because the filesystem does not distinguish one', () => {
+    // On APFS and NTFS `Manifest.json` IS `manifest.json`. A case-sensitive
+    // check let one capital letter reproduce the whole bug.
+    expect(outputPathFromFile('Manifest.ts').toLowerCase()).toBe('manifest');
+    expect(outputPathFromFile('MANIFEST.ts').toLowerCase()).toBe('manifest');
+  });
+
+  it('does not reach a nested one, which collides with nothing', () => {
+    expect(outputPathFromFile('sub/manifest.ts')).toBe('sub/manifest');
+    expect(outputPathFromFile('sub/manifest.ts').toLowerCase()).not.toBe('manifest');
+  });
+});
+
 describe('appSegmentsFromFile', () => {
   it('drops empty segments from a doubled separator', () => {
     expect(appSegmentsFromFile('a//b.ts')).toEqual(['a', 'b']);
@@ -208,6 +252,16 @@ describe('assertUniqueUris', () => {
         { name: 'b', uri: 'ui://pkg/a%2fb' },
       ]),
     ).toThrow(/resolve to the uri/);
+  });
+
+  it('reads as a list at three, not a chain of "and"', () => {
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a', uri: 'ui://x/a' },
+        { name: 'b', uri: 'ui://x/a' },
+        { name: 'c', uri: 'ui://x/a' },
+      ]),
+    ).toThrow(/a, b and c all resolve/);
   });
 
   it('names both apps with "and", not "all", when there are two', () => {

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -247,6 +247,36 @@ describe('assertLoadablePaths', () => {
   });
 });
 
+describe('what the command refuses before it loads anything', () => {
+  const APP = 'export default {};';
+
+  // THE WIRING, not the helper. `assertLoadablePaths` and the ignore list were
+  // both pinned as pure values while the code that calls them was not — the
+  // second glob could be deleted outright, and the ignore list could drift out
+  // of sync with the one the build uses, with the whole suite green. Third time
+  // this exact gap has appeared on this branch.
+  it('refuses a backslash in a filename, through the real command', async () => {
+    const { code, errors } = await buildWith({ 'a\\b.ts': APP });
+    expect(code).toBe(1);
+    expect(errors).toMatch(/backslash/);
+  });
+
+  it('does not fire the backslash guard on an ordinary name', async () => {
+    const { errors } = await buildWith({ 'plain.ts': APP });
+    expect(errors).not.toMatch(/backslash/);
+  });
+
+  it('skips a declaration file rather than loading it as an app', async () => {
+    // `.d.ts` was skipped and `.d.mts` was not, so a declaration file was
+    // loaded, found to have no `defineMcpApp()`, and failed the WHOLE build —
+    // every other app stopped building until it was renamed.
+    const { code, errors } = await buildWith({ 'types.d.ts': APP, 'types.d.mts': APP });
+    expect(code).toBe(1);
+    expect(errors).toMatch(/no app files found/);
+    expect(errors).not.toMatch(/d\.mts/);
+  });
+});
+
 describe('the reserved manifest stem', () => {
   const APP = 'export default {};';
 

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   appSegmentsFromFile,
+  assertLoadablePaths,
   assertUniqueUris,
   mcpAppCommand,
   outputPathFromFile,
@@ -227,6 +228,25 @@ function buildWith(files: Record<string, string>): Promise<{ code: number; error
     });
 }
 
+describe('assertLoadablePaths', () => {
+  it('refuses a filename whose backslash the absolute glob would rewrite', () => {
+    // `fast-glob` KEEPS the backslash in its relative form and loses it under
+    // `absolute: true`, so this guard reads the form that still has it. Without
+    // it the build hands the loader `a/b.ts` and reports a file that plainly
+    // exists as missing.
+    expect(() => assertLoadablePaths(['a\\b.ts'])).toThrow(/backslash/);
+  });
+
+  it('names every offender, and does not fire on ordinary paths', () => {
+    expect(() => assertLoadablePaths(['a\\b.ts', 'c\\d.ts'])).toThrow(/"a\\b.ts", "c\\d.ts"/);
+    expect(() => assertLoadablePaths(['weather/card.ts', 'big card.ts'])).not.toThrow();
+  });
+
+  it('says an explicit uri does not help, because the file must load first', () => {
+    expect(() => assertLoadablePaths(['a\\b.ts'])).toThrow(/Setting "uri" does not/);
+  });
+});
+
 describe('the reserved manifest stem', () => {
   const APP = 'export default {};';
 
@@ -253,6 +273,25 @@ describe('the reserved manifest stem', () => {
     const { code, errors } = await buildWith({ 'manife\u017Ft.ts': APP });
     expect(code).toBe(1);
     expect(errors).toMatch(/index listing every app/);
+  });
+
+  // These assert in the PRE-FLIGHT, which runs before the packager is loaded —
+  // the fixture project has no @beatzball/litro-agent, so anything asserted
+  // after that point passes vacuously. Two files share a stem: if the ignore
+  // works neither is seen ("no app files found"); if it does not, they collide
+  // on one output path and the pre-flight says so.
+  it.each([
+    ['the off switch', '-off'],
+    ['a test file', 'card.test'],
+    ['a spec file', 'card.spec'],
+  ])('skips %s for every extension the glob accepts', async (_label, stem) => {
+    // The ignore list named only `.ts`, so renaming `card.tsx` to `-card.tsx`
+    // left it building — and shipping `ui://pkg/-card`, a leading hyphen in a
+    // protocol-visible address.
+    const { code, errors } = await buildWith({ [`${stem}.tsx`]: APP, [`${stem}.mts`]: APP });
+    expect(errors).not.toMatch(/both pack to/);
+    expect(errors).toMatch(/no app files found/);
+    expect(code).toBe(1);
   });
 
   it('leaves a NESTED manifest.ts alone, which collides with nothing', async () => {

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { appNameFromFile, assertUniqueUris, mcpAppCommand } from './mcp-app.js';
+import {
+  appNameFromFile,
+  assertUniqueUris,
+  mcpAppCommand,
+  packageAuthority,
+  uriFromFile,
+} from './mcp-app.js';
 
 describe('appNameFromFile', () => {
   it.each([
@@ -15,6 +21,76 @@ describe('appNameFromFile', () => {
   it('keeps a dot inside the stem, which is not the extension', () => {
     expect(appNameFromFile('weather.v2.ts')).toBe('weather.v2');
   });
+});
+
+describe('uriFromFile', () => {
+  it.each([
+    ['weather/card.ts', 'ui://weather/card'],
+    ['a/b/c.tsx', 'ui://a/b/c'],
+    ['weather\\card.ts', 'ui://weather/card'],
+  ])('%s -> %s', (input, expected) => {
+    expect(uriFromFile(input, 'playground')).toBe(expected);
+  });
+
+  it('takes the first segment from the package name for a flat file', () => {
+    // A single segment would give host "weather-card" and an EMPTY path — a
+    // different shape from every nested file, which a host that groups by
+    // authority treats differently.
+    expect(uriFromFile('weather-card.ts', 'playground')).toBe('ui://playground/weather-card');
+  });
+
+  it('does NOT prefix the package name when the file already has a folder', () => {
+    // The folder is the authority. Prefixing as well would bury the path the
+    // author wrote one level down and make the address unreadable from the tree.
+    expect(uriFromFile('weather/card.ts', 'playground')).toBe('ui://weather/card');
+  });
+
+  it('does not treat index.ts as the folder root, the way pages/ does', () => {
+    // Collapsing it to `ui://weather` would leave a host with no path — the
+    // one shape the package-name rule above exists to avoid.
+    expect(uriFromFile('weather/index.ts', 'playground')).toBe('ui://weather/index');
+  });
+
+  it('says what to do when a flat file has no package name to borrow', () => {
+    expect(() => uriFromFile('weather-card.ts', undefined)).toThrow(/Give it a folder/);
+  });
+
+  it.each(['[slug].ts', 'blog/[slug].ts', '[...all].ts', '[[opt]]/card.ts'])(
+    'refuses the dynamic segment in %s',
+    (input) => {
+      // Every other filesystem-routed directory in Litro supports these. A
+      // ui:// resource is a static template the host caches by address, so
+      // there is no request to fill a parameter from — and a literal "[slug]"
+      // in a protocol-visible address is a typo that would otherwise ship.
+      expect(() => uriFromFile(input, 'playground')).toThrow(/dynamic segment/);
+    },
+  );
+
+  it('agrees with appNameFromFile, which names the same file on disk', () => {
+    // The manifest pairs the two. Derived apart, they drift on the next edit
+    // to either, and the descriptor then points at a file that is not there.
+    for (const rel of ['weather/card.ts', 'a/b/c.tsx']) {
+      const fromUri = uriFromFile(rel, 'playground').replace('ui://', '').split('/').join('-');
+      expect(fromUri).toBe(appNameFromFile(rel));
+    }
+  });
+});
+
+describe('packageAuthority', () => {
+  it.each([
+    ['playground', 'playground'],
+    ['@beatzball/playground', 'playground'],
+    ['litro-docs', 'litro-docs'],
+  ])('%s -> %s', (input, expected) => {
+    expect(packageAuthority(input)).toBe(expected);
+  });
+
+  it.each([undefined, '', '@scope/', 'Has Spaces', 'UPPER', '_leading'])(
+    'gives up on %s rather than emitting a broken authority',
+    (input) => {
+      expect(packageAuthority(input)).toBeUndefined();
+    },
+  );
 });
 
 describe('assertUniqueUris', () => {

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -1,25 +1,38 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
-  appNameFromFile,
+  appSegmentsFromFile,
   assertUniqueUris,
   mcpAppCommand,
+  outputPathFromFile,
   packageAuthority,
   uriFromFile,
 } from './mcp-app.js';
 
-describe('appNameFromFile', () => {
+describe('outputPathFromFile', () => {
   it.each([
     ['weather-card.ts', 'weather-card'],
-    ['weather/card.ts', 'weather-card'],
-    ['a/b/c.tsx', 'a-b-c'],
+    ['weather/card.ts', 'weather/card'],
+    ['a/b/c.tsx', 'a/b/c'],
     ['card.mts', 'card'],
-    ['weather\\card.ts', 'weather-card'],
+    ['weather\\card.ts', 'weather/card'],
   ])('%s -> %s', (input, expected) => {
-    expect(appNameFromFile(input)).toBe(expected);
+    expect(outputPathFromFile(input)).toBe(expected);
   });
 
   it('keeps a dot inside the stem, which is not the extension', () => {
-    expect(appNameFromFile('weather.v2.ts')).toBe('weather.v2');
+    expect(outputPathFromFile('weather.v2.ts')).toBe('weather.v2');
+  });
+
+  it('mirrors the uri path, so two files can never claim one output file', () => {
+    // The old scheme flattened with "-", which let `weather/card.ts` and
+    // `weather-card.ts` — two DIFFERENT addresses — both claim
+    // `weather-card.html`, and the build had to detect the clash. Mirroring
+    // makes the clash unrepresentable.
+    for (const rel of ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx']) {
+      const uriPath = uriFromFile(rel, 'playground').replace('ui://playground/', '');
+      expect(outputPathFromFile(rel)).toBe(uriPath);
+    }
+    expect(outputPathFromFile('weather/card.ts')).not.toBe(outputPathFromFile('weather-card.ts'));
   });
 });
 
@@ -43,16 +56,14 @@ describe('uriFromFile', () => {
   });
 
   it('moves every address together when the package is renamed', () => {
-    // That is what an authority is for, and it is the reason this is one rule
-    // with no branch in it.
-    const files = ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx'];
-    for (const rel of files) {
-      expect(uriFromFile(rel, 'renamed')).toBe(uriFromFile(rel, 'playground').replace('playground', 'renamed'));
+    for (const rel of ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx']) {
+      expect(uriFromFile(rel, 'renamed')).toBe(
+        uriFromFile(rel, 'playground').replace('playground', 'renamed'),
+      );
     }
   });
 
   it('does not treat index.ts as the folder root, the way pages/ does', () => {
-    // Collapsing it would silently merge with a sibling `weather.ts`.
     expect(uriFromFile('weather/index.ts', 'playground')).toBe('ui://playground/weather/index');
   });
 
@@ -72,14 +83,50 @@ describe('uriFromFile', () => {
     },
   );
 
-  it('agrees with appNameFromFile, which names the same file on disk', () => {
-    // The manifest pairs the two. Derived apart, they drift on the next edit
-    // to either, and the descriptor then points at a file that is not there.
-    // The uri path BELOW the authority is exactly the output name, unflattened.
-    for (const rel of ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx']) {
-      const path = uriFromFile(rel, 'playground').replace('ui://playground/', '');
-      expect(path.split('/').join('-')).toBe(appNameFromFile(rel));
-    }
+  describe('characters a uri parser would rewrite or read as syntax', () => {
+    // Each of these built successfully before, and shipped a descriptor whose
+    // uri a host resolves to a DIFFERENT string than the manifest contains.
+    it.each([
+      ['big card.ts', 'a space becomes %20'],
+      ['weird?name.ts', '? opens a query, truncating the path'],
+      ['weird#name.ts', '# opens a fragment, truncating the path'],
+      ['café.ts', 'non-ascii is percent-encoded'],
+      ['a/b c/d.ts', 'a space in a middle segment'],
+    ])('refuses %s (%s)', (input) => {
+      expect(() => uriFromFile(input, 'playground')).toThrow(/rewrites or reads as syntax/);
+    });
+
+    it('refuses a literal % , which is what makes an encoded twin possible', () => {
+      // THE COLLISION THIS CLOSES: `big card.ts` and `big%20card.ts` produced
+      // two different raw strings that a parser resolves to ONE address, and
+      // neither the output-path check nor the uri check could see it.
+      expect(() => uriFromFile('big%20card.ts', 'playground')).toThrow(/rewrites or reads as syntax/);
+      expect(() => uriFromFile('big card.ts', 'playground')).toThrow(/rewrites or reads as syntax/);
+    });
+
+    it.each(['../escape.ts', 'a/./b.ts', 'a/../b.ts'])('refuses the dot segment in %s', (input) => {
+      // RFC 3986 normalisation REMOVES these, so `a/./b` and `a/b` are one
+      // resource to a host and two entries to us.
+      expect(() => uriFromFile(input, 'playground')).toThrow(/parser removes those/);
+    });
+
+    it('still accepts the unreserved set, which ordinary filenames use', () => {
+      expect(uriFromFile('weather_card-v2.x~1.ts', 'playground')).toBe(
+        'ui://playground/weather_card-v2.x~1',
+      );
+    });
+
+    it('rejects the same characters for the OUTPUT PATH, not only the uri', () => {
+      // Both derivations share one validator, so a file cannot be rejected as
+      // an address yet accepted as a filename.
+      expect(() => outputPathFromFile('big card.ts')).toThrow(/rewrites or reads as syntax/);
+    });
+  });
+});
+
+describe('appSegmentsFromFile', () => {
+  it('drops empty segments from a doubled separator', () => {
+    expect(appSegmentsFromFile('a//b.ts')).toEqual(['a', 'b']);
   });
 });
 
@@ -119,7 +166,33 @@ describe('assertUniqueUris', () => {
         { name: 'weather-card', uri: 'ui://x/a' },
         { name: 'weather-refresh', uri: 'ui://x/a' },
       ]),
-    ).toThrow(/weather-card and weather-refresh/);
+    ).toThrow(/weather-card, weather-refresh/);
+  });
+
+  it('compares what a parser resolves to, not the raw string', () => {
+    // Two strings, one address: a parser rewrites the space to %20. Neither of
+    // these can be DERIVED any more — the segment check refuses both — but an
+    // app may still write its own uri, and comparing raw text is how two apps
+    // end up sharing a host's cache key.
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a', uri: 'ui://x/big card' },
+        { name: 'b', uri: 'ui://x/big%20card' },
+      ]),
+    ).toThrow(/resolve to the uri/);
+  });
+
+  it('reports EVERY clash, not just the first', () => {
+    // A project that fixes one clash only to meet the next on the following
+    // run learns the shape of its directory one build at a time.
+    expect(() =>
+      assertUniqueUris([
+        { name: 'a1', uri: 'ui://x/a' },
+        { name: 'a2', uri: 'ui://x/a' },
+        { name: 'b1', uri: 'ui://x/b' },
+        { name: 'b2', uri: 'ui://x/b' },
+      ]),
+    ).toThrow(/2 address clashes/);
   });
 });
 

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -25,34 +25,40 @@ describe('appNameFromFile', () => {
 
 describe('uriFromFile', () => {
   it.each([
-    ['weather/card.ts', 'ui://weather/card'],
-    ['a/b/c.tsx', 'ui://a/b/c'],
-    ['weather\\card.ts', 'ui://weather/card'],
+    ['weather-card.ts', 'ui://playground/weather-card'],
+    ['weather/card.ts', 'ui://playground/weather/card'],
+    ['a/b/c.tsx', 'ui://playground/a/b/c'],
+    ['weather\\card.ts', 'ui://playground/weather/card'],
   ])('%s -> %s', (input, expected) => {
     expect(uriFromFile(input, 'playground')).toBe(expected);
   });
 
-  it('takes the first segment from the package name for a flat file', () => {
-    // A single segment would give host "weather-card" and an EMPTY path — a
-    // different shape from every nested file, which a host that groups by
-    // authority treats differently.
+  it('puts the package name in front of a nested path too, not only a flat file', () => {
+    // The authority is the PACKAGE, uniformly. Letting the first folder be the
+    // authority instead would give a flat file host "weather-card" and an EMPTY
+    // path — a different shape from every nested file, which a host that groups
+    // by authority treats differently.
+    expect(uriFromFile('weather/card.ts', 'playground')).toBe('ui://playground/weather/card');
     expect(uriFromFile('weather-card.ts', 'playground')).toBe('ui://playground/weather-card');
   });
 
-  it('does NOT prefix the package name when the file already has a folder', () => {
-    // The folder is the authority. Prefixing as well would bury the path the
-    // author wrote one level down and make the address unreadable from the tree.
-    expect(uriFromFile('weather/card.ts', 'playground')).toBe('ui://weather/card');
+  it('moves every address together when the package is renamed', () => {
+    // That is what an authority is for, and it is the reason this is one rule
+    // with no branch in it.
+    const files = ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx'];
+    for (const rel of files) {
+      expect(uriFromFile(rel, 'renamed')).toBe(uriFromFile(rel, 'playground').replace('playground', 'renamed'));
+    }
   });
 
   it('does not treat index.ts as the folder root, the way pages/ does', () => {
-    // Collapsing it to `ui://weather` would leave a host with no path — the
-    // one shape the package-name rule above exists to avoid.
-    expect(uriFromFile('weather/index.ts', 'playground')).toBe('ui://weather/index');
+    // Collapsing it would silently merge with a sibling `weather.ts`.
+    expect(uriFromFile('weather/index.ts', 'playground')).toBe('ui://playground/weather/index');
   });
 
-  it('says what to do when a flat file has no package name to borrow', () => {
-    expect(() => uriFromFile('weather-card.ts', undefined)).toThrow(/Give it a folder/);
+  it('says what to do when there is no package name to take an authority from', () => {
+    expect(() => uriFromFile('weather/card.ts', undefined)).toThrow(/no usable "name"/);
+    expect(() => uriFromFile('weather-card.ts', undefined)).toThrow(/set "uri" in defineMcpApp/);
   });
 
   it.each(['[slug].ts', 'blog/[slug].ts', '[...all].ts', '[[opt]]/card.ts'])(
@@ -69,9 +75,10 @@ describe('uriFromFile', () => {
   it('agrees with appNameFromFile, which names the same file on disk', () => {
     // The manifest pairs the two. Derived apart, they drift on the next edit
     // to either, and the descriptor then points at a file that is not there.
-    for (const rel of ['weather/card.ts', 'a/b/c.tsx']) {
-      const fromUri = uriFromFile(rel, 'playground').replace('ui://', '').split('/').join('-');
-      expect(fromUri).toBe(appNameFromFile(rel));
+    // The uri path BELOW the authority is exactly the output name, unflattened.
+    for (const rel of ['weather-card.ts', 'weather/card.ts', 'a/b/c.tsx']) {
+      const path = uriFromFile(rel, 'playground').replace('ui://playground/', '');
+      expect(path.split('/').join('-')).toBe(appNameFromFile(rel));
     }
   });
 });

--- a/packages/framework/src/cli/mcp-app.test.ts
+++ b/packages/framework/src/cli/mcp-app.test.ts
@@ -37,13 +37,13 @@ describe('outputPathFromFile', () => {
   );
 
   it.each(['weather#card.ts', 'weather?card.ts', 'a/b#c/d.ts'])(
-    'refuses %s, which the module loader cannot address',
+    'refuses %s, which the module loader reads as url syntax',
     (input) => {
       // Vite resolves a module by a URL-shaped id, so `#` opens a fragment and
       // `?` a query: the file is looked up under a shorter name and reported
       // as missing when it plainly exists. NOT excusable by setting `uri` —
       // the docs used to promise it was, and it never was.
-      expect(() => outputPathFromFile(input)).toThrow(/module loader reads as part of a url/);
+      expect(() => outputPathFromFile(input)).toThrow(/reads as url syntax/);
     },
   );
 
@@ -52,7 +52,23 @@ describe('outputPathFromFile', () => {
     ['weather\u2028card.ts', 'U+2028, a line separator above the C0 range'],
     ['weather\u2029card.ts', 'U+2029, a paragraph separator'],
   ])('refuses %s (%s)', (input) => {
-    expect(() => outputPathFromFile(input)).toThrow(/module loader/);
+    // A DIFFERENT reason from `#`/`?`, and deliberately so. These do not all
+    // break the loader — some C0 bytes load fine, and U+2028 splits the source
+    // into a ReferenceError rather than a missing file. What holds for all of
+    // them is that they have no printable form, and this path is written
+    // verbatim into the manifest, the descriptor and every error message.
+    expect(() => outputPathFromFile(input)).toThrow(/no printable form/);
+  });
+
+  it('names the offending character by code point, since it cannot be shown', () => {
+    expect(() => outputPathFromFile('weather\u2028card.ts')).toThrow(/U\+2028/);
+  });
+
+  it('does not blame the loader for a character the loader accepts', () => {
+    // The old single message claimed every one of these "would report the file
+    // as missing". Two of the three classes fail some other way, and some do
+    // not fail at all — an error must not assert a failure it cannot show.
+    expect(() => outputPathFromFile('weather\u0001card.ts')).not.toThrow(/missing/);
   });
 
   it('does NOT refuse DEL, which the loader handles fine', () => {
@@ -62,11 +78,14 @@ describe('outputPathFromFile', () => {
     expect(outputPathFromFile('weather\u007Fcard.ts')).toBe('weather\u007Fcard');
   });
 
-  it('says plainly that an explicit uri does not help for a loader character', () => {
-    // Every other refusal points at "or set uri". This one must not, because
-    // that advice does nothing — the failure is before an address is consulted.
-    expect(() => outputPathFromFile('weather#card.ts')).toThrow(/Setting "uri" does not/);
-  });
+  it.each(['weather#card.ts', 'weather\u0001card.ts'])(
+    'says plainly that an explicit uri does not help (%s)',
+    (input) => {
+      // Every other refusal points at "or set uri". These must not, because
+      // that advice does nothing — neither failure is about the address.
+      expect(() => outputPathFromFile(input)).toThrow(/Setting "uri" does not/);
+    },
+  );
 
   it('refuses a path with no name left after the extension', () => {
     // uriFromFile has the same guard; they must not disagree on emptiness, or

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -22,6 +22,16 @@ import { patchCustomElementsIdempotent } from '../plugins/ssg.js';
 const DEFAULT_SOURCE_DIR = 'mcp-apps';
 const DEFAULT_OUT_DIR = 'dist/mcp-apps';
 
+/**
+ * The index every app is listed in. An app packing to this stem would write
+ * `manifest.json` as its descriptor and then have it overwritten by the index,
+ * leaving its manifest entry pointing `descriptor` at the array itself.
+ *
+ * The output mirrors the source tree, so only the TOP level collides:
+ * `mcp-apps/sub/manifest.ts` is fine.
+ */
+const MANIFEST_STEM = 'manifest';
+
 /** One packed app, as it lands on disk. */
 export interface PackedApp {
   /**
@@ -56,10 +66,10 @@ export function appSegmentsFromFile(relPath: string): string[] {
  * Characters a path segment may contribute to a `ui://` address.
  *
  * This is RFC 3986's `unreserved` set. Anything outside it either changes
- * meaning (`?` opens a query, `#` opens a fragment, `/` opens a segment) or is
- * rewritten by any parser that touches it (a space becomes `%20`, `é` becomes
- * `%C3%A9`) — and a rewritten address no longer matches the string in the
- * descriptor, so a host caches under a key the manifest does not contain.
+ * meaning (`?` opens a query, `#` opens a fragment) or is rewritten by any
+ * parser that touches it (a space becomes `%20`, `é` becomes `%C3%A9`) — and a
+ * rewritten address no longer matches the string in the descriptor, so a host
+ * caches under a key the manifest does not contain.
  *
  * `%` is excluded deliberately, not by omission. Allowing it would make
  * `big%20card.ts` and `big card.ts` two files with ONE effective address, and
@@ -69,13 +79,41 @@ export function appSegmentsFromFile(relPath: string): string[] {
 const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
 
 /**
+ * Refuses a path that cannot safely name a file under the output directory.
+ *
+ * DELIBERATELY NARROW. Only `.` and `..` qualify: they are resolved by the
+ * filesystem, so `../x` would write OUTSIDE the out dir. Everything else — a
+ * space, an accent, a `[` — is a perfectly legal filename, and refusing it here
+ * would be refusing it for an app that names its own uri and never needed one
+ * derived. That was exactly the failure this split exists to undo.
+ */
+function assertUsableOutputPath(relPath: string, segments: string[]): void {
+  if (segments.length === 0) {
+    throw new Error(`"${relPath}" has no name to build an output file from.`);
+  }
+  const dot = segments.find((seg) => seg === '.' || seg === '..');
+  if (dot) {
+    throw new Error(
+      `"${relPath}" contains a "${dot}" segment, which would resolve to a path outside the ` +
+        'output directory.',
+    );
+  }
+}
+
+/**
  * Refuses a path that cannot become an unambiguous `ui://` address.
  *
- * Held to the same standard as the authority, and for the same reason given on
- * `packageAuthority`: an address is protocol-visible and cached by the host, so
- * the build is the last place a bad one can be stopped cheaply.
+ * Every throw here is RECOVERABLE by the app naming its own `uri` — which is
+ * why the CLI carries the reason instead of failing on it. An address is the
+ * only thing at stake, so an author who supplies one has already answered the
+ * objection. An error that names a remedy the caller has already applied is
+ * worse than no error at all.
  */
-function assertUsableSegments(relPath: string, segments: string[]): void {
+function assertUsableUriSegments(relPath: string, segments: string[]): void {
+  if (segments.length === 0) {
+    throw new Error(`"${relPath}" has no name to build a uri from.`);
+  }
+
   const dynamic = segments.find((seg) => seg.includes('[') || seg.includes(']'));
   if (dynamic) {
     throw new Error(
@@ -86,8 +124,7 @@ function assertUsableSegments(relPath: string, segments: string[]): void {
 
   // `.` and `..` are syntactically fine but are REMOVED by RFC 3986
   // normalisation, so `a/./b` and `a/b` are one resource to a host and two
-  // entries to us. Unreachable through the CLI's own globbing today; rejected
-  // because `uriFromFile` is exported and does not know its caller.
+  // entries to us.
   const dot = segments.find((seg) => seg === '.' || seg === '..');
   if (dot) {
     throw new Error(
@@ -111,15 +148,21 @@ function assertUsableSegments(relPath: string, segments: string[]): void {
  * Turns a path relative to the source dir into an output path stem.
  * `weather/card.ts` -> `weather/card`, so `dist/mcp-apps/weather/card.html`.
  *
- * NESTED, MIRRORING THE URI. An earlier version flattened to `weather-card`,
+ * NESTED, MIRRORING THE URI. Through 0.15.0 this flattened to `weather-card`,
  * which let `weather/card.ts` and `weather-card.ts` — two files with two
  * DIFFERENT addresses — claim one output file, so the build had to detect the
- * clash and refuse. Mirroring the uri makes that clash unrepresentable: the
- * output path is the uri path, and two files cannot share one relative path.
+ * clash and refuse. Mirroring makes that clash unrepresentable: the output path
+ * is the uri path, and two files cannot share one relative path.
+ *
+ * THIS MOVES PUBLISHED OUTPUT. The recursive glob shipped in 0.15.0, so a
+ * project with `mcp-apps/weather/card.ts` already gets `weather-card.html`
+ * today and gets `weather/card.html` after this. Anything pinned to the flat
+ * path — a static mount, a COPY line, a path in a server config — has to
+ * follow. Reading `manifest.json` rather than guessing the path does not.
  */
 export function outputPathFromFile(relPath: string): string {
   const segments = appSegmentsFromFile(relPath);
-  assertUsableSegments(relPath, segments);
+  assertUsableOutputPath(relPath, segments);
   return segments.join('/');
 }
 
@@ -141,14 +184,12 @@ export function outputPathFromFile(relPath: string): string {
  * `index.ts` IS NOT SPECIAL, unlike in `pages/`. `weather/index.ts` is
  * `ui://<package>/weather/index`; collapsing it would silently merge with a
  * sibling `weather.ts`.
+ *
+ * EVERY THROW IS RECOVERABLE by setting `uri` on the app.
  */
 export function uriFromFile(relPath: string, packageName?: string): string {
   const segments = appSegmentsFromFile(relPath);
-  assertUsableSegments(relPath, segments);
-
-  if (segments.length === 0) {
-    throw new Error(`"${relPath}" has no name to build a uri from.`);
-  }
+  assertUsableUriSegments(relPath, segments);
 
   const authority = packageAuthority(packageName);
   if (!authority) {
@@ -177,18 +218,30 @@ export function packageAuthority(packageName?: string): string | undefined {
 
 /**
  * The form of a uri that two addresses must differ in to be different
- * resources: what a parser resolves the string to, not the string itself.
+ * resources: what RFC 3986 equivalence says the string means, not the string.
  *
- * `ui://p/a%2Fb` and `ui://p/a%2fb` are one address to a host and two strings
- * to us. Comparing raw strings is how two apps end up sharing a cache key.
+ * `new URL()` alone is not enough. It folds a space into `%20` and removes dot
+ * segments, but for a NON-SPECIAL scheme like `ui:` it leaves the host's case
+ * and a percent-triplet's case exactly as written — so `ui://P/a%2Fb` and
+ * `ui://p/a%2fb`, one resource by §6.2.2.1, stay two strings. Both of those
+ * remaining normalisations are applied here.
+ *
+ * Only reachable through a hand-written `uri`: a derived one is lowercase by
+ * construction and can hold no `%`.
  */
 function canonicalUri(uri: string): string {
+  let parsed: URL;
   try {
-    return new URL(uri).href;
+    parsed = new URL(uri);
   } catch {
     // Not parseable, so nothing can normalise it into another entry either.
     return uri;
   }
+  // Scheme and host are case-insensitive; a percent-triplet's hex digits are
+  // too, and RFC 3986 makes uppercase the normal form.
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.host = parsed.host.toLowerCase();
+  return parsed.href.replace(/%[0-9a-fA-F]{2}/g, (t) => t.toUpperCase());
 }
 
 /**
@@ -215,8 +268,9 @@ export function assertUniqueUris(apps: { name: string; uri: string }[]): void {
   for (const [uri, names] of byUri) {
     if (names.length < 2) continue;
     problems.push(
-      `  ${names.join(', ')} all resolve to the uri ${uri}. A host caches templates by uri, so one ` +
-        'would silently serve the others’ markup. Give each its own address, or its own file path.',
+      `  ${names.join(' and ')} ${names.length > 2 ? 'all ' : ''}resolve to the uri ${uri}. A host ` +
+        'caches templates by uri, so one would silently serve the other’s markup. Give each its own ' +
+        'address, or its own file path.',
     );
   }
 
@@ -286,6 +340,14 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
       // A path this broken cannot name an OUTPUT FILE either, so unlike a
       // derivation failure there is nothing an explicit uri could rescue.
       problems.push(`  ${here}: ${(err as Error).message}`);
+      continue;
+    }
+
+    if (outPath === MANIFEST_STEM) {
+      problems.push(
+        `  ${here} packs to "${MANIFEST_STEM}.json", which is the index listing every app — the ` +
+          'index would overwrite its descriptor. Rename it, or move it into a folder.',
+      );
       continue;
     }
 
@@ -462,7 +524,7 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
     html: relative(outDir, a.htmlPath),
     descriptor: relative(outDir, a.descriptorPath),
   }));
-  await writeFile(join(outDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  await writeFile(join(outDir, `${MANIFEST_STEM}.json`), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 
   for (const app of packed) {
     console.log(`  ${app.uri}  ${relative(cwd, app.htmlPath)}  ${app.bytes} bytes`);

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -16,7 +16,7 @@
 import { createServer } from 'vite';
 import fastGlob from 'fast-glob';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join, relative, resolve } from 'pathe';
+import { dirname, join, relative, resolve } from 'pathe';
 import { patchCustomElementsIdempotent } from '../plugins/ssg.js';
 
 const DEFAULT_SOURCE_DIR = 'mcp-apps';
@@ -24,7 +24,11 @@ const DEFAULT_OUT_DIR = 'dist/mcp-apps';
 
 /** One packed app, as it lands on disk. */
 export interface PackedApp {
-  /** Filename stem, `/` flattened to `-`. Names the output files. */
+  /**
+   * Output path stem, relative to the out dir and mirroring the source tree:
+   * `weather/card`. Equal to the uri's path, which is what makes two apps
+   * unable to claim one output file.
+   */
   name: string;
   uri: string;
   htmlPath: string;
@@ -33,11 +37,11 @@ export interface PackedApp {
 }
 
 /**
- * The path segments an app file contributes, source of BOTH its output name
+ * The path segments an app file contributes, source of BOTH its output path
  * and its `ui://` address.
  *
- * One function on purpose. The name flattens the segments with `-` and the uri
- * joins them with `/`, so deriving them separately would let the manifest and
+ * One function on purpose. Both are the segments joined — by `/` for the uri,
+ * by `/` for the file — so deriving them separately would let the manifest and
  * the address drift apart on the next edit to either.
  */
 export function appSegmentsFromFile(relPath: string): string[] {
@@ -49,12 +53,74 @@ export function appSegmentsFromFile(relPath: string): string[] {
 }
 
 /**
- * Turns a path relative to the source dir into an output name.
- * `weather/card.ts` -> `weather-card`, so the output directory stays flat and
- * a name can be read straight off a filename.
+ * Characters a path segment may contribute to a `ui://` address.
+ *
+ * This is RFC 3986's `unreserved` set. Anything outside it either changes
+ * meaning (`?` opens a query, `#` opens a fragment, `/` opens a segment) or is
+ * rewritten by any parser that touches it (a space becomes `%20`, `é` becomes
+ * `%C3%A9`) — and a rewritten address no longer matches the string in the
+ * descriptor, so a host caches under a key the manifest does not contain.
+ *
+ * `%` is excluded deliberately, not by omission. Allowing it would make
+ * `big%20card.ts` and `big card.ts` two files with ONE effective address, and
+ * neither the output-path check nor the uri check would see it: the raw strings
+ * differ, and only a parser makes them equal.
  */
-export function appNameFromFile(relPath: string): string {
-  return appSegmentsFromFile(relPath).join('-');
+const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
+
+/**
+ * Refuses a path that cannot become an unambiguous `ui://` address.
+ *
+ * Held to the same standard as the authority, and for the same reason given on
+ * `packageAuthority`: an address is protocol-visible and cached by the host, so
+ * the build is the last place a bad one can be stopped cheaply.
+ */
+function assertUsableSegments(relPath: string, segments: string[]): void {
+  const dynamic = segments.find((seg) => seg.includes('[') || seg.includes(']'));
+  if (dynamic) {
+    throw new Error(
+      `"${relPath}" uses a dynamic segment ("${dynamic}"). A ui:// app is a static template a host ` +
+        'caches by address, so there is no request to fill one from — use plain folder and file names.',
+    );
+  }
+
+  // `.` and `..` are syntactically fine but are REMOVED by RFC 3986
+  // normalisation, so `a/./b` and `a/b` are one resource to a host and two
+  // entries to us. Unreachable through the CLI's own globbing today; rejected
+  // because `uriFromFile` is exported and does not know its caller.
+  const dot = segments.find((seg) => seg === '.' || seg === '..');
+  if (dot) {
+    throw new Error(
+      `"${relPath}" contains a "${dot}" segment. A uri parser removes those, so the address it resolves ` +
+        'to would not be the address the build wrote down.',
+    );
+  }
+
+  const bad = segments.find((seg) => !URI_SAFE_SEGMENT.test(seg));
+  if (bad) {
+    const offending = [...bad].find((ch) => !URI_SAFE_SEGMENT.test(ch)) ?? bad;
+    throw new Error(
+      `"${relPath}" cannot become a ui:// address: the segment "${bad}" contains ${JSON.stringify(offending)}, ` +
+        'which a uri parser rewrites or reads as syntax. Rename the file using letters, digits, ' +
+        '"." "_" "~" or "-", or set "uri" in defineMcpApp() to choose the address yourself.',
+    );
+  }
+}
+
+/**
+ * Turns a path relative to the source dir into an output path stem.
+ * `weather/card.ts` -> `weather/card`, so `dist/mcp-apps/weather/card.html`.
+ *
+ * NESTED, MIRRORING THE URI. An earlier version flattened to `weather-card`,
+ * which let `weather/card.ts` and `weather-card.ts` — two files with two
+ * DIFFERENT addresses — claim one output file, so the build had to detect the
+ * clash and refuse. Mirroring the uri makes that clash unrepresentable: the
+ * output path is the uri path, and two files cannot share one relative path.
+ */
+export function outputPathFromFile(relPath: string): string {
+  const segments = appSegmentsFromFile(relPath);
+  assertUsableSegments(relPath, segments);
+  return segments.join('/');
 }
 
 /**
@@ -75,23 +141,10 @@ export function appNameFromFile(relPath: string): string {
  * `index.ts` IS NOT SPECIAL, unlike in `pages/`. `weather/index.ts` is
  * `ui://<package>/weather/index`; collapsing it would silently merge with a
  * sibling `weather.ts`.
- *
- * NO DYNAMIC SEGMENTS. `[slug]`, `[[opt]]` and `[...all]` mean something in
- * `pages/` and nothing here: a `ui://` resource is a static template the host
- * caches by address, so there is no request to take a parameter from. They are
- * rejected rather than passed through, because a literal `[slug]` in a
- * protocol-visible address is a typo that would otherwise ship.
  */
 export function uriFromFile(relPath: string, packageName?: string): string {
   const segments = appSegmentsFromFile(relPath);
-
-  const dynamic = segments.find((seg) => seg.includes('[') || seg.includes(']'));
-  if (dynamic) {
-    throw new Error(
-      `"${relPath}" uses a dynamic segment ("${dynamic}"). A ui:// app is a static template a host ` +
-        'caches by address, so there is no request to fill one from — use plain folder and file names.',
-    );
-  }
+  assertUsableSegments(relPath, segments);
 
   if (segments.length === 0) {
     throw new Error(`"${relPath}" has no name to build a uri from.`);
@@ -102,7 +155,7 @@ export function uriFromFile(relPath: string, packageName?: string): string {
     throw new Error(
       `cannot build a uri for "${relPath}": the package name supplies the authority ` +
         `(ui://<package>/${segments.join('/')}), and this project has no usable "name" in its ` +
-        'package.json. Add one, or set "uri" in defineMcpApp().',
+        'package.json. Add one, or set "uri" in defineMcpApp() to choose the address yourself.',
     );
   }
 
@@ -123,23 +176,54 @@ export function packageAuthority(packageName?: string): string | undefined {
 }
 
 /**
- * Throws when two apps claim the same `ui://` address.
+ * The form of a uri that two addresses must differ in to be different
+ * resources: what a parser resolves the string to, not the string itself.
+ *
+ * `ui://p/a%2Fb` and `ui://p/a%2fb` are one address to a host and two strings
+ * to us. Comparing raw strings is how two apps end up sharing a cache key.
+ */
+function canonicalUri(uri: string): string {
+  try {
+    return new URL(uri).href;
+  } catch {
+    // Not parseable, so nothing can normalise it into another entry either.
+    return uri;
+  }
+}
+
+/**
+ * Throws when two apps claim the same `ui://` address, or the same output file.
  *
  * A host keys its template cache by URI, so a collision does not merge — one
  * app silently serves the other's markup. Failing the build is the only place
  * this is visible.
+ *
+ * REPORTS EVERY CLASH, not the first. A project that renames one file only to
+ * hit the next clash on the following run learns its shape one build at a time;
+ * a list is one read.
  */
 export function assertUniqueUris(apps: { name: string; uri: string }[]): void {
-  const seen = new Map<string, string>();
+  const byUri = new Map<string, string[]>();
+
   for (const app of apps) {
-    const first = seen.get(app.uri);
-    if (first) {
-      throw new Error(
-        `Two MCP apps declare the same uri "${app.uri}": ${first} and ${app.name}. ` +
-          'A host caches templates by uri, so one would silently serve the other’s markup.',
-      );
-    }
-    seen.set(app.uri, app.name);
+    const uriKey = canonicalUri(app.uri);
+    byUri.set(uriKey, [...(byUri.get(uriKey) ?? []), app.name]);
+  }
+
+  const problems: string[] = [];
+
+  for (const [uri, names] of byUri) {
+    if (names.length < 2) continue;
+    problems.push(
+      `  ${names.join(', ')} all resolve to the uri ${uri}. A host caches templates by uri, so one ` +
+        'would silently serve the others’ markup. Give each its own address, or its own file path.',
+    );
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `${problems.length} address clash${problems.length > 1 ? 'es' : ''}:\n${problems.join('\n')}`,
+    );
   }
 }
 
@@ -160,9 +244,10 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
   const sourceDir = resolve(cwd, dirFlag);
   const outDir = resolve(cwd, outFlag);
 
-  // Fills the first uri segment for a file that sits flat in the app directory.
-  // Read once, and read leniently: a project without a package.json still packs
-  // fine as long as every app is in a folder or names its own uri.
+  // Supplies the authority for EVERY derived address, not just a flat file's.
+  // A project whose package.json has no usable "name" can still pack, but only
+  // if every app names its own uri — which is why a failure to derive is
+  // carried rather than thrown, below.
   const packageName = await readPackageName(cwd);
 
   const files = await fastGlob('**/*.{ts,tsx,mts}', {
@@ -178,23 +263,60 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
     return 1;
   }
 
-  // Two source paths can flatten to one output name (`weather/card.ts` and
-  // `weather-card.ts` both become `weather-card`), and the second write would
-  // silently replace the first. Caught before anything reaches disk — the
-  // uri check below cannot see it, since only one of the two survives to be
-  // compared.
-  const byName = new Map<string, string>();
-  for (const file of files) {
-    const name = appNameFromFile(relative(sourceDir, file));
-    const first = byName.get(name);
-    if (first) {
-      console.error(
-        `litro mcp-app build: ${relative(cwd, first)} and ${relative(cwd, file)} both pack to ` +
-          `"${name}.html". Rename one — the second would overwrite the first.`,
-      );
-      return 1;
+  // EVERY problem the file paths alone can show, gathered before a single
+  // module is loaded or a byte is written. One list beats learning the shape of
+  // the directory one failed build at a time.
+  //
+  // A derivation failure is NOT fatal here. An app is allowed to name its own
+  // uri, and `defineMcpApp()` has not run yet — so the reason it could not be
+  // derived is CARRIED, and only reported if the config turns out to have no
+  // uri either. Throwing here is what made an explicit uri unable to rescue a
+  // project whose package name is unusable.
+  const plans = new Map<string, { file: string; outPath: string; uri?: string; why?: string }>();
+  const problems: string[] = [];
+
+  for (const file of files.sort()) {
+    const relPath = relative(sourceDir, file);
+    const here = relative(cwd, file);
+
+    let outPath: string;
+    try {
+      outPath = outputPathFromFile(relPath);
+    } catch (err) {
+      // A path this broken cannot name an OUTPUT FILE either, so unlike a
+      // derivation failure there is nothing an explicit uri could rescue.
+      problems.push(`  ${here}: ${(err as Error).message}`);
+      continue;
     }
-    byName.set(name, file);
+
+    // Two source extensions reduce to one output path (`a/b.ts` and `a/b.tsx`),
+    // and the second write would silently replace the first.
+    const clash = plans.get(outPath);
+    if (clash) {
+      problems.push(
+        `  ${relative(cwd, clash.file)} and ${here} both pack to "${outPath}.html". ` +
+          'Rename one — the second would overwrite the first.',
+      );
+      continue;
+    }
+
+    let uri: string | undefined;
+    let why: string | undefined;
+    try {
+      uri = uriFromFile(relPath, packageName);
+    } catch (err) {
+      why = (err as Error).message;
+    }
+
+    plans.set(outPath, { file, outPath, uri, why });
+  }
+
+  if (problems.length > 0) {
+    console.error(
+      `litro mcp-app build: ${problems.length} problem${problems.length > 1 ? 's' : ''} in ` +
+        `${relative(cwd, sourceDir) || '.'}/\n${problems.join('\n')}`,
+    );
+    return 1;
   }
 
   const packed: PackedApp[] = [];
@@ -244,20 +366,8 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
       return 1;
     }
 
-    for (const file of files.sort()) {
-      const relPath = relative(sourceDir, file);
-      const name = appNameFromFile(relPath);
-
-      // A FALLBACK, not an override: an app that names its own uri keeps it.
-      // Derived even so, because the failure it reports (a dynamic segment, a
-      // flat file with no package name) is about the file, not about the config.
-      let derivedUri: string;
-      try {
-        derivedUri = uriFromFile(relPath, packageName);
-      } catch (err) {
-        console.error(`litro mcp-app build: ${(err as Error).message}`);
-        return 1;
-      }
+    for (const plan of plans.values()) {
+      const { file, outPath, uri: derivedUri, why } = plan;
 
       // Loading a component registers its custom element, and two apps may pull
       // in the same one. Lit's SSR shim throws on a duplicate define(); this
@@ -295,21 +405,40 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
         return 1;
       }
 
+      // A FALLBACK, not an override: an app that names its own uri keeps it.
+      // `derivedUri` is undefined when the path could not produce one, and the
+      // packager then reports the app as having no address — at which point
+      // `why` is the answer to "why was none derived?", which is the half the
+      // packager cannot know.
       let built: { html: string; descriptor: { uri: string } };
       try {
         built = await packager.buildMcpAppDocument(definition, { uri: derivedUri });
       } catch (err) {
-        console.error(`litro mcp-app build: ${relative(cwd, file)}\n  ${(err as Error).message}`);
+        const message = (err as Error).message;
+        // The packager's own "no uri anywhere" text tells the reader to pack
+        // the file with this command — which is what they just did. When the
+        // derivation is the half that failed, say THAT instead: it is the only
+        // half the packager could not see.
+        if (why && /no "uri" and none was supplied/.test(message)) {
+          console.error(
+            `litro mcp-app build: ${relative(cwd, file)} declares no "uri", and one could not be ` +
+              `derived from its path.\n  ${why}`,
+          );
+          return 1;
+        }
+        console.error(`litro mcp-app build: ${relative(cwd, file)}\n  ${message}`);
         return 1;
       }
 
-      const htmlPath = join(outDir, `${name}.html`);
-      const descriptorPath = join(outDir, `${name}.json`);
+      const htmlPath = join(outDir, `${outPath}.html`);
+      const descriptorPath = join(outDir, `${outPath}.json`);
+      // The output mirrors the source tree, so a nested app needs its folder.
+      await mkdir(dirname(htmlPath), { recursive: true });
       await writeFile(htmlPath, built.html, 'utf8');
       await writeFile(descriptorPath, `${JSON.stringify(built.descriptor, null, 2)}\n`, 'utf8');
 
       packed.push({
-        name,
+        name: outPath,
         uri: built.descriptor.uri,
         htmlPath,
         descriptorPath,

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -35,9 +35,11 @@ const MANIFEST_STEM = 'manifest';
 /** One packed app, as it lands on disk. */
 export interface PackedApp {
   /**
-   * Output path stem, relative to the out dir and mirroring the source tree:
-   * `weather/card`. Equal to the uri's path, which is what makes two apps
-   * unable to claim one output file.
+   * Output path stem, relative to the out dir and mirroring the SOURCE tree:
+   * `weather/card`. That is what makes two apps unable to claim one output
+   * file — two files cannot share one relative path — and it is why the
+   * guarantee survives an app setting its own `uri`, where this no longer
+   * matches the address at all.
    */
   name: string;
   uri: string;
@@ -50,9 +52,9 @@ export interface PackedApp {
  * The path segments an app file contributes, source of BOTH its output path
  * and its `ui://` address.
  *
- * One function on purpose. Both are the segments joined — by `/` for the uri,
- * by `/` for the file — so deriving them separately would let the manifest and
- * the address drift apart on the next edit to either.
+ * One function on purpose. Both join these segments with `/`, so deriving them
+ * separately would let the manifest and the address drift apart on the next
+ * edit to either.
  */
 export function appSegmentsFromFile(relPath: string): string[] {
   return relPath
@@ -79,31 +81,43 @@ export function appSegmentsFromFile(relPath: string): string[] {
 const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
 
 /**
- * Characters that break the MODULE LOADER, whatever the filesystem thinks.
+ * Characters refused on the OUTPUT PATH, in two groups with two different
+ * reasons — kept apart because one message covering both would be true of
+ * neither.
  *
- * Vite resolves a module by id, and an id is URL-shaped: `#` opens a fragment
- * and `?` a query, so `weather#card.ts` is read as `weather` with a fragment
- * and reported as "Does the file exist?" for a file that plainly does. Control
- * characters break the id in their own ways.
+ * URL_SYNTAX (`#`, `?`): Vite resolves a module by a URL-shaped id, so `#`
+ * opens a fragment and `?` a query. `weather#card.ts` is looked up as
+ * `weather` and reported as "Does the file exist?" for a file that plainly
+ * does. Verified against the real loader.
  *
- * U+2028 and U+2029 are ECMAScript line terminators sitting above the C0 range,
- * so they break the module and the C0 check misses them.
+ * UNPRINTABLE (C0 controls, U+2028, U+2029): these do not all break the
+ * loader — some C0 bytes load fine, and U+2028/U+2029 break it differently
+ * again, splitting the module source into a `ReferenceError` rather than a
+ * missing file. What is true of ALL of them is that they have no printable
+ * form, and this path is written verbatim into `manifest.json`, into the
+ * descriptor, and into every error message about the app. That is the reason
+ * given, because it is the one that holds.
  *
- * A BACKSLASH is knowingly ABSENT, and cannot be added here. A POSIX file
- * literally named `a\b.ts` is handed to the loader as `a/b.ts` — a path that
- * does not exist — because `appSegmentsFromFile` folds `\` into `/` for
- * Windows BEFORE these segments exist, so by the time this runs there is no
- * backslash left to see. Catching it means testing the raw relative path, which
- * is only safe if `pathe` never hands us a backslash on Windows. That is
- * believable and untested here, and getting it wrong refuses every file on a
- * platform this repo has no runner for. Left alone deliberately: the failure is
- * loud, and the character is one almost nobody puts in a filename.
+ * U+007F (DEL) is deliberately absent from both. It loads, it prints, and
+ * there is a test asserting it still packs — a rule with no failure behind it
+ * is noise.
  *
  * NOT exemptible by setting `uri`. Every other objection to a filename is about
  * the ADDRESS, and an author who writes their own address has answered it —
- * but no address makes a file loadable.
+ * but no address makes a file loadable or a manifest readable.
+ *
+ * A BACKSLASH is knowingly ABSENT and CANNOT be caught here, for a reason
+ * worth stating precisely: `fast-glob` itself returns `mcp-apps/a\b.ts` as
+ * `mcp-apps/a/b.ts`. The character is gone from the `files` array before
+ * `relative()` runs, before `appSegmentsFromFile` runs, before anything in
+ * this module sees a path — and this happens on POSIX, unconditionally,
+ * nothing to do with Windows. Catching it means not trusting the glob's output
+ * for the filename, which is a bigger change than the failure warrants: the
+ * file fails loudly at load time, and almost nobody puts a backslash in a
+ * filename.
  */
-const LOADER_HOSTILE = /[#?\u0000-\u001f\u2028\u2029]/;
+const URL_SYNTAX = /[#?]/;
+const UNPRINTABLE = /[\u0000-\u001f\u2028\u2029]/;
 
 /**
  * Refuses a path that cannot safely name a file, or be loaded as a module.
@@ -125,18 +139,34 @@ function assertUsableOutputPath(relPath: string, segments: string[]): void {
   }
   const dot = segments.find((seg) => seg === '.' || seg === '..');
   if (dot) {
+    // Two different hazards, one refusal. A `.` never escapes the out dir and a
+    // `..` only does so from the front — but NEITHER survives normalisation, so
+    // the path written into the manifest is not the path anything resolves to.
     throw new Error(
-      `"${relPath}" contains a "${dot}" segment, which would resolve to a path outside the ` +
-        'output directory.',
+      `"${relPath}" contains a "${dot}" segment. It does not survive path normalisation, so the ` +
+        'file written down would not be the file resolved — and a leading ".." lands outside the ' +
+        'output directory entirely.',
     );
   }
-  const hostile = segments.find((seg) => LOADER_HOSTILE.test(seg));
-  if (hostile) {
-    const ch = [...hostile].find((c) => LOADER_HOSTILE.test(c)) ?? hostile;
+  const urlish = segments.find((seg) => URL_SYNTAX.test(seg));
+  if (urlish) {
+    const ch = [...urlish].find((c) => URL_SYNTAX.test(c)) ?? urlish;
     throw new Error(
-      `"${relPath}" contains ${JSON.stringify(ch)}, which the module loader reads as part of a url ` +
-        'rather than a name — it would report the file as missing. Rename it. Setting "uri" does not ' +
-        'help here: the file has to be loadable before its address matters.',
+      `"${relPath}" contains ${JSON.stringify(ch)}, which the module loader reads as url syntax rather ` +
+        'than part of the name — it looks the file up under a shorter name and reports it missing. ' +
+        'Rename it. Setting "uri" does not help here: the file has to be loadable before its address ' +
+        'matters.',
+    );
+  }
+
+  const unprintable = segments.find((seg) => UNPRINTABLE.test(seg));
+  if (unprintable) {
+    const ch = [...unprintable].find((c) => UNPRINTABLE.test(c)) ?? unprintable;
+    const code = `U+${ch.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')}`;
+    throw new Error(
+      `"${relPath}" contains ${code}, which has no printable form — it would appear as itself in the ` +
+        'manifest, in the descriptor and in every error message about this app. Rename it. Setting ' +
+        '"uri" does not help here: the address is not the problem.',
     );
   }
 }
@@ -192,8 +222,10 @@ function assertUsableUriSegments(relPath: string, segments: string[]): void {
  * NESTED, MIRRORING THE URI. Through 0.15.0 this flattened to `weather-card`,
  * which let `weather/card.ts` and `weather-card.ts` — two files with two
  * DIFFERENT addresses — claim one output file, so the build had to detect the
- * clash and refuse. Mirroring makes that clash unrepresentable: the output path
- * is the uri path, and two files cannot share one relative path.
+ * clash and refuse. Mirroring makes that clash unrepresentable, because the
+ * output path is the SOURCE path and two files cannot share one relative path.
+ * It equals the uri's path only while the uri is derived; an app that names its
+ * own address still gets an output file named after its source.
  *
  * This moves output for a project that already had app files in subfolders:
  * 0.15.0's recursive glob wrote `weather-card.html` for `weather/card.ts`.

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -86,11 +86,24 @@ const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
  * and reported as "Does the file exist?" for a file that plainly does. Control
  * characters break the id in their own ways.
  *
+ * U+2028 and U+2029 are ECMAScript line terminators sitting above the C0 range,
+ * so they break the module and the C0 check misses them.
+ *
+ * A BACKSLASH is knowingly ABSENT, and cannot be added here. A POSIX file
+ * literally named `a\b.ts` is handed to the loader as `a/b.ts` — a path that
+ * does not exist — because `appSegmentsFromFile` folds `\` into `/` for
+ * Windows BEFORE these segments exist, so by the time this runs there is no
+ * backslash left to see. Catching it means testing the raw relative path, which
+ * is only safe if `pathe` never hands us a backslash on Windows. That is
+ * believable and untested here, and getting it wrong refuses every file on a
+ * platform this repo has no runner for. Left alone deliberately: the failure is
+ * loud, and the character is one almost nobody puts in a filename.
+ *
  * NOT exemptible by setting `uri`. Every other objection to a filename is about
  * the ADDRESS, and an author who writes their own address has answered it —
  * but no address makes a file loadable.
  */
-const LOADER_HOSTILE = /[#?\u0000-\u001f]/;
+const LOADER_HOSTILE = /[#?\u0000-\u001f\u2028\u2029]/;
 
 /**
  * Refuses a path that cannot safely name a file, or be loaded as a module.
@@ -246,6 +259,15 @@ export function packageAuthority(packageName?: string): string | undefined {
   return /^[a-z0-9][a-z0-9._-]*$/.test(bare) ? bare : undefined;
 }
 
+/**
+ * Unicode case folding, as close as JS gets. `toLowerCase()` alone misses any
+ * character that is already lowercase but folds to something else — U+017F
+ * LONG S being the one that reaches a filesystem.
+ */
+function caseFold(value: string): string {
+  return value.toUpperCase().toLowerCase();
+}
+
 /** "a and b", "a, b and c" — a list a person reads, not a join. */
 function listNames(names: string[]): string {
   if (names.length <= 2) return names.join(' and ');
@@ -385,10 +407,14 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
       continue;
     }
 
-    // Compared case-INSENSITIVELY: on APFS and NTFS `Manifest.json` and
+    // CASE-FOLDED, not lowercased. On APFS and NTFS `Manifest.json` and
     // `manifest.json` are one file, so a capital letter reproduced the exact
-    // clobber this guard exists to stop.
-    if (outPath.toLowerCase() === MANIFEST_STEM) {
+    // clobber this guard exists to stop. `toLowerCase()` is not enough: APFS
+    // folds by the full Unicode rules, under which U+017F LONG S folds to `s`
+    // — and `manifeſt` is already lowercase, so `toLowerCase()` leaves it be
+    // while the filesystem still collides it. JS has no `toCaseFold`;
+    // upper-then-lower is the working stand-in.
+    if (caseFold(outPath) === MANIFEST_STEM) {
       problems.push(
         `  ${here} packs to "${MANIFEST_STEM}.json", which is the index listing every app — the ` +
           'index would overwrite its descriptor. Rename it, or move it into a folder.',

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -195,11 +195,9 @@ function assertUsableUriSegments(relPath: string, segments: string[]): void {
  * clash and refuse. Mirroring makes that clash unrepresentable: the output path
  * is the uri path, and two files cannot share one relative path.
  *
- * THIS MOVES PUBLISHED OUTPUT. The recursive glob shipped in 0.15.0, so a
- * project with `mcp-apps/weather/card.ts` already gets `weather-card.html`
- * today and gets `weather/card.html` after this. Anything pinned to the flat
- * path — a static mount, a COPY line, a path in a server config — has to
- * follow. Reading `manifest.json` rather than guessing the path does not.
+ * This moves output for a project that already had app files in subfolders:
+ * 0.15.0's recursive glob wrote `weather-card.html` for `weather/card.ts`.
+ * Reading `manifest.json` rather than guessing the path is unaffected.
  */
 export function outputPathFromFile(relPath: string): string {
   const segments = appSegmentsFromFile(relPath);

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -32,6 +32,38 @@ const DEFAULT_OUT_DIR = 'dist/mcp-apps';
  */
 const MANIFEST_STEM = 'manifest';
 
+/**
+ * What counts as an app file. ONE definition, because the directory is walked
+ * twice — once for absolute paths to load, once for the relative form that
+ * still carries a backslash — and two copies of this list would let the guard
+ * check a different set of files than the build packs, silently.
+ */
+const APP_FILE_GLOB = '**/*.{ts,tsx,mts}';
+
+/**
+ * Names skipped without a word.
+ *
+ * EVERY EXTENSION THE GLOB ACCEPTS, which is the bug this shape exists to stop:
+ * these once named `.ts` alone, so renaming `card.tsx` to `-card.tsx` to turn
+ * it off left it building — and shipping `ui://pkg/-card`, a leading hyphen in
+ * a protocol-visible address.
+ *
+ * `-*` is the same off switch the page scanner uses (`plugins/pages.ts`:
+ * "Dash-prefixed files are disabled routes"), so an app is disabled by renaming
+ * rather than deleting. It matches a FILE name, not a folder, exactly as
+ * `pages/` does.
+ *
+ * `.d.tsx` is left out on purpose — it is not a real extension. `.d.mts` is,
+ * and without it a declaration file sitting in `mcp-apps/` is loaded as an app
+ * and fails the whole build.
+ */
+const APP_FILE_IGNORE = [
+  '**/*.d.{ts,mts}',
+  '**/*.test.{ts,tsx,mts}',
+  '**/*.spec.{ts,tsx,mts}',
+  '**/-*.{ts,tsx,mts}',
+];
+
 /** One packed app, as it lands on disk. */
 export interface PackedApp {
   /**
@@ -412,25 +444,12 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
   // carried rather than thrown, below.
   const packageName = await readPackageName(cwd);
 
-  const files = await fastGlob('**/*.{ts,tsx,mts}', {
+  const files = await fastGlob(APP_FILE_GLOB, {
     cwd: sourceDir,
     absolute: true,
     onlyFiles: true,
     followSymbolicLinks: true,
-    // `-*` is the same off switch the page scanner uses (see plugins/pages.ts:
-    // "Dash-prefixed files are disabled routes"), so an app is turned off by
-    // renaming rather than deleting. All of these are skipped SILENTLY.
-    //
-    // EVERY EXTENSION, not just `.ts`. The glob above accepts `.ts`, `.tsx` and
-    // `.mts`, so an ignore that named only `.ts` meant renaming `card.tsx` to
-    // `-card.tsx` left it building — and shipping `ui://pkg/-card`, a leading
-    // hyphen in a protocol-visible address. `pages.ts` covers `.tsx` too.
-    ignore: [
-      '**/*.d.ts',
-      '**/*.test.{ts,tsx,mts}',
-      '**/*.spec.{ts,tsx,mts}',
-      '**/-*.{ts,tsx,mts}',
-    ],
+    ignore: APP_FILE_IGNORE,
   });
 
   if (files.length === 0) {
@@ -440,19 +459,14 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
 
   // The same glob, asked for the form that survives a backslash. `absolute: true`
   // above rewrites one into `/`, so this is the only place the real filename is
-  // still visible.
+  // still visible. Same constants, so the two walks cannot see different files.
   try {
     assertLoadablePaths(
-      await fastGlob('**/*.{ts,tsx,mts}', {
+      await fastGlob(APP_FILE_GLOB, {
         cwd: sourceDir,
         onlyFiles: true,
         followSymbolicLinks: true,
-        ignore: [
-          '**/*.d.ts',
-          '**/*.test.{ts,tsx,mts}',
-          '**/*.spec.{ts,tsx,mts}',
-          '**/-*.{ts,tsx,mts}',
-        ],
+        ignore: APP_FILE_IGNORE,
       }),
     );
   } catch (err) {

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -15,7 +15,7 @@
  */
 import { createServer } from 'vite';
 import fastGlob from 'fast-glob';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'pathe';
 import { patchCustomElementsIdempotent } from '../plugins/ssg.js';
 
@@ -33,15 +33,94 @@ export interface PackedApp {
 }
 
 /**
+ * The path segments an app file contributes, source of BOTH its output name
+ * and its `ui://` address.
+ *
+ * One function on purpose. The name flattens the segments with `-` and the uri
+ * joins them with `/`, so deriving them separately would let the manifest and
+ * the address drift apart on the next edit to either.
+ */
+export function appSegmentsFromFile(relPath: string): string[] {
+  return relPath
+    .replace(/\.[cm]?tsx?$/, '')
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter(Boolean);
+}
+
+/**
  * Turns a path relative to the source dir into an output name.
  * `weather/card.ts` -> `weather-card`, so the output directory stays flat and
  * a name can be read straight off a filename.
  */
 export function appNameFromFile(relPath: string): string {
-  return relPath
-    .replace(/\.[cm]?tsx?$/, '')
-    .replace(/\\/g, '/')
-    .replace(/\//g, '-');
+  return appSegmentsFromFile(relPath).join('-');
+}
+
+/**
+ * Turns a path relative to the source dir into a `ui://` address.
+ * `weather/card.ts` -> `ui://weather/card`, the way `pages/blog/index.ts`
+ * serves `/blog`.
+ *
+ * THE FLAT CASE. A `ui://` uri needs an authority and a path, so a single
+ * segment is not enough on its own: `weather-card.ts` would give host
+ * `weather-card` and an EMPTY path, a different shape from every nested file,
+ * and a host that groups by authority treats the two differently. The package
+ * name supplies the missing first segment, which is what projects were already
+ * writing by hand.
+ *
+ * `index.ts` IS NOT SPECIAL, unlike in `pages/`. `weather/index.ts` is
+ * `ui://weather/index`; collapsing it to `ui://weather` would leave a host
+ * with no path, which is the shape the flat case above exists to avoid.
+ *
+ * NO DYNAMIC SEGMENTS. `[slug]`, `[[opt]]` and `[...all]` mean something in
+ * `pages/` and nothing here: a `ui://` resource is a static template the host
+ * caches by address, so there is no request to take a parameter from. They are
+ * rejected rather than passed through, because a literal `[slug]` in a
+ * protocol-visible address is a typo that would otherwise ship.
+ */
+export function uriFromFile(relPath: string, packageName?: string): string {
+  const segments = appSegmentsFromFile(relPath);
+
+  const dynamic = segments.find((seg) => seg.includes('[') || seg.includes(']'));
+  if (dynamic) {
+    throw new Error(
+      `"${relPath}" uses a dynamic segment ("${dynamic}"). A ui:// app is a static template a host ` +
+        'caches by address, so there is no request to fill one from — use plain folder and file names.',
+    );
+  }
+
+  if (segments.length === 0) {
+    throw new Error(`"${relPath}" has no name to build a uri from.`);
+  }
+
+  if (segments.length === 1) {
+    const authority = packageAuthority(packageName);
+    if (!authority) {
+      throw new Error(
+        `"${relPath}" sits at the top of the app directory, so its uri would have no path — only a host. ` +
+          'Give it a folder (mcp-apps/<group>/' +
+          `${segments[0]}.ts), or set "uri" in defineMcpApp(). ` +
+          'Normally the package name fills that first segment, but this package has no usable "name".',
+      );
+    }
+    return `ui://${authority}/${segments[0]}`;
+  }
+
+  return `ui://${segments.join('/')}`;
+}
+
+/**
+ * The uri authority a package name contributes: `@beatzball/playground` ->
+ * `playground`. Returns undefined when nothing valid survives, so the caller
+ * can say what to do instead rather than emitting a broken address.
+ */
+export function packageAuthority(packageName?: string): string | undefined {
+  if (!packageName) return undefined;
+  const bare = packageName.replace(/^@[^/]+\//, '');
+  // A uri authority is not a free-form string. Anything outside this set would
+  // either be percent-encoded by a parser or rejected outright.
+  return /^[a-z0-9][a-z0-9._-]*$/.test(bare) ? bare : undefined;
 }
 
 /**
@@ -81,6 +160,11 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
   const outFlag = flagValue(args, '--out') ?? DEFAULT_OUT_DIR;
   const sourceDir = resolve(cwd, dirFlag);
   const outDir = resolve(cwd, outFlag);
+
+  // Fills the first uri segment for a file that sits flat in the app directory.
+  // Read once, and read leniently: a project without a package.json still packs
+  // fine as long as every app is in a folder or names its own uri.
+  const packageName = await readPackageName(cwd);
 
   const files = await fastGlob('**/*.{ts,tsx,mts}', {
     cwd: sourceDir,
@@ -135,7 +219,10 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
   // with is the copy their templates were built by. Two copies of either would
   // fail in ways that are tedious to read.
   let packager: {
-    buildMcpAppDocument(app: unknown): Promise<{ html: string; descriptor: { uri: string } }>;
+    buildMcpAppDocument(
+      app: unknown,
+      options?: { uri?: string },
+    ): Promise<{ html: string; descriptor: { uri: string } }>;
   };
 
   try {
@@ -159,14 +246,46 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
     }
 
     for (const file of files.sort()) {
-      const name = appNameFromFile(relative(sourceDir, file));
+      const relPath = relative(sourceDir, file);
+      const name = appNameFromFile(relPath);
+
+      // A FALLBACK, not an override: an app that names its own uri keeps it.
+      // Derived even so, because the failure it reports (a dynamic segment, a
+      // flat file with no package name) is about the file, not about the config.
+      let derivedUri: string;
+      try {
+        derivedUri = uriFromFile(relPath, packageName);
+      } catch (err) {
+        console.error(`litro mcp-app build: ${(err as Error).message}`);
+        return 1;
+      }
 
       // Loading a component registers its custom element, and two apps may pull
       // in the same one. Lit's SSR shim throws on a duplicate define(); this
       // makes it a no-op, exactly as SSG prerendering does.
       patchCustomElementsIdempotent();
 
-      const mod = (await vite.ssrLoadModule(file)) as McpAppModule;
+      // Loading is where an app's own defineMcpApp() runs, so a throw here is
+      // the author's error and reads far better with the file named. Left
+      // unwrapped, it escaped the command as a raw Vite stack.
+      let mod: McpAppModule;
+      try {
+        mod = (await vite.ssrLoadModule(file)) as McpAppModule;
+      } catch (err) {
+        // The packager is resolved from the PROJECT's dependencies, so it can
+        // be older than this CLI. An older one ignores the derived uri and
+        // rejects the app at define time — a message that sends the reader to
+        // fix a "uri" the file is not supposed to need.
+        let message = (err as Error).message;
+        if (/defineMcpApp: "uri"/.test(message) && /undefined/.test(message)) {
+          message +=
+            '\n  This CLI derives a uri from the file path, but the installed @beatzball/litro-agent ' +
+            'is older than that. Upgrade it, or set "uri" in defineMcpApp().';
+        }
+        console.error(`litro mcp-app build: ${relative(cwd, file)}\n  ${message}`);
+        return 1;
+      }
+
       const definition = mod.default;
 
       if (!definition || typeof definition !== 'object') {
@@ -179,7 +298,7 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
 
       let built: { html: string; descriptor: { uri: string } };
       try {
-        built = await packager.buildMcpAppDocument(definition);
+        built = await packager.buildMcpAppDocument(definition, { uri: derivedUri });
       } catch (err) {
         console.error(`litro mcp-app build: ${relative(cwd, file)}\n  ${(err as Error).message}`);
         return 1;
@@ -222,6 +341,17 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
   }
   console.log(`litro mcp-app build: ${packed.length} app(s) -> ${relative(cwd, outDir)}/`);
   return 0;
+}
+
+/** The project's package name, or undefined when there is nothing readable. */
+async function readPackageName(cwd: string): Promise<string | undefined> {
+  try {
+    const raw = await readFile(join(cwd, 'package.json'), 'utf8');
+    const name = (JSON.parse(raw) as { name?: unknown }).name;
+    return typeof name === 'string' ? name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function flagValue(args: string[], flag: string): string | undefined {

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -79,13 +79,32 @@ export function appSegmentsFromFile(relPath: string): string[] {
 const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
 
 /**
- * Refuses a path that cannot safely name a file under the output directory.
+ * Characters that break the MODULE LOADER, whatever the filesystem thinks.
  *
- * DELIBERATELY NARROW. Only `.` and `..` qualify: they are resolved by the
- * filesystem, so `../x` would write OUTSIDE the out dir. Everything else — a
- * space, an accent, a `[` — is a perfectly legal filename, and refusing it here
- * would be refusing it for an app that names its own uri and never needed one
- * derived. That was exactly the failure this split exists to undo.
+ * Vite resolves a module by id, and an id is URL-shaped: `#` opens a fragment
+ * and `?` a query, so `weather#card.ts` is read as `weather` with a fragment
+ * and reported as "Does the file exist?" for a file that plainly does. Control
+ * characters break the id in their own ways.
+ *
+ * NOT exemptible by setting `uri`. Every other objection to a filename is about
+ * the ADDRESS, and an author who writes their own address has answered it —
+ * but no address makes a file loadable.
+ */
+const LOADER_HOSTILE = /[#?\u0000-\u001f]/;
+
+/**
+ * Refuses a path that cannot safely name a file, or be loaded as a module.
+ *
+ * DELIBERATELY NARROW, because everything refused here is refused even for an
+ * app that names its own uri. Two things qualify:
+ *
+ *   - `.` and `..`, which the filesystem resolves, so `../x` would write
+ *     OUTSIDE the out dir.
+ *   - `#`, `?` and control characters, which the module loader cannot address.
+ *
+ * A space, an accent, a `[` are none of those: `big card.html` is a perfectly
+ * good filename and Vite loads `big card.ts` without complaint. Refusing those
+ * here is what made an explicit `uri` unable to rescue a build.
  */
 function assertUsableOutputPath(relPath: string, segments: string[]): void {
   if (segments.length === 0) {
@@ -96,6 +115,15 @@ function assertUsableOutputPath(relPath: string, segments: string[]): void {
     throw new Error(
       `"${relPath}" contains a "${dot}" segment, which would resolve to a path outside the ` +
         'output directory.',
+    );
+  }
+  const hostile = segments.find((seg) => LOADER_HOSTILE.test(seg));
+  if (hostile) {
+    const ch = [...hostile].find((c) => LOADER_HOSTILE.test(c)) ?? hostile;
+    throw new Error(
+      `"${relPath}" contains ${JSON.stringify(ch)}, which the module loader reads as part of a url ` +
+        'rather than a name — it would report the file as missing. Rename it. Setting "uri" does not ' +
+        'help here: the file has to be loadable before its address matters.',
     );
   }
 }
@@ -185,7 +213,9 @@ export function outputPathFromFile(relPath: string): string {
  * `ui://<package>/weather/index`; collapsing it would silently merge with a
  * sibling `weather.ts`.
  *
- * EVERY THROW IS RECOVERABLE by setting `uri` on the app.
+ * EVERY THROW HERE IS RECOVERABLE by setting `uri` on the app. The refusals
+ * that are not — a dot segment, a character the module loader cannot address
+ * — live in `assertUsableOutputPath`, because they survive having an address.
  */
 export function uriFromFile(relPath: string, packageName?: string): string {
   const segments = appSegmentsFromFile(relPath);
@@ -216,6 +246,12 @@ export function packageAuthority(packageName?: string): string | undefined {
   return /^[a-z0-9][a-z0-9._-]*$/.test(bare) ? bare : undefined;
 }
 
+/** "a and b", "a, b and c" — a list a person reads, not a join. */
+function listNames(names: string[]): string {
+  if (names.length <= 2) return names.join(' and ');
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
 /**
  * The form of a uri that two addresses must differ in to be different
  * resources: what RFC 3986 equivalence says the string means, not the string.
@@ -237,9 +273,9 @@ function canonicalUri(uri: string): string {
     // Not parseable, so nothing can normalise it into another entry either.
     return uri;
   }
-  // Scheme and host are case-insensitive; a percent-triplet's hex digits are
-  // too, and RFC 3986 makes uppercase the normal form.
-  parsed.protocol = parsed.protocol.toLowerCase();
+  // The host is case-insensitive and a percent-triplet's hex digits are too;
+  // RFC 3986 makes uppercase the normal form for the latter. The SCHEME needs
+  // no line of its own — the URL constructor has already lowercased it.
   parsed.host = parsed.host.toLowerCase();
   return parsed.href.replace(/%[0-9a-fA-F]{2}/g, (t) => t.toUpperCase());
 }
@@ -268,7 +304,7 @@ export function assertUniqueUris(apps: { name: string; uri: string }[]): void {
   for (const [uri, names] of byUri) {
     if (names.length < 2) continue;
     problems.push(
-      `  ${names.join(' and ')} ${names.length > 2 ? 'all ' : ''}resolve to the uri ${uri}. A host ` +
+      `  ${listNames(names)} ${names.length > 2 ? 'all ' : ''}resolve to the uri ${uri}. A host ` +
         'caches templates by uri, so one would silently serve the other’s markup. Give each its own ' +
         'address, or its own file path.',
     );
@@ -317,9 +353,15 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
     return 1;
   }
 
-  // EVERY problem the file paths alone can show, gathered before a single
-  // module is loaded or a byte is written. One list beats learning the shape of
-  // the directory one failed build at a time.
+  // Every problem that is FATAL WHATEVER THE APP SAYS, gathered before a module
+  // is loaded or a byte is written. One list beats learning the shape of the
+  // directory one failed build at a time.
+  //
+  // Not every problem, and the difference matters. A character that only breaks
+  // the ADDRESS is not fatal here, because the app may name its own uri — so it
+  // is carried, and only reported after the module loads, by which time earlier
+  // apps are already on disk. Dot segments, loader-hostile characters, output
+  // clashes and the manifest stem are the ones nothing can excuse.
   //
   // A derivation failure is NOT fatal here. An app is allowed to name its own
   // uri, and `defineMcpApp()` has not run yet — so the reason it could not be
@@ -343,7 +385,10 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
       continue;
     }
 
-    if (outPath === MANIFEST_STEM) {
+    // Compared case-INSENSITIVELY: on APFS and NTFS `Manifest.json` and
+    // `manifest.json` are one file, so a capital letter reproduced the exact
+    // clobber this guard exists to stop.
+    if (outPath.toLowerCase() === MANIFEST_STEM) {
       problems.push(
         `  ${here} packs to "${MANIFEST_STEM}.json", which is the index listing every app — the ` +
           'index would overwrite its descriptor. Rename it, or move it into a folder.',

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -106,15 +106,13 @@ const URI_SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
  * the ADDRESS, and an author who writes their own address has answered it —
  * but no address makes a file loadable or a manifest readable.
  *
- * A BACKSLASH is knowingly ABSENT and CANNOT be caught here, for a reason
- * worth stating precisely: `fast-glob` itself returns `mcp-apps/a\b.ts` as
- * `mcp-apps/a/b.ts`. The character is gone from the `files` array before
- * `relative()` runs, before `appSegmentsFromFile` runs, before anything in
- * this module sees a path — and this happens on POSIX, unconditionally,
- * nothing to do with Windows. Catching it means not trusting the glob's output
- * for the filename, which is a bigger change than the failure warrants: the
- * file fails loudly at load time, and almost nobody puts a backslash in a
- * filename.
+ * A BACKSLASH is caught, but not here — it cannot reach this function. The
+ * glob runs with `absolute: true`, and THAT is what folds `a\b.ts` into
+ * `a/b.ts`; `fast-glob` hands back the name intact when asked for relative
+ * paths. So the character is gone from `files` before `relative()` or
+ * `appSegmentsFromFile` ever runs, and the build would otherwise fail at load
+ * with "Does the file exist?" for a file that plainly does. `assertLoadablePaths`
+ * asks the same glob for the form that keeps it.
  */
 const URL_SYNTAX = /[#?]/;
 const UNPRINTABLE = /[\u0000-\u001f\u2028\u2029]/;
@@ -298,6 +296,28 @@ function caseFold(value: string): string {
   return value.toUpperCase().toLowerCase();
 }
 
+/**
+ * Refuses a filename the glob's absolute form would silently rewrite.
+ *
+ * Only a backslash does this today: `absolute: true` folds `a\b.ts` into
+ * `a/b.ts`, so the CLI would hand the loader a path that does not exist and
+ * report the file missing. Detected by asking the SAME glob for its relative
+ * form, which keeps the character — cheaper and safer than distrusting the
+ * glob, and on Windows the relative form is POSIX-separated, so nothing here
+ * fires falsely.
+ */
+export function assertLoadablePaths(relPaths: string[]): void {
+  const bad = relPaths.filter((p) => p.includes('\\'));
+  if (bad.length > 0) {
+    throw new Error(
+      `${bad.map((p) => `"${p}"`).join(', ')} contain${bad.length > 1 ? '' : 's'} a backslash. ` +
+        'The module loader is handed a path with it turned into "/", so it looks for a file that ' +
+        'does not exist. Rename it. Setting "uri" does not help here: the file has to be loadable ' +
+        'before its address matters.',
+    );
+  }
+}
+
 /** "a and b", "a, b and c" — a list a person reads, not a join. */
 function listNames(names: string[]): string {
   if (names.length <= 2) return names.join(' and ');
@@ -397,11 +417,46 @@ export async function mcpAppCommand(args: string[], cwd: string): Promise<number
     absolute: true,
     onlyFiles: true,
     followSymbolicLinks: true,
-    ignore: ['**/*.d.ts', '**/*.test.ts', '**/*.spec.ts', '**/-*.ts'],
+    // `-*` is the same off switch the page scanner uses (see plugins/pages.ts:
+    // "Dash-prefixed files are disabled routes"), so an app is turned off by
+    // renaming rather than deleting. All of these are skipped SILENTLY.
+    //
+    // EVERY EXTENSION, not just `.ts`. The glob above accepts `.ts`, `.tsx` and
+    // `.mts`, so an ignore that named only `.ts` meant renaming `card.tsx` to
+    // `-card.tsx` left it building — and shipping `ui://pkg/-card`, a leading
+    // hyphen in a protocol-visible address. `pages.ts` covers `.tsx` too.
+    ignore: [
+      '**/*.d.ts',
+      '**/*.test.{ts,tsx,mts}',
+      '**/*.spec.{ts,tsx,mts}',
+      '**/-*.{ts,tsx,mts}',
+    ],
   });
 
   if (files.length === 0) {
     console.error(`litro mcp-app build: no app files found in ${relative(cwd, sourceDir) || '.'}/`);
+    return 1;
+  }
+
+  // The same glob, asked for the form that survives a backslash. `absolute: true`
+  // above rewrites one into `/`, so this is the only place the real filename is
+  // still visible.
+  try {
+    assertLoadablePaths(
+      await fastGlob('**/*.{ts,tsx,mts}', {
+        cwd: sourceDir,
+        onlyFiles: true,
+        followSymbolicLinks: true,
+        ignore: [
+          '**/*.d.ts',
+          '**/*.test.{ts,tsx,mts}',
+          '**/*.spec.{ts,tsx,mts}',
+          '**/-*.{ts,tsx,mts}',
+        ],
+      }),
+    );
+  } catch (err) {
+    console.error(`litro mcp-app build: ${(err as Error).message}`);
     return 1;
   }
 

--- a/packages/framework/src/cli/mcp-app.ts
+++ b/packages/framework/src/cli/mcp-app.ts
@@ -59,19 +59,22 @@ export function appNameFromFile(relPath: string): string {
 
 /**
  * Turns a path relative to the source dir into a `ui://` address.
- * `weather/card.ts` -> `ui://weather/card`, the way `pages/blog/index.ts`
- * serves `/blog`.
  *
- * THE FLAT CASE. A `ui://` uri needs an authority and a path, so a single
- * segment is not enough on its own: `weather-card.ts` would give host
- * `weather-card` and an EMPTY path, a different shape from every nested file,
- * and a host that groups by authority treats the two differently. The package
- * name supplies the missing first segment, which is what projects were already
- * writing by hand.
+ * The PACKAGE NAME is always the authority and the FILE PATH is always the
+ * path, so `weather/card.ts` in package `playground` is
+ * `ui://playground/weather/card`. One rule with no branch in it: rename the
+ * package and every address moves together, which is the point of an authority.
+ *
+ * WHY THE PACKAGE AND NOT THE FIRST FOLDER. A `ui://` uri needs an authority
+ * AND a path. Letting the first folder be the authority reads fine until a file
+ * sits flat in `mcp-apps/`: `weather-card.ts` would give host `weather-card`
+ * and an EMPTY path, a different shape from every nested file, which a host
+ * that groups by authority treats differently. Taking the authority from the
+ * package makes the flat file ordinary instead of a special case.
  *
  * `index.ts` IS NOT SPECIAL, unlike in `pages/`. `weather/index.ts` is
- * `ui://weather/index`; collapsing it to `ui://weather` would leave a host
- * with no path, which is the shape the flat case above exists to avoid.
+ * `ui://<package>/weather/index`; collapsing it would silently merge with a
+ * sibling `weather.ts`.
  *
  * NO DYNAMIC SEGMENTS. `[slug]`, `[[opt]]` and `[...all]` mean something in
  * `pages/` and nothing here: a `ui://` resource is a static template the host
@@ -94,20 +97,16 @@ export function uriFromFile(relPath: string, packageName?: string): string {
     throw new Error(`"${relPath}" has no name to build a uri from.`);
   }
 
-  if (segments.length === 1) {
-    const authority = packageAuthority(packageName);
-    if (!authority) {
-      throw new Error(
-        `"${relPath}" sits at the top of the app directory, so its uri would have no path — only a host. ` +
-          'Give it a folder (mcp-apps/<group>/' +
-          `${segments[0]}.ts), or set "uri" in defineMcpApp(). ` +
-          'Normally the package name fills that first segment, but this package has no usable "name".',
-      );
-    }
-    return `ui://${authority}/${segments[0]}`;
+  const authority = packageAuthority(packageName);
+  if (!authority) {
+    throw new Error(
+      `cannot build a uri for "${relPath}": the package name supplies the authority ` +
+        `(ui://<package>/${segments.join('/')}), and this project has no usable "name" in its ` +
+        'package.json. Add one, or set "uri" in defineMcpApp().',
+    );
   }
 
-  return `ui://${segments.join('/')}`;
+  return `ui://${authority}/${segments.join('/')}`;
 }
 
 /**

--- a/packages/litro-agent/src/mcp-app/index.test.ts
+++ b/packages/litro-agent/src/mcp-app/index.test.ts
@@ -22,6 +22,12 @@ describe('defineMcpApp', () => {
     expect(() => defineMcpApp({ uri, shell })).toThrow(/must start with "ui:\/\/"/);
   });
 
+  it('accepts an app with NO uri, because the packer supplies one', () => {
+    // A widening, and the reason this is decidable only at build time: an
+    // absent uri here is not yet a missing address.
+    expect(() => defineMcpApp({ shell })).not.toThrow();
+  });
+
   it('rejects a missing shell', () => {
     expect(() => defineMcpApp({ uri: 'ui://a/b', shell: undefined })).toThrow(/"shell" is required/);
   });
@@ -108,6 +114,49 @@ describe('buildMcpAppDocument', () => {
       defineMcpApp({ uri: 'ui://a/b', shell, apply: 'function (el, d) { el.value = d.value; }' }),
     );
     expect(doc).toContain('window.litroMcpApply = function (el, d)');
+  });
+});
+
+describe('where the uri comes from', () => {
+  it('uses the build-time uri when the app declares none', async () => {
+    const { descriptor } = await buildMcpAppDocument(defineMcpApp({ shell }), {
+      uri: 'ui://playground/weather-card',
+    });
+
+    expect(descriptor.uri).toBe('ui://playground/weather-card');
+    expect(descriptor.name).toBe('weather-card');
+  });
+
+  it("keeps the app's own uri when it has one", async () => {
+    // A FALLBACK, not an override — which is what makes this change cost an
+    // existing project no edits: every declared address survives untouched.
+    const { descriptor } = await buildMcpAppDocument(
+      defineMcpApp({ uri: 'ui://mine/card', shell }),
+      { uri: 'ui://derived/elsewhere' },
+    );
+
+    expect(descriptor.uri).toBe('ui://mine/card');
+  });
+
+  it('titles the document with the resolved uri when there is no title', async () => {
+    const { html: doc } = await buildMcpAppDocument(defineMcpApp({ shell }), {
+      uri: 'ui://playground/weather-card',
+    });
+
+    expect(doc).toContain('<title>ui://playground/weather-card</title>');
+  });
+
+  it('refuses to build an app with no uri from either side', async () => {
+    await expect(buildMcpAppDocument(defineMcpApp({ shell }))).rejects.toThrow(
+      /has no "uri" and none was supplied/,
+    );
+  });
+
+  it('validates a build-time uri to the same standard as a declared one', async () => {
+    // The check moved out of defineMcpApp, so it has to still be somewhere.
+    await expect(
+      buildMcpAppDocument(defineMcpApp({ shell }), { uri: 'http://weather/card' }),
+    ).rejects.toThrow(/must start with "ui:\/\//);
   });
 });
 

--- a/packages/litro-agent/src/mcp-app/index.ts
+++ b/packages/litro-agent/src/mcp-app/index.ts
@@ -67,8 +67,16 @@ export interface McpAppPermissions {
 }
 
 export interface McpAppConfig {
-  /** Resource address. MUST start with `ui://`. */
-  uri: string;
+  /**
+   * Resource address. MUST start with `ui://`.
+   *
+   * OPTIONAL because `litro mcp-app build` derives one from the file path —
+   * `mcp-apps/weather/card.ts` packs as `ui://weather/card`, the way
+   * `pages/blog/index.ts` serves `/blog`. Set it to override that, or when
+   * calling `buildMcpAppDocument` standalone, where there is no file to
+   * derive from. An explicit value always wins over a derived one.
+   */
+  uri?: string;
   /**
    * Resource name. The base MCP `Resource` type requires it alongside `uri`,
    * and a server forwarding our descriptor into `resources/list` emits an
@@ -144,14 +152,28 @@ export interface McpAppDocument {
   descriptor: McpAppDescriptor;
 }
 
-export function defineMcpApp(config: McpAppConfig): McpAppDefinition {
-  if (typeof config.uri !== 'string' || !/^ui:\/\/.+/.test(config.uri)) {
+/**
+ * Rejects anything that is not a `ui://` address.
+ *
+ * Shared by `defineMcpApp` (when a uri is written by hand) and
+ * `buildMcpAppDocument` (for the resolved one), so a hand-written and a
+ * path-derived uri are held to exactly one standard.
+ */
+function assertUiUri(uri: unknown, caller: string): asserts uri is string {
+  if (typeof uri !== 'string' || !/^ui:\/\/.+/.test(uri)) {
     throw new AgentError(
-      `defineMcpApp: "uri" must start with "ui://" and name something after it — got ${JSON.stringify(config.uri)}. ` +
+      `${caller}: "uri" must start with "ui://" and name something after it — got ${JSON.stringify(uri)}. ` +
         'The scheme is how a host tells a UI resource from every other resource, and the spec requires it.',
       { status: 500 },
     );
   }
+}
+
+export function defineMcpApp(config: McpAppConfig): McpAppDefinition {
+  // Only checked when one is GIVEN. An absent uri is not an error here: the
+  // packager supplies a path-derived one, and it is only at build time — once
+  // we know whether an override is coming — that "no uri anywhere" is decidable.
+  if (config.uri !== undefined) assertUiUri(config.uri, 'defineMcpApp');
   if (config.shell === undefined || config.shell === null) {
     throw new AgentError(
       'defineMcpApp: "shell" is required — it is the data-free markup the host paints before any tool result arrives.',
@@ -240,8 +262,23 @@ function escapeHtml(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
+/** Build-time inputs that come from outside the app file. */
+export interface BuildMcpAppOptions {
+  /**
+   * Fallback address, used only when the config has none. `litro mcp-app build`
+   * passes the value it derives from the file path.
+   *
+   * A fallback and not an override: the config wins, so a file that names its
+   * own uri keeps it, and adding this to an existing project changes no address.
+   */
+  uri?: string;
+}
+
 /** Renders the shell and assembles the document. */
-export async function buildMcpAppDocument(app: McpAppDefinition): Promise<McpAppDocument> {
+export async function buildMcpAppDocument(
+  app: McpAppDefinition,
+  options: BuildMcpAppOptions = {},
+): Promise<McpAppDocument> {
   const config = app[MCP_APP_CONFIG];
   if (!config) {
     throw new AgentError(
@@ -250,20 +287,34 @@ export async function buildMcpAppDocument(app: McpAppDefinition): Promise<McpApp
     );
   }
 
+  // The one place a uri is finally decided, which is why validation lives here
+  // and not in defineMcpApp. Neither source alone can tell whether the app has
+  // an address; only both together can.
+  const uri = config.uri ?? options.uri;
+  if (uri === undefined) {
+    throw new AgentError(
+      'buildMcpAppDocument: this app has no "uri" and none was supplied. ' +
+        'Either set "uri" in defineMcpApp(), or pack the file with `litro mcp-app build`, ' +
+        'which derives one from the file path.',
+      { status: 500 },
+    );
+  }
+  assertUiUri(uri, 'buildMcpAppDocument');
+
   // Rendered with no data on purpose — see the constraint at the top of this file.
   const shell = await ui(config.shell);
 
   const head = [
     '<meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
-    `<title>${escapeHtml(config.title ?? config.uri)}</title>`,
+    `<title>${escapeHtml(config.title ?? uri)}</title>`,
     config.styles ? `<style>\n${inlineSafe(config.styles, 'style')}\n</style>` : '',
   ].filter(Boolean);
 
   // Read by the bridge for its ui/initialize handshake. A separate script so
   // BRIDGE_SOURCE stays a constant the tests can evaluate unchanged.
   const appMeta = {
-    name: config.name ?? nameFromUri(config.uri),
+    name: config.name ?? nameFromUri(uri),
     version: config.version ?? '0.0.0',
     displayModes: config.displayModes ?? ['inline'],
   };
@@ -293,7 +344,7 @@ export async function buildMcpAppDocument(app: McpAppDefinition): Promise<McpApp
     '\n</body>\n' +
     '</html>\n';
 
-  assertSelfContained(html, config.uri);
+  assertSelfContained(html, uri);
 
   const meta: McpAppDescriptor['_meta']['ui'] = {};
   if (config.csp) meta.csp = config.csp;
@@ -305,7 +356,7 @@ export async function buildMcpAppDocument(app: McpAppDefinition): Promise<McpApp
     // Nested `_meta.ui.*` only. The flat `_meta["ui/resourceUri"]` form is
     // deprecated and the spec removes it before GA.
     descriptor: {
-      uri: config.uri,
+      uri,
       name: appMeta.name,
       mimeType: MCP_APP_MIME_TYPE,
       _meta: { ui: meta },

--- a/packages/litro-agent/src/mcp-app/index.ts
+++ b/packages/litro-agent/src/mcp-app/index.ts
@@ -70,11 +70,11 @@ export interface McpAppConfig {
   /**
    * Resource address. MUST start with `ui://`.
    *
-   * OPTIONAL because `litro mcp-app build` derives one from the file path —
-   * `mcp-apps/weather/card.ts` packs as `ui://weather/card`, the way
-   * `pages/blog/index.ts` serves `/blog`. Set it to override that, or when
-   * calling `buildMcpAppDocument` standalone, where there is no file to
-   * derive from. An explicit value always wins over a derived one.
+   * OPTIONAL because `litro mcp-app build` derives one: the package name is
+   * the authority and the file path is the path, so `mcp-apps/weather/card.ts`
+   * in package `playground` packs as `ui://playground/weather/card`. Set it to
+   * override that, or when calling `buildMcpAppDocument` standalone, where
+   * there is no file to derive from. An explicit value always wins.
    */
   uri?: string;
   /**

--- a/playground/mcp-apps/weather-card.ts
+++ b/playground/mcp-apps/weather-card.ts
@@ -23,8 +23,8 @@ import { DemoWeatherCard } from '../components/demo-weather-card.js';
 void DemoWeatherCard; // named import + void: bare side-effect imports get tree-shaken
 
 export default defineMcpApp({
-  // No `uri`: the packer derives it from this file's path. `weather-card.ts` in
-  // package `playground` packs as `ui://playground/weather-card`.
+  // No `uri`: the packer derives it. The package name is the authority and
+  // the file path is the path, so this packs as `ui://playground/weather-card`.
   title: 'Weather',
 
   // Rendered with no data: a host caches this template and reuses it for every

--- a/playground/mcp-apps/weather-card.ts
+++ b/playground/mcp-apps/weather-card.ts
@@ -23,7 +23,8 @@ import { DemoWeatherCard } from '../components/demo-weather-card.js';
 void DemoWeatherCard; // named import + void: bare side-effect imports get tree-shaken
 
 export default defineMcpApp({
-  uri: 'ui://playground/weather-card',
+  // No `uri`: the packer derives it from this file's path. `weather-card.ts` in
+  // package `playground` packs as `ui://playground/weather-card`.
   title: 'Weather',
 
   // Rendered with no data: a host caches this template and reuses it for every

--- a/playground/mcp-apps/weather-refresh.ts
+++ b/playground/mcp-apps/weather-refresh.ts
@@ -15,7 +15,8 @@ import { defineMcpApp } from '@beatzball/litro-agent/mcp-app';
 import { html } from 'lit';
 
 export default defineMcpApp({
-  uri: 'ui://playground/weather-refresh',
+  // No `uri`: the packer derives it from this file's path. `weather-refresh.ts` in
+  // package `playground` packs as `ui://playground/weather-refresh`.
   title: 'Weather, refreshable',
 
   shell: html`

--- a/playground/mcp-apps/weather-refresh.ts
+++ b/playground/mcp-apps/weather-refresh.ts
@@ -15,8 +15,8 @@ import { defineMcpApp } from '@beatzball/litro-agent/mcp-app';
 import { html } from 'lit';
 
 export default defineMcpApp({
-  // No `uri`: the packer derives it from this file's path. `weather-refresh.ts` in
-  // package `playground` packs as `ui://playground/weather-refresh`.
+  // No `uri`: the packer derives it. The package name is the authority and
+  // the file path is the path, so this packs as `ui://playground/weather-refresh`.
   title: 'Weather, refreshable',
 
   shell: html`


### PR DESCRIPTION
Closes the one follow-up deliberately left out of the MCP Apps packager (PRD item: "Deferred: infer the `ui://` uri from the file path").

`mcp-apps/weather/card.ts` packs as `ui://weather/card`, the way `pages/blog/index.ts` serves `/blog`. Filesystem-as-routing is the convention everywhere else in Litro, and an app declaring its own address was the odd one out.

## A widening, so nothing existing changes

- `uri` is now optional in `McpAppConfig`.
- `buildMcpAppDocument(app, { uri })` takes a **fallback**, not an override — the config still wins.
- URI validation moves from define time to build time, since an absent `uri` is only an error once it is known no fallback is coming. A malformed one is still rejected, and a path-derived address is now held to the same standard as a hand-written one.
- Calling `buildMcpAppDocument()` standalone is unchanged: with no file there is nothing to derive from, so it throws unless the config carries a `uri` or one is passed in.

## Two shapes that needed deciding

**The flat file.** A `ui://` address needs a host and a path, so one segment is not enough on its own: `weather-card.ts` would give host `weather-card` and an *empty* path, which a host that groups by authority treats differently from every nested file. The **package name** fills the first segment — which is what projects were already writing by hand. The playground's two apps drop their explicit `uri` in this PR and pack to byte-identical addresses. A package with no usable `name` gets an error naming both ways out.

**`index.ts` is not the folder root here.** `weather/index.ts` is `ui://weather/index`; collapsing it would leave `ui://weather`, the one shape the rule above exists to avoid.

## No dynamic segments

`[slug]`, `[[opt]]` and `[...all]` mean something in `pages/` and nothing here — a `ui://` resource is a static template the host caches by address, so there is no request to fill a parameter from. Rejected at build time rather than passed through, because a literal `[slug]` in a protocol-visible address is a typo that would otherwise ship. Called out in the docs, since every other filesystem-routed directory in Litro does support them.

## The uri and the filename now come from one function

`appNameFromFile` already flattened `playground/weather-card.ts` to `playground-weather-card` for the output filename. The manifest pairs the two, so derived apart they would drift on the next edit to either. Both now come from `appSegmentsFromFile`.

## Verified against a real host, not our own

The suites are green (474 framework, 305 agent), but that is not the evidence that matters here — the last round shipped 675 green tests against a handshake Inspector V2 rejects, because every test used a fake host we wrote.

So: packed the playground with **no `uri` in either app file**, served it over HTTP from `playground/mcp-server/`, and drove MCP Inspector V2 (`@mcp-use/inspector@20.3.7`) with `inspector-probe.mjs`. The host resolved both inferred addresses, painted both server-rendered shells before the result, delivered both tool results, and round-tripped the view's own `tools/call`. Packed bytes and both addresses are unchanged from `main`.

## Also

An error thrown while *loading* an app file is now reported with the file named, instead of escaping the command as a raw Vite stack. Since the packager is resolved from the project's own dependencies and can be older than this CLI, an old one rejecting an app for the `uri` it is no longer supposed to need gets an upgrade hint.
